### PR TITLE
Allow parallel testcase runs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Allow running test cases in parallel

--- a/cbor_test.go
+++ b/cbor_test.go
@@ -30,6 +30,7 @@ func cborDecodeAny(t *testing.T, b []byte) any {
 // --- CBOR round-trip ---
 
 func TestCBORRoundtripInt(t *testing.T) {
+	t.Parallel()
 	for _, v := range []int64{0, 1, -1, 127, -128, 1<<31 - 1, -(1 << 31)} {
 		b := cborEncode(t, v)
 		var got int64
@@ -43,6 +44,7 @@ func TestCBORRoundtripInt(t *testing.T) {
 }
 
 func TestCBORRoundtripString(t *testing.T) {
+	t.Parallel()
 	for _, v := range []string{"", "hello", "unicode: \u00e9", "a longer string with spaces"} {
 		b := cborEncode(t, v)
 		var got string
@@ -56,6 +58,7 @@ func TestCBORRoundtripString(t *testing.T) {
 }
 
 func TestCBORRoundtripBool(t *testing.T) {
+	t.Parallel()
 	for _, v := range []bool{true, false} {
 		b := cborEncode(t, v)
 		var got bool
@@ -69,6 +72,7 @@ func TestCBORRoundtripBool(t *testing.T) {
 }
 
 func TestCBORRoundtripFloat(t *testing.T) {
+	t.Parallel()
 	for _, v := range []float64{0.0, 1.5, -3.14, 1e100} {
 		b := cborEncode(t, v)
 		var got float64
@@ -82,6 +86,7 @@ func TestCBORRoundtripFloat(t *testing.T) {
 }
 
 func TestCBORRoundtripBytes(t *testing.T) {
+	t.Parallel()
 	v := []byte{0x00, 0xFF, 0x42, 0xAB}
 	b := cborEncode(t, v)
 	var got []byte
@@ -99,6 +104,7 @@ func TestCBORRoundtripBytes(t *testing.T) {
 }
 
 func TestCBORRoundtripNull(t *testing.T) {
+	t.Parallel()
 	b := cborEncode(t, nil)
 	var got any
 	if err := cbor.Unmarshal(b, &got); err != nil {
@@ -110,6 +116,7 @@ func TestCBORRoundtripNull(t *testing.T) {
 }
 
 func TestCBORRoundtripList(t *testing.T) {
+	t.Parallel()
 	v := []any{int64(1), "two", true}
 	b := cborEncode(t, v)
 	var got []any
@@ -122,6 +129,7 @@ func TestCBORRoundtripList(t *testing.T) {
 }
 
 func TestCBORRoundtripDict(t *testing.T) {
+	t.Parallel()
 	v := map[string]any{"key": "value", "num": int64(42)}
 	b := cborEncode(t, v)
 	var got map[string]any
@@ -134,6 +142,7 @@ func TestCBORRoundtripDict(t *testing.T) {
 }
 
 func TestCBORRoundtripNested(t *testing.T) {
+	t.Parallel()
 	v := []any{map[string]any{"x": int64(1)}, map[string]any{"y": []any{int64(2), int64(3)}}}
 	b := cborEncode(t, v)
 	var got []any
@@ -148,6 +157,7 @@ func TestCBORRoundtripNested(t *testing.T) {
 // --- CBOR extractor helper tests ---
 
 func TestExtractCBORInt(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, int64(42)))
 	v, err := extractCBORInt(decoded)
 	if err != nil {
@@ -159,6 +169,7 @@ func TestExtractCBORInt(t *testing.T) {
 }
 
 func TestExtractCBORIntWrongType(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, "not an int"))
 	_, err := extractCBORInt(decoded)
 	if err == nil {
@@ -167,6 +178,7 @@ func TestExtractCBORIntWrongType(t *testing.T) {
 }
 
 func TestExtractCBORFloat(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, 3.14))
 	v, err := extractCBORFloat(decoded)
 	if err != nil {
@@ -178,6 +190,7 @@ func TestExtractCBORFloat(t *testing.T) {
 }
 
 func TestExtractCBORFloatFromInt(t *testing.T) {
+	t.Parallel()
 	// Integers should also be extractable as floats (common protocol pattern)
 	decoded := cborDecodeAny(t, cborEncode(t, int64(7)))
 	v, err := extractCBORFloat(decoded)
@@ -190,6 +203,7 @@ func TestExtractCBORFloatFromInt(t *testing.T) {
 }
 
 func TestExtractCBORFloatWrongType(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, "not a float"))
 	_, err := extractCBORFloat(decoded)
 	if err == nil {
@@ -198,6 +212,7 @@ func TestExtractCBORFloatWrongType(t *testing.T) {
 }
 
 func TestExtractCBORString(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, "hello"))
 	v, err := extractCBORString(decoded)
 	if err != nil {
@@ -209,6 +224,7 @@ func TestExtractCBORString(t *testing.T) {
 }
 
 func TestExtractCBORStringWrongType(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, int64(42)))
 	_, err := extractCBORString(decoded)
 	if err == nil {
@@ -217,6 +233,7 @@ func TestExtractCBORStringWrongType(t *testing.T) {
 }
 
 func TestExtractCBORBool(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, true))
 	v, err := extractCBORBool(decoded)
 	if err != nil {
@@ -228,6 +245,7 @@ func TestExtractCBORBool(t *testing.T) {
 }
 
 func TestExtractCBORBoolWrongType(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, int64(1)))
 	_, err := extractCBORBool(decoded)
 	if err == nil {
@@ -236,6 +254,7 @@ func TestExtractCBORBoolWrongType(t *testing.T) {
 }
 
 func TestExtractCBORBytes(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, []byte{0xDE, 0xAD}))
 	v, err := extractCBORBytes(decoded)
 	if err != nil {
@@ -247,6 +266,7 @@ func TestExtractCBORBytes(t *testing.T) {
 }
 
 func TestExtractCBORBytesWrongType(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, "not bytes"))
 	_, err := extractCBORBytes(decoded)
 	if err == nil {
@@ -255,6 +275,7 @@ func TestExtractCBORBytesWrongType(t *testing.T) {
 }
 
 func TestExtractCBORList(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, []any{int64(1), int64(2)}))
 	v, err := extractCBORList(decoded)
 	if err != nil {
@@ -266,6 +287,7 @@ func TestExtractCBORList(t *testing.T) {
 }
 
 func TestExtractCBORListWrongType(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, "not a list"))
 	_, err := extractCBORList(decoded)
 	if err == nil {
@@ -274,6 +296,7 @@ func TestExtractCBORListWrongType(t *testing.T) {
 }
 
 func TestExtractCBORDict(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, map[string]any{"k": "v"}))
 	v, err := extractCBORDict(decoded)
 	if err != nil {
@@ -285,6 +308,7 @@ func TestExtractCBORDict(t *testing.T) {
 }
 
 func TestExtractCBORDictWrongType(t *testing.T) {
+	t.Parallel()
 	decoded := cborDecodeAny(t, cborEncode(t, int64(42)))
 	_, err := extractCBORDict(decoded)
 	if err == nil {
@@ -293,6 +317,7 @@ func TestExtractCBORDictWrongType(t *testing.T) {
 }
 
 func TestExtractCBORNullInput(t *testing.T) {
+	t.Parallel()
 	// Each extractor with nil input should return an error
 	if _, err := extractCBORInt(nil); err == nil {
 		t.Error("extractCBORInt(nil): expected error")
@@ -320,6 +345,7 @@ func TestExtractCBORNullInput(t *testing.T) {
 // --- decodeCBOR / encodeCBOR ---
 
 func TestDecodeCBOR(t *testing.T) {
+	t.Parallel()
 	b := cborEncode(t, int64(99))
 	v, err := decodeCBOR(b)
 	if err != nil {
@@ -332,6 +358,7 @@ func TestDecodeCBOR(t *testing.T) {
 }
 
 func TestDecodeCBORError(t *testing.T) {
+	t.Parallel()
 	// 0xFF is not valid CBOR (break code without indefinite-length context)
 	_, err := decodeCBOR([]byte{0xFF})
 	if err == nil {
@@ -340,6 +367,7 @@ func TestDecodeCBORError(t *testing.T) {
 }
 
 func TestEncodeCBOR(t *testing.T) {
+	t.Parallel()
 	b, err := encodeCBOR("hello")
 	if err != nil {
 		t.Fatalf("encodeCBOR: %v", err)
@@ -352,6 +380,7 @@ func TestEncodeCBOR(t *testing.T) {
 // --- Additional extractor branches ---
 
 func TestExtractCBORIntUint64(t *testing.T) {
+	t.Parallel()
 	// Directly pass a uint64 (positive CBOR integers decode as uint64 in fxamacker).
 	v, err := extractCBORInt(uint64(42))
 	if err != nil {
@@ -363,6 +392,7 @@ func TestExtractCBORIntUint64(t *testing.T) {
 }
 
 func TestExtractCBORFloatFloat32(t *testing.T) {
+	t.Parallel()
 	v, err := extractCBORFloat(float32(1.5))
 	if err != nil {
 		t.Fatalf("extractCBORFloat(float32): %v", err)
@@ -373,6 +403,7 @@ func TestExtractCBORFloatFloat32(t *testing.T) {
 }
 
 func TestExtractCBORFloatUint64(t *testing.T) {
+	t.Parallel()
 	v, err := extractCBORFloat(uint64(10))
 	if err != nil {
 		t.Fatalf("extractCBORFloat(uint64): %v", err)
@@ -383,6 +414,7 @@ func TestExtractCBORFloatUint64(t *testing.T) {
 }
 
 func TestExtractCBORDictStringKeyed(t *testing.T) {
+	t.Parallel()
 	// Directly pass a map[string]any to test that branch.
 	input := map[string]any{"key": "value"}
 	m, err := extractCBORDict(input)
@@ -395,6 +427,7 @@ func TestExtractCBORDictStringKeyed(t *testing.T) {
 }
 
 func TestExtractCBORIntNegative(t *testing.T) {
+	t.Parallel()
 	// Negative CBOR integers decode as int64 in fxamacker/cbor.
 	// Pass int64 directly to ensure the case int64: branch is exercised.
 	v, err := extractCBORInt(int64(-42))
@@ -407,6 +440,7 @@ func TestExtractCBORIntNegative(t *testing.T) {
 }
 
 func TestExtractCBORFloatNegativeInt(t *testing.T) {
+	t.Parallel()
 	// Negative integers come as int64 from CBOR decode.
 	// Pass int64 directly to exercise the case int64: branch in extractCBORFloat.
 	v, err := extractCBORFloat(int64(-3))
@@ -419,6 +453,7 @@ func TestExtractCBORFloatNegativeInt(t *testing.T) {
 }
 
 func TestEncodeCBORError(t *testing.T) {
+	t.Parallel()
 	// Functions cannot be CBOR-encoded; this exercises the error return path.
 	_, err := encodeCBOR(func() {})
 	if err == nil {

--- a/connection.go
+++ b/connection.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -19,7 +18,7 @@ const handshakePrefix = "Hegel/"
 // handshakeRequest is the fixed bytes sent by the client to initiate a handshake.
 var handshakeRequest = []byte("hegel_handshake_start")
 
-// shutdownSentinel is placed in a channel's inbox to signal connection close.
+// shutdownSentinel is placed in a channel's inbox to signal that it was closed.
 var shutdownSentinel = &struct{}{}
 
 // connectionState tracks whether the connection has performed a handshake.
@@ -30,21 +29,21 @@ const (
 	stateClient
 )
 
-// connection manages a multiplexed socket with a demand-driven reader.
+// connection manages a multiplexed socket with a dedicated reader goroutine.
 // It is safe to call Close from any goroutine; all other methods must be called
-// from a single goroutine per connection (the reader lock provides ordering).
+// from a single goroutine per connection.
 type connection struct {
-	name    string
-	conn    net.Conn
-	running atomic.Bool
+	name string
+	conn net.Conn
 
 	nextChannelID int
 	channels      map[uint32]*channel
 	state         connectionState
 
 	writerMu sync.Mutex
-	readerMu sync.Mutex
+	done     chan struct{}
 
+	controlMu sync.Mutex
 	controlCh *channel
 }
 
@@ -56,26 +55,30 @@ func newConnection(conn net.Conn, name string) *connection {
 		channels:      make(map[uint32]*channel),
 		state:         stateUnresolved,
 		nextChannelID: 1, // first real channel counter (matches Python's __next_channel_id = 1)
+		done:          make(chan struct{}),
 	}
-	c.running.Store(true)
 	// channel 0 is the control channel; it is pre-registered before any handshake.
-	c.controlCh = &channel{
-		conn:          c,
-		channelID:     0,
-		inbox:         make(chan any, 64),
-		nextMessageID: 1,
-	}
+	c.controlCh = newChannel(c, 0, name)
 	c.channels[0] = c.controlCh
+	go c.readLoop()
 	return c
-}
-
-// Live reports whether the connection is still open.
-func (c *connection) Live() bool {
-	return c.running.Load()
 }
 
 // ControlChannel returns the channel used for handshake and control messages.
 func (c *connection) ControlChannel() *channel { return c.controlCh }
+
+// SendControlRequest sends a request on the control channel and waits for the
+// response. Access is serialized so concurrent callers don't race on the
+// control channel's internal state.
+func (c *connection) SendControlRequest(payload []byte) (any, error) {
+	c.controlMu.Lock()
+	defer c.controlMu.Unlock()
+	pending, err := c.controlCh.Request(payload)
+	if err != nil {
+		return nil, err
+	}
+	return pending.Get()
+}
 
 // SendPacket sends a packet to the peer. It is safe to call concurrently.
 func (c *connection) SendPacket(pkt packet) error {
@@ -84,67 +87,26 @@ func (c *connection) SendPacket(pkt packet) error {
 	return writePacket(c.conn, pkt)
 }
 
-// Close shuts down the connection and signals all channels.
+// Close shuts down the connection. Closing the socket causes readLoop to exit,
+// which closes the done channel and wakes all waiters.
 func (c *connection) Close() {
-	c.writerMu.Lock()
-	if !c.running.Load() {
-		c.writerMu.Unlock()
-		return
-	}
-	c.running.Store(false)
-	channels := make([]*channel, 0, len(c.channels))
-	for _, ch := range c.channels {
-		channels = append(channels, ch)
-	}
-	c.writerMu.Unlock()
-
 	// Shut down the socket to unblock any pending reads.
 	if tc, ok := c.conn.(interface{ CloseRead() error }); ok {
 		tc.CloseRead() //nolint:errcheck
 	}
-	c.conn.Close() //nolint:errcheck
 
-	// Signal all channel inboxes so waiters unblock.
-	for _, ch := range channels {
-		ch.putInbox(shutdownSentinel)
-	}
+	_ = c.conn.Close()
+	<-c.done
 }
 
-// runReader is the demand-driven reader loop.
-// It reads packets from the socket and dispatches them to the correct channel's inbox
-// until the until() predicate returns true, the connection closes, or a short timeout elapses.
-func (c *connection) runReader(until func() bool) {
-	if until() {
-		return
-	}
-	acquired := false
-	defer func() {
-		if acquired {
-			c.readerMu.Unlock()
-		}
-	}()
-
+// readLoop continuously reads packets from the socket and dispatches them.
+// It exits when readPacket returns an error (e.g. the socket was closed).
+func (c *connection) readLoop() {
+	defer c.conn.Close()
+	defer close(c.done)
 	for {
-		acquired = c.readerMu.TryLock()
-		if acquired {
-			break
-		}
-		if until() {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-
-	for c.running.Load() && !until() {
-		// Set a short deadline so we can re-check until() periodically.
-		c.conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond)) //nolint:errcheck
 		pkt, err := readPacket(c.conn)
-		c.conn.SetReadDeadline(time.Time{}) //nolint:errcheck
 		if err != nil {
-			if isTimeout(err) {
-				continue
-			}
-			// connection error — stop reading.
 			return
 		}
 		c.dispatch(pkt)
@@ -158,7 +120,9 @@ func (c *connection) dispatch(pkt packet) {
 	c.writerMu.Unlock()
 
 	if bytes.Equal(pkt.Payload, closeChannelPayload) && pkt.MessageID == closeChannelMessageID {
-		// channel close notification — remove the channel.
+		if ok && ch != nil {
+			ch.putInbox(shutdownSentinel)
+		}
 		c.writerMu.Lock()
 		delete(c.channels, pkt.ChannelID)
 		c.writerMu.Unlock()
@@ -183,17 +147,6 @@ func (c *connection) dispatch(pkt packet) {
 		return
 	}
 	ch.putInbox(pkt)
-}
-
-// isTimeout reports whether err is a network timeout.
-func isTimeout(err error) bool {
-	if err == nil {
-		return false
-	}
-	if ne, ok := err.(net.Error); ok {
-		return ne.Timeout()
-	}
-	return false
 }
 
 // SendHandshake performs the client side of the handshake and discards the version.
@@ -242,13 +195,7 @@ func (c *connection) NewChannel(name string) *channel {
 	channelID := uint32((c.nextChannelID << 1) | 1)
 	c.nextChannelID++
 
-	ch := &channel{
-		conn:          c,
-		channelID:     channelID,
-		inbox:         make(chan any, 64),
-		nextMessageID: 1,
-		name:          name,
-	}
+	ch := newChannel(c, channelID, name)
 	c.channels[channelID] = ch
 	return ch
 }
@@ -265,13 +212,7 @@ func (c *connection) ConnectChannel(id uint32, name string) (*channel, error) {
 		return nil, fmt.Errorf("channel already connected as channel %d", id)
 	}
 
-	ch := &channel{
-		conn:          c,
-		channelID:     id,
-		inbox:         make(chan any, 64),
-		nextMessageID: 1,
-		name:          name,
-	}
+	ch := newChannel(c, id, name)
 	c.channels[id] = ch
 	return ch, nil
 }
@@ -317,6 +258,8 @@ type channel struct {
 	conn          *connection
 	channelID     uint32
 	inbox         chan any
+	droppedOnce   sync.Once
+	dropped       chan struct{} // indicates that a message was dropped at some point
 	nextMessageID uint32
 	responses     map[uint32][]byte
 	requests      []packet
@@ -324,15 +267,34 @@ type channel struct {
 	name          string
 }
 
+func newChannel(c *connection, id uint32, name string) *channel {
+	return &channel{
+		conn:          c,
+		channelID:     id,
+		inbox:         make(chan any, 64),
+		dropped:       make(chan struct{}),
+		nextMessageID: 1,
+		name:          name,
+	}
+}
+
+func (ch *channel) String() string {
+	if ch.name != "" {
+		return fmt.Sprintf("channel %d (%s)", ch.channelID, ch.name)
+	}
+	return fmt.Sprintf("channel %d", ch.channelID)
+}
+
 // ChannelID returns the numeric ID of this channel.
 func (ch *channel) ChannelID() uint32 { return ch.channelID }
 
-// putInbox delivers a value (packet or shutdownSentinel) to the channel's inbox.
+// putInbox delivers a packet to the channel's inbox.
 func (ch *channel) putInbox(v any) {
 	select {
 	case ch.inbox <- v:
 	default:
-		// Drop if full — shouldn't happen with a generous buffer.
+		// Panic if full — shouldn't happen with a generous buffer.
+		ch.droppedOnce.Do(func() { close(ch.dropped) })
 	}
 }
 
@@ -341,14 +303,14 @@ func (ch *channel) Close() {
 	if ch.closed {
 		return
 	}
+	ch.closed = true
+
 	// Check if this channel is still registered (not already removed by the peer).
 	ch.conn.writerMu.Lock()
 	registered := ch.conn.channels[ch.channelID] == ch
-	live := ch.conn.running.Load()
 	ch.conn.writerMu.Unlock()
 
-	ch.closed = true
-	if registered && live {
+	if registered {
 		// Send asynchronously: write may block if the reader isn't consuming yet.
 		go ch.conn.SendPacket(packet{ //nolint:errcheck
 			ChannelID: ch.channelID,
@@ -464,50 +426,42 @@ func (ch *channel) ReceiveResponse(msgID uint32, timeout time.Duration) (any, er
 	return resultOrError(m)
 }
 
-// processOneMessage calls runReader until the channel's inbox has something,
-// then dequeues and routes it.
+// processOneMessage waits for a packet on the channel's inbox and routes it.
 func (ch *channel) processOneMessage(timeout time.Duration) error {
-	start := time.Now()
-	needsMessages := func() bool {
-		return ch.closed || len(ch.inbox) > 0 ||
-			(timeout > 0 && time.Since(start) > timeout)
-	}
-
-	ch.conn.runReader(needsMessages)
-
 	if ch.closed {
-		return fmt.Errorf("%s is closed", ch.channelName())
+		return fmt.Errorf("%s is closed", ch)
 	}
 
+	var timeoutCh <-chan time.Time
+	if timeout > 0 {
+		timeoutCh = time.After(timeout)
+	}
+
+	var pkt packet
 	select {
 	case item := <-ch.inbox:
 		if item == shutdownSentinel {
-			return fmt.Errorf("connection closed")
+			ch.closed = true
+			return fmt.Errorf("%s was closed", ch)
 		}
-		pkt := item.(packet)
-		if pkt.IsReply {
-			if ch.responses == nil {
-				ch.responses = make(map[uint32][]byte)
-			}
-			ch.responses[pkt.MessageID] = pkt.Payload
-		} else {
-			ch.requests = append(ch.requests, pkt)
-		}
-		return nil
-	default:
-		// Nothing arrived — must be timeout.
-		if timeout > 0 && time.Since(start) >= timeout {
-			return fmt.Errorf("timed out after %v waiting for a message on %s", timeout, ch.channelName())
-		}
-		return fmt.Errorf("timed out waiting for a message on %s", ch.channelName())
+		pkt = item.(packet)
+	case <-ch.dropped:
+		panic(fmt.Errorf("%s: dropped a message", ch))
+	case <-ch.conn.done:
+		return fmt.Errorf("connection closed")
+	case <-timeoutCh:
+		return fmt.Errorf("timed out after %v waiting for a message on %s", timeout, ch)
 	}
-}
 
-func (ch *channel) channelName() string {
-	if ch.name != "" {
-		return ch.name
+	if pkt.IsReply {
+		if ch.responses == nil {
+			ch.responses = make(map[uint32][]byte)
+		}
+		ch.responses[pkt.MessageID] = pkt.Payload
+	} else {
+		ch.requests = append(ch.requests, pkt)
 	}
-	return fmt.Sprintf("channel %d", ch.channelID)
+	return nil
 }
 
 // Request sends a request and returns a pendingRequest future.
@@ -533,7 +487,7 @@ func (p *pendingRequest) Get() (any, error) {
 	if p.done {
 		return p.value, p.err
 	}
-	v, err := p.ch.ReceiveResponse(p.msgID, 10*time.Second)
+	v, err := p.ch.ReceiveResponse(p.msgID, 100*time.Second)
 	p.value = v
 	p.err = err
 	p.done = true

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,7 +2,6 @@ package hegel
 
 import (
 	"bytes"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -41,23 +40,28 @@ func clientConnPair(t *testing.T) (*connection, net.Conn) {
 	return clientConn, s
 }
 
-// --- connection.live ---
+// --- connection done channel ---
 
-func TestConnectionLive(t *testing.T) {
+func TestConnectionDone(t *testing.T) {
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
-	if !conn.Live() {
-		t.Error("new connection should be live")
+	select {
+	case <-conn.done:
+		t.Error("new connection should not be done")
+	default:
 	}
 	conn.Close()
-	if conn.Live() {
-		t.Error("closed connection should not be live")
+	select {
+	case <-conn.done:
+	default:
+		t.Error("closed connection should be done")
 	}
 }
 
 // --- connection.Close idempotent ---
 
 func TestConnectionDoubleClose(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	conn.Close()
@@ -67,6 +71,7 @@ func TestConnectionDoubleClose(t *testing.T) {
 // --- Handshake: double send raises ---
 
 func TestDoubleSendHandshakeRaises(t *testing.T) {
+	t.Parallel()
 	clientConn, _ := clientConnPair(t)
 
 	err := clientConn.SendHandshake()
@@ -79,6 +84,7 @@ func TestDoubleSendHandshakeRaises(t *testing.T) {
 // --- Handshake: bad response from server ---
 
 func TestSendHandshakeBadResponse(t *testing.T) {
+	t.Parallel()
 	s, c := socketPair(t)
 	clientConn := newConnection(c, "Client")
 
@@ -106,6 +112,7 @@ func TestSendHandshakeBadResponse(t *testing.T) {
 // --- channel allocation: new_channel returns odd IDs ---
 
 func TestNewChannelOddIDs(t *testing.T) {
+	t.Parallel()
 	clientConn, _ := clientConnPair(t)
 
 	ch1 := clientConn.NewChannel("ch1")
@@ -129,6 +136,7 @@ func TestNewChannelOddIDs(t *testing.T) {
 // --- new_channel before handshake raises ---
 
 func TestNewChannelBeforeHandshakeRaises(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
@@ -144,6 +152,7 @@ func TestNewChannelBeforeHandshakeRaises(t *testing.T) {
 // --- connect_channel before handshake raises ---
 
 func TestConnectChannelBeforeHandshakeRaises(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
@@ -158,6 +167,7 @@ func TestConnectChannelBeforeHandshakeRaises(t *testing.T) {
 // --- connect_channel already exists raises ---
 
 func TestConnectChannelAlreadyExistsRaises(t *testing.T) {
+	t.Parallel()
 	clientConn, _ := clientConnPair(t)
 
 	// channel 0 (control channel) already exists.
@@ -171,6 +181,7 @@ func TestConnectChannelAlreadyExistsRaises(t *testing.T) {
 // --- channel close: sends close packet, idempotent ---
 
 func TestChannelClose(t *testing.T) {
+	t.Parallel()
 	clientConn, _ := clientConnPair(t)
 
 	ch := clientConn.NewChannel("TestClose")
@@ -181,6 +192,7 @@ func TestChannelClose(t *testing.T) {
 // --- channel close when connection not live ---
 
 func TestChannelCloseWhenConnectionNotLive(t *testing.T) {
+	t.Parallel()
 	clientConn, _ := clientConnPair(t)
 
 	ch := clientConn.NewChannel("TestClose")
@@ -191,6 +203,7 @@ func TestChannelCloseWhenConnectionNotLive(t *testing.T) {
 // --- channel: closed channel rejects recv ---
 
 func TestChannelProcessMessageWhenClosed(t *testing.T) {
+	t.Parallel()
 	clientConn, _ := clientConnPair(t)
 
 	ch := clientConn.NewChannel("TestClosed")
@@ -206,6 +219,7 @@ func TestChannelProcessMessageWhenClosed(t *testing.T) {
 // --- channel timeout ---
 
 func TestChannelTimeout(t *testing.T) {
+	t.Parallel()
 	clientConn, _ := clientConnPair(t)
 
 	ch := clientConn.NewChannel("TestTimeout")
@@ -218,19 +232,22 @@ func TestChannelTimeout(t *testing.T) {
 	mustContain(t, err.Error(), "timed out")
 }
 
-// --- SHUTDOWN in inbox raises ---
+// --- connection closed while waiting for message ---
 
-func TestShutdownInInboxRaises(t *testing.T) {
+func TestConnectionClosedWhileWaiting(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
-	defer conn.Close()
 
 	ch := conn.ControlChannel()
-	ch.putInbox(shutdownSentinel)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		conn.Close()
+	}()
 
-	_, _, err := ch.RecvRequest(100 * time.Millisecond)
+	_, _, err := ch.RecvRequest(2 * time.Second)
 	if err == nil {
-		t.Fatal("expected error for SHUTDOWN in inbox")
+		t.Fatal("expected error when connection closes")
 	}
 	mustContain(t, err.Error(), "connection closed")
 }
@@ -238,6 +255,7 @@ func TestShutdownInInboxRaises(t *testing.T) {
 // --- Message to nonexistent channel ---
 
 func TestMessageToNonexistentChannel(t *testing.T) {
+	t.Parallel()
 	clientConn, remote := clientConnPair(t)
 
 	// Send a request from the "server" to a nonexistent channel on the client.
@@ -285,6 +303,7 @@ func TestMessageToNonexistentChannel(t *testing.T) {
 // --- requestError ---
 
 func TestRequestError(t *testing.T) {
+	t.Parallel()
 	data := map[any]any{
 		any("error"): any("something went wrong"),
 		any("type"):  any("TestError"),
@@ -302,6 +321,7 @@ func TestRequestError(t *testing.T) {
 // --- ResultOrError ---
 
 func TestResultOrErrorRaises(t *testing.T) {
+	t.Parallel()
 	body := map[any]any{
 		any("error"): any("bad"),
 		any("type"):  any("TestError"),
@@ -314,6 +334,7 @@ func TestResultOrErrorRaises(t *testing.T) {
 }
 
 func TestResultOrErrorReturnsResult(t *testing.T) {
+	t.Parallel()
 	body := map[any]any{any("result"): any(uint64(42))}
 	v, err := resultOrError(body)
 	if err != nil {
@@ -339,6 +360,7 @@ func (c *closeReadConn) CloseRead() error {
 }
 
 func TestConnectionCloseCallsCloseRead(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	cr := &closeReadConn{Conn: s}
 	conn := newConnection(cr, "Test")
@@ -348,40 +370,10 @@ func TestConnectionCloseCallsCloseRead(t *testing.T) {
 	}
 }
 
-// --- runReader: until() fires while waiting for reader lock ---
-
-func TestRunReaderUntilFiresWhileWaitingForLock(t *testing.T) {
-	s, c := socketPair(t)
-	defer s.Close()
-	defer c.Close()
-	conn := newConnection(s, "Test")
-	defer conn.Close()
-
-	// Hold the reader lock so TryLock fails.
-	conn.readerMu.Lock()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		// until() returns true after a brief pause, simulating data becoming available.
-		i := 0
-		conn.runReader(func() bool {
-			i++
-			return i > 2
-		})
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Error("runReader did not exit when until() returned true while waiting for lock")
-	}
-	conn.readerMu.Unlock()
-}
-
 // --- dispatch: close-channel notification path ---
 
 func TestDispatchCloseChannelNotification(t *testing.T) {
+	t.Parallel()
 	clientConn, remote := clientConnPair(t)
 
 	clientCh := clientConn.NewChannel("ClosedCh")
@@ -396,15 +388,46 @@ func TestDispatchCloseChannelNotification(t *testing.T) {
 		})
 	}()
 
-	// Force client to read the close packet by trying to recv on control channel.
-	done := make(chan struct{})
+	// A subsequent recv on the closed channel should return a close error.
+	_, _, err := clientCh.RecvRequestRaw(2 * time.Second)
+	if err == nil {
+		t.Fatal("expected error after peer close")
+	}
+	mustContain(t, err.Error(), "closed")
+}
+
+func TestPeerCloseWakesBlockedGoroutine(t *testing.T) {
+	t.Parallel()
+	clientConn, remote := clientConnPair(t)
+
+	clientCh := clientConn.NewChannel("BlockedCh")
+
+	// Block a goroutine on RecvRequestRaw.
+	errc := make(chan error, 1)
 	go func() {
-		defer close(done)
-		clientConn.ControlChannel().RecvRequestRaw(200 * time.Millisecond) //nolint:errcheck
+		_, _, err := clientCh.RecvRequestRaw(5 * time.Second)
+		errc <- err
 	}()
+
+	// Give the goroutine time to block.
+	time.Sleep(20 * time.Millisecond)
+
+	// Send a close-channel notification from the peer.
+	writePacket(remote, packet{ //nolint:errcheck
+		ChannelID: clientCh.ChannelID(),
+		MessageID: closeChannelMessageID,
+		IsReply:   false,
+		Payload:   closeChannelPayload,
+	})
+
 	select {
-	case <-done:
-	case <-time.After(500 * time.Millisecond):
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("expected error from RecvRequestRaw after peer close")
+		}
+		mustContain(t, err.Error(), "closed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocked goroutine was not woken by peer close")
 	}
 }
 
@@ -412,6 +435,7 @@ func TestDispatchCloseChannelNotification(t *testing.T) {
 // --- dispatch: message to unknown channel (reply) → silently dropped ---
 
 func TestDispatchUnknownChannelIsReply(t *testing.T) {
+	t.Parallel()
 	clientConn, remote := clientConnPair(t)
 
 	// Send an IsReply=true packet from remote to a nonexistent channel — should be silently dropped.
@@ -448,6 +472,7 @@ func TestDispatchUnknownChannelIsReply(t *testing.T) {
 }
 
 func TestDispatchUnknownChannelRequest(t *testing.T) {
+	t.Parallel()
 	clientConn, remote := clientConnPair(t)
 
 	// Send a request (IsReply=false) to a nonexistent client channel.
@@ -490,24 +515,10 @@ func TestDispatchUnknownChannelRequest(t *testing.T) {
 	}
 }
 
-// --- isTimeout: nil error and non-net.Error paths ---
-
-func TestIsTimeoutNil(t *testing.T) {
-	if isTimeout(nil) {
-		t.Error("nil error should not be a timeout")
-	}
-}
-
-func TestIsTimeoutNonNetError(t *testing.T) {
-	// A plain error is not a timeout.
-	if isTimeout(fmt.Errorf("plain error")) {
-		t.Error("plain error should not be a timeout")
-	}
-}
-
 // --- SendHandshakeVersion: error from SendRequestRaw (closed connection) ---
 
 func TestSendHandshakeVersionSendError(t *testing.T) {
+	t.Parallel()
 	s, c := net.Pipe()
 	conn := newConnection(s, "Test")
 	// Close both ends so SendRequestRaw fails.
@@ -523,6 +534,7 @@ func TestSendHandshakeVersionSendError(t *testing.T) {
 // --- SendHandshakeVersion: error from recvResponseRaw (connection closed mid-handshake) ---
 
 func TestSendHandshakeVersionRecvError(t *testing.T) {
+	t.Parallel()
 	s, c := net.Pipe()
 	conn := newConnection(s, "Test")
 	// Close the peer end immediately after accepting the write.
@@ -542,6 +554,7 @@ func TestSendHandshakeVersionRecvError(t *testing.T) {
 // --- newRequestError: non-string key is skipped ---
 
 func TestNewRequestErrorNonStringKey(t *testing.T) {
+	t.Parallel()
 	data := map[any]any{
 		any("error"):   any("oops"),
 		any("type"):    any("E"),
@@ -559,26 +572,38 @@ func TestNewRequestErrorNonStringKey(t *testing.T) {
 
 // --- putInbox: default drop path (inbox full) ---
 
-func TestPutInboxDropsWhenFull(t *testing.T) {
+func TestChannelPanicsOnDroppedMessage(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
-	// Fill the inbox (capacity 64).
-	for i := 0; i < 64; i++ {
+	for i := range cap(ch.inbox) {
 		ch.inbox <- packet{ChannelID: 0, MessageID: uint32(i)}
 	}
-	// This call should hit the default case and silently drop.
+	// This call should hit the default case and enqueue a panic for the next receive.
 	ch.putInbox(packet{ChannelID: 0, MessageID: 99})
-	if len(ch.inbox) != 64 {
-		t.Errorf("inbox length = %d, want 64 (drop did not work)", len(ch.inbox))
+	if len(ch.inbox) != cap(ch.inbox) {
+		t.Errorf("inbox isn't full: %d < %d", len(ch.inbox), cap(ch.inbox))
 	}
+
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("Expected Recv to panic")
+			}
+		}()
+		_, _ = ch.ReceiveResponse(999, time.Second)
+	}()
+
 }
 
 // --- SendReplyValue: CBOR encode error ---
 
 func TestSendReplyValueEncodeError(t *testing.T) {
+	t.Parallel()
 	s, c := socketPair(t)
 	defer s.Close()
 	defer c.Close()
@@ -597,6 +622,7 @@ func TestSendReplyValueEncodeError(t *testing.T) {
 // --- SendReplyError: verify happy path ---
 
 func TestSendReplyErrorSucceeds(t *testing.T) {
+	t.Parallel()
 	s, c := socketPair(t)
 	defer s.Close()
 	defer c.Close()
@@ -615,6 +641,7 @@ func TestSendReplyErrorSucceeds(t *testing.T) {
 // --- RecvRequest: CBOR decode error path ---
 
 func TestRecvRequestDecodeCBORError(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
@@ -632,15 +659,18 @@ func TestRecvRequestDecodeCBORError(t *testing.T) {
 // --- recvResponseRaw: processOneMessage error path ---
 
 func TestRecvResponseRawProcessError(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
-	defer conn.Close()
 
 	ch := conn.ControlChannel()
-	// Inject shutdown sentinel to make processOneMessage return an error.
-	ch.inbox <- shutdownSentinel
+	// Close connection so processOneMessage returns an error.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		conn.Close()
+	}()
 
-	_, err := ch.recvResponseRaw(1, 100*time.Millisecond)
+	_, err := ch.recvResponseRaw(1, 2*time.Second)
 	if err == nil {
 		t.Fatal("expected error from recvResponseRaw when connection closed")
 	}
@@ -649,6 +679,7 @@ func TestRecvResponseRawProcessError(t *testing.T) {
 // --- ReceiveResponse: CBOR decode error ---
 
 func TestReceiveResponseDecodeCBORError(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
@@ -666,6 +697,7 @@ func TestReceiveResponseDecodeCBORError(t *testing.T) {
 // --- ReceiveResponse: extractCBORDict error (payload is not a map) ---
 
 func TestReceiveResponseExtractCBORDictError(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
@@ -684,14 +716,18 @@ func TestReceiveResponseExtractCBORDictError(t *testing.T) {
 // --- ReceiveResponse: recvResponseRaw error path ---
 
 func TestReceiveResponseRecvError(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
-	defer conn.Close()
 
 	ch := conn.ControlChannel()
-	ch.inbox <- shutdownSentinel
+	// Close connection so recvResponseRaw returns an error.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		conn.Close()
+	}()
 
-	_, err := ch.ReceiveResponse(1, 100*time.Millisecond)
+	_, err := ch.ReceiveResponse(1, 2*time.Second)
 	if err == nil {
 		t.Fatal("expected error from ReceiveResponse when connection closed")
 	}
@@ -700,6 +736,7 @@ func TestReceiveResponseRecvError(t *testing.T) {
 // --- processOneMessage: reply packet routed to responses map (ch.responses nil) ---
 
 func TestProcessOneMessageRouteReplyNilResponses(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
@@ -725,19 +762,21 @@ func TestProcessOneMessageRouteReplyNilResponses(t *testing.T) {
 // --- channelName: unnamed channel returns "channel N" ---
 
 func TestChannelNameUnnamed(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "Test")
 	defer conn.Close()
 
-	// Control channel has no name set.
-	ch := conn.ControlChannel()
-	name := ch.channelName()
-	mustContain(t, name, "channel 0")
+	// Create a channel with an empty name to exercise the unnamed branch.
+	ch := newChannel(conn, 42, "")
+	name := ch.String()
+	mustContain(t, name, "channel 42")
 }
 
 // --- Request: SendRequestRaw error path ---
 
 func TestRequestSendError(t *testing.T) {
+	t.Parallel()
 	s, c := net.Pipe()
 	conn := newConnection(s, "Test")
 	// Close both ends so SendRequestRaw fails.
@@ -799,6 +838,22 @@ func TestPendingRequestGetCached(t *testing.T) {
 	}
 	if v1 != v2 {
 		t.Errorf("cached Get returned different value: %v vs %v", v1, v2)
+	}
+}
+
+// --- SendControlRequest: error from Request (closed connection) ---
+
+func TestSendControlRequestSendError(t *testing.T) {
+	t.Parallel()
+	s, c := net.Pipe()
+	conn := newConnection(s, "Test")
+	// Close both ends so SendRequestRaw fails.
+	s.Close()
+	c.Close()
+
+	_, err := conn.SendControlRequest([]byte("test"))
+	if err == nil {
+		t.Fatal("expected error from SendControlRequest on closed conn")
 	}
 }
 

--- a/dicts_test.go
+++ b/dicts_test.go
@@ -16,6 +16,7 @@ import (
 // TestDictsBasicSchema verifies that Dicts with two basic generators produces
 // a basicGenerator with a dict schema containing the expected fields.
 func TestDictsBasicSchema(t *testing.T) {
+	t.Parallel()
 	keys := Text(0, 5)
 	vals := Integers[int64](0, 100)
 	gen := Dicts(keys, vals, DictMaxSize(3))
@@ -52,6 +53,7 @@ func TestDictsBasicSchema(t *testing.T) {
 
 // TestDictsBasicSchemaNoMaxSize verifies that when HasMaxSize=false, max_size is omitted.
 func TestDictsBasicSchemaNoMaxSize(t *testing.T) {
+	t.Parallel()
 	gen := Dicts(Text(0, 5), Integers[int64](0, 100), DictMinSize(1))
 	bg, ok := gen.(*basicGenerator[map[string]int64])
 	if !ok {
@@ -64,6 +66,7 @@ func TestDictsBasicSchemaNoMaxSize(t *testing.T) {
 
 // TestDictsBasicSchemaMinSize verifies that MinSize is propagated to the schema.
 func TestDictsBasicSchemaMinSize(t *testing.T) {
+	t.Parallel()
 	gen := Dicts(Text(0, 5), Integers[int64](0, 100), DictMinSize(2), DictMaxSize(5))
 	bg, ok := gen.(*basicGenerator[map[string]int64])
 	if !ok {
@@ -77,6 +80,7 @@ func TestDictsBasicSchemaMinSize(t *testing.T) {
 
 // TestDictsBasicIsBasicGenerator verifies basicGenerator path via type assertion.
 func TestDictsBasicIsBasicGenerator(t *testing.T) {
+	t.Parallel()
 	gen := Dicts(Text(0, 5), Integers[int64](0, 100))
 	if _, ok := gen.(*basicGenerator[map[string]int64]); !ok {
 		t.Errorf("Dicts(basic,basic) should be *basicGenerator[map[string]int64], got %T", gen)
@@ -85,6 +89,7 @@ func TestDictsBasicIsBasicGenerator(t *testing.T) {
 
 // TestDictsCompositeIsNotBasicGenerator verifies compositeDictGenerator is not a basicGenerator.
 func TestDictsCompositeIsNotBasicGenerator(t *testing.T) {
+	t.Parallel()
 	// Use a non-basic key generator (mappedGenerator wrapping a basic generator)
 	nonBasicKeys := &mappedGenerator[int64, int64]{
 		inner: Integers[int64](0, 10),
@@ -98,6 +103,7 @@ func TestDictsCompositeIsNotBasicGenerator(t *testing.T) {
 
 // TestDictsCompositeMap verifies that Map on a compositeDictGenerator returns a mappedGenerator.
 func TestDictsCompositeMap(t *testing.T) {
+	t.Parallel()
 	nonBasicKeys := &mappedGenerator[int64, int64]{
 		inner: Integers[int64](0, 10),
 		fn:    func(v int64) int64 { return v },
@@ -115,6 +121,7 @@ func TestDictsCompositeMap(t *testing.T) {
 
 // TestPairsToMapNoTransform verifies pairsToMap converts pairs to a map with no transforms.
 func TestPairsToMapNoTransform(t *testing.T) {
+	t.Parallel()
 	pairs := []any{
 		[]any{"a", int64(1)},
 		[]any{"b", int64(2)},
@@ -130,6 +137,7 @@ func TestPairsToMapNoTransform(t *testing.T) {
 
 // TestPairsToMapWithKeyTransform verifies that the key transform is applied.
 func TestPairsToMapWithKeyTransform(t *testing.T) {
+	t.Parallel()
 	pairs := []any{
 		[]any{"hello", int64(1)},
 	}
@@ -145,6 +153,7 @@ func TestPairsToMapWithKeyTransform(t *testing.T) {
 
 // TestPairsToMapWithValTransform verifies that the value transform is applied.
 func TestPairsToMapWithValTransform(t *testing.T) {
+	t.Parallel()
 	pairs := []any{
 		[]any{"x", int64(5)},
 	}
@@ -160,6 +169,7 @@ func TestPairsToMapWithValTransform(t *testing.T) {
 
 // TestPairsToMapBothTransforms verifies both key and value transforms are applied.
 func TestPairsToMapBothTransforms(t *testing.T) {
+	t.Parallel()
 	pairs := []any{
 		[]any{"k", int64(3)},
 	}
@@ -176,6 +186,7 @@ func TestPairsToMapBothTransforms(t *testing.T) {
 
 // TestPairsToMapNonSliceInput verifies pairsToMap handles non-slice input gracefully.
 func TestPairsToMapNonSliceInput(t *testing.T) {
+	t.Parallel()
 	// If the server sends something unexpected, return an empty map.
 	result := pairsToMap[string, int64]("not a slice", nil, nil)
 	if len(result) != 0 {
@@ -185,6 +196,7 @@ func TestPairsToMapNonSliceInput(t *testing.T) {
 
 // TestPairsToMapShortPair verifies that short pairs (len < 2) are skipped.
 func TestPairsToMapShortPair(t *testing.T) {
+	t.Parallel()
 	pairs := []any{
 		[]any{"only_key"}, // only one element -- skip
 		[]any{"a", int64(1)},
@@ -197,6 +209,7 @@ func TestPairsToMapShortPair(t *testing.T) {
 
 // TestPairsToMapNonSlicePair verifies that non-slice pair entries are skipped.
 func TestPairsToMapNonSlicePair(t *testing.T) {
+	t.Parallel()
 	pairs := []any{
 		"not a pair",
 		[]any{"a", int64(1)},
@@ -251,6 +264,7 @@ func TestDictsStopTestOnCollectionMore(t *testing.T) {
 // TestDictsBasicE2E verifies the basic Dicts generator produces maps with
 // string keys and integer values within bounds.
 func TestDictsBasicE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		gen := Dicts(Text(0, 5), Integers[int](0, 100), DictMaxSize(3))
@@ -274,6 +288,7 @@ func TestDictsBasicE2E(t *testing.T) {
 // TestDictsBasicWithBoundsE2E verifies that Dicts with min_size/max_size constraints
 // produces maps with the right number of entries.
 func TestDictsBasicWithBoundsE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		gen := Dicts(Integers[int](0, 10), Booleans(), DictMinSize(1), DictMaxSize(3))
@@ -312,6 +327,7 @@ func TestDictsCompositeNoMaxE2E(t *testing.T) {
 // TestDictsCompositeE2E verifies the composite Dicts generator (non-basic keys)
 // produces valid maps.
 func TestDictsCompositeE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		// mappedGenerator makes this non-basic -> composite path

--- a/filter_test.go
+++ b/filter_test.go
@@ -14,6 +14,7 @@ import (
 // TestBasicGeneratorFilterReturnsfilteredGenerator verifies that calling Filter
 // on a basicGenerator returns a *filteredGenerator.
 func TestBasicGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
+	t.Parallel()
 	g := Integers[int](0, 100)
 	filtered := Filter(g, func(v int) bool { return true })
 	if _, ok := filtered.(*filteredGenerator[int]); !ok {
@@ -24,6 +25,7 @@ func TestBasicGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
 // TestMappedGeneratorFilterReturnsfilteredGenerator verifies that calling Filter
 // on a mappedGenerator returns a *filteredGenerator.
 func TestMappedGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
+	t.Parallel()
 	inner := Integers[int](0, 100)
 	mapped := Map(inner, func(v int) int { return v })
 	filtered := Filter(mapped, func(v int) bool { return true })
@@ -35,6 +37,7 @@ func TestMappedGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
 // TestFilteredGeneratorFilterChainsfilteredGenerators verifies that calling Filter
 // on a filteredGenerator returns another *filteredGenerator (chained filtering).
 func TestFilteredGeneratorFilterChainsfilteredGenerators(t *testing.T) {
+	t.Parallel()
 	g := Integers[int](0, 100)
 	fg := Filter(g, func(v int) bool { return true })
 	fg2 := Filter(fg, func(v int) bool { return true })
@@ -46,6 +49,7 @@ func TestFilteredGeneratorFilterChainsfilteredGenerators(t *testing.T) {
 // TestFilteredGeneratorMapReturnsmappedGenerator verifies that calling Map
 // on a filteredGenerator returns a *mappedGenerator.
 func TestFilteredGeneratorMapReturnsmappedGenerator(t *testing.T) {
+	t.Parallel()
 	g := Integers[int](0, 100)
 	fg := Filter(g, func(v int) bool { return true })
 	mapped := Map(fg, func(v int) int { return v })
@@ -61,6 +65,7 @@ func TestFilteredGeneratorMapReturnsmappedGenerator(t *testing.T) {
 // TestCompositeListGeneratorFilterReturnsfilteredGenerator verifies that calling
 // Filter on a compositeListGenerator returns a *filteredGenerator.
 func TestCompositeListGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
+	t.Parallel()
 	// compositeListGenerator is produced when elements are non-basic.
 	// Filter produces a filteredGenerator (non-basic), forcing Lists into composite path.
 	nonBasic := Filter(Integers[int](0, 10), func(v int) bool { return true })
@@ -74,6 +79,7 @@ func TestCompositeListGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
 // TestCompositeDictGeneratorFilterReturnsfilteredGenerator verifies that calling
 // Filter on a compositeDictGenerator returns a *filteredGenerator.
 func TestCompositeDictGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
+	t.Parallel()
 	// compositeDictGenerator is produced when key or value is non-basic.
 	// Filter produces a filteredGenerator (non-basic), forcing Dicts into composite path.
 	nonBasic := Filter(Integers[int](0, 10), func(v int) bool { return true })
@@ -87,6 +93,7 @@ func TestCompositeDictGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
 // TestCompositeOneOfGeneratorFilterReturnsfilteredGenerator verifies that calling
 // Filter on a compositeOneOfGenerator returns a *filteredGenerator.
 func TestCompositeOneOfGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
+	t.Parallel()
 	// compositeOneOfGenerator is produced when any branch is non-basic.
 	// Filter produces a filteredGenerator (non-basic), forcing OneOf into composite path.
 	nonBasic := Filter(Integers[int](0, 10), func(v int) bool { return true })
@@ -100,6 +107,7 @@ func TestCompositeOneOfGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
 // TestFlatMappedGeneratorFilterReturnsfilteredGenerator verifies that calling
 // Filter on a flatMappedGenerator returns a *filteredGenerator.
 func TestFlatMappedGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
+	t.Parallel()
 	flatGen := FlatMap(Integers[int](1, 5), func(v int) Generator[int] {
 		return Integers[int](0, v)
 	})
@@ -116,6 +124,7 @@ func TestFlatMappedGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
 // TestFilteredGeneratorGeneratePredicatePassesFirstTry verifies that when the
 // predicate passes on the first attempt, the value is returned immediately.
 func TestFilteredGeneratorGeneratePredicatePassesFirstTry(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Filter that always passes: every value is accepted on first try.
 	gen := Filter(Integers[int](0, 100), func(v int) bool { return true })
@@ -132,6 +141,7 @@ func TestFilteredGeneratorGeneratePredicatePassesFirstTry(t *testing.T) {
 // TestFilteredGeneratorGenerateWithRealPredicate verifies that Filter correctly
 // filters values: only even numbers should pass.
 func TestFilteredGeneratorGenerateWithRealPredicate(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Filter integers [0,50] keeping only even ones.
 	gen := Filter(Integers[int](0, 50), func(v int) bool {
@@ -153,6 +163,7 @@ func TestFilteredGeneratorGenerateWithRealPredicate(t *testing.T) {
 // TestFilteredGeneratorGenerateChainedFilters verifies that chaining two Filter
 // calls composes the predicates: both must be satisfied.
 func TestFilteredGeneratorGenerateChainedFilters(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// First filter: even numbers; second filter: divisible by 4.
 	// Combined: only multiples of 4.
@@ -173,6 +184,7 @@ func TestFilteredGeneratorGenerateChainedFilters(t *testing.T) {
 // TestFilteredGeneratorGenerateThenMap verifies that Filter followed by Map
 // correctly applies the predicate first and then the transform.
 func TestFilteredGeneratorGenerateThenMap(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Filter odd numbers from [1,20], then multiply by 10.
 	gen := Map(

--- a/formats_test.go
+++ b/formats_test.go
@@ -15,6 +15,7 @@ import (
 
 // TestEmailsSchema verifies that Emails() produces the correct schema.
 func TestEmailsSchema(t *testing.T) {
+	t.Parallel()
 	g := Emails()
 	bg, ok := g.(*basicGenerator[string])
 	if !ok {
@@ -30,6 +31,7 @@ func TestEmailsSchema(t *testing.T) {
 
 // TestURLsSchema verifies that URLs() produces the correct schema.
 func TestURLsSchema(t *testing.T) {
+	t.Parallel()
 	g := URLs()
 	bg, ok := g.(*basicGenerator[string])
 	if !ok {
@@ -45,6 +47,7 @@ func TestURLsSchema(t *testing.T) {
 
 // TestDomainsSchemaNoMaxLength verifies that Domains() with no MaxLength uses the default (255).
 func TestDomainsSchemaNoMaxLength(t *testing.T) {
+	t.Parallel()
 	g := Domains()
 	bg, ok := g.(*basicGenerator[string])
 	if !ok {
@@ -65,6 +68,7 @@ func TestDomainsSchemaNoMaxLength(t *testing.T) {
 
 // TestDomainsSchemaWithMaxLength verifies that Domains() with MaxLength includes it.
 func TestDomainsSchemaWithMaxLength(t *testing.T) {
+	t.Parallel()
 	g := Domains(DomainMaxLength(63))
 	bg, ok := g.(*basicGenerator[string])
 	if !ok {
@@ -85,6 +89,7 @@ func TestDomainsSchemaWithMaxLength(t *testing.T) {
 
 // TestDatesSchema verifies that Dates() produces the correct schema.
 func TestDatesSchema(t *testing.T) {
+	t.Parallel()
 	g := Dates()
 	bg, ok := g.(*basicGenerator[time.Time])
 	if !ok {
@@ -100,6 +105,7 @@ func TestDatesSchema(t *testing.T) {
 
 // TestTimesSchema verifies that Times() produces the correct schema.
 func TestTimesSchema(t *testing.T) {
+	t.Parallel()
 	g := Times()
 	bg, ok := g.(*basicGenerator[string])
 	if !ok {
@@ -115,6 +121,7 @@ func TestTimesSchema(t *testing.T) {
 
 // TestDatetimesSchema verifies that Datetimes() produces the correct schema.
 func TestDatetimesSchema(t *testing.T) {
+	t.Parallel()
 	g := Datetimes()
 	bg, ok := g.(*basicGenerator[time.Time])
 	if !ok {
@@ -134,6 +141,7 @@ func TestDatetimesSchema(t *testing.T) {
 
 // TestEmailsE2E verifies that generated emails contain "@".
 func TestEmailsE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw(s, Emails())
@@ -147,6 +155,7 @@ func TestEmailsE2E(t *testing.T) {
 
 // TestURLsE2E verifies that generated URLs start with "http://" or "https://".
 func TestURLsE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw(s, URLs())
@@ -165,6 +174,7 @@ func isValidDomainChar(r rune) bool {
 
 // TestDomainsE2E verifies that generated domains contain only valid domain characters.
 func TestDomainsE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw(s, Domains())
@@ -180,6 +190,7 @@ func TestDomainsE2E(t *testing.T) {
 
 // TestDomainsMaxLengthE2E verifies that generated domains respect the max_length constraint.
 func TestDomainsMaxLengthE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	const maxLen = 20
 	if _err := runHegel(func(s *TestCase) {
@@ -194,6 +205,7 @@ func TestDomainsMaxLengthE2E(t *testing.T) {
 
 // TestDatesE2E verifies that generated dates are valid time.Time values.
 func TestDatesE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw(s, Dates())
@@ -207,6 +219,7 @@ func TestDatesE2E(t *testing.T) {
 
 // TestTimesE2E verifies that generated times contain ":".
 func TestTimesE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw(s, Times())
@@ -220,6 +233,7 @@ func TestTimesE2E(t *testing.T) {
 
 // TestDatetimesE2E verifies that generated datetimes are valid time.Time values.
 func TestDatetimesE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw(s, Datetimes())

--- a/generators_test.go
+++ b/generators_test.go
@@ -14,6 +14,7 @@ import (
 // --- Map free function on basicGenerator: no existing transform ---
 
 func TestBasicGeneratorMapNoTransform(t *testing.T) {
+	t.Parallel()
 	schema := map[string]any{"type": "boolean"}
 	g := &basicGenerator[bool]{schema: schema}
 	mapped := Map[bool, string](g, func(v bool) string {
@@ -38,6 +39,7 @@ func TestBasicGeneratorMapNoTransform(t *testing.T) {
 // --- Map free function on basicGenerator: compose transforms ---
 
 func TestBasicGeneratorMapComposesTransforms(t *testing.T) {
+	t.Parallel()
 	schema := map[string]any{"type": "integer"}
 	g := &basicGenerator[int64]{
 		schema:    schema,
@@ -61,6 +63,7 @@ func TestBasicGeneratorMapComposesTransforms(t *testing.T) {
 // --- Map on basicGenerator inner returns basicGenerator ---
 
 func TestMappedGeneratorMapOnBasicInner(t *testing.T) {
+	t.Parallel()
 	inner := &basicGenerator[int64]{schema: map[string]any{"type": "integer"}, transform: func(v any) int64 { return extractInt(v) }}
 	// Map on basicGenerator returns basicGenerator.
 	result := Map[int64, int64](inner, func(v int64) int64 { return v })
@@ -103,6 +106,7 @@ func TestCollectionStopTestOnCollectionMore(t *testing.T) {
 // =============================================================================
 
 func TestLabelConstants(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		val  spanLabel
@@ -138,6 +142,7 @@ func TestLabelConstants(t *testing.T) {
 // =============================================================================
 
 func TestIntegersGeneratorHappyPath(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	var vals []int64
 	if _err := runHegel(func(s *TestCase) {
@@ -157,6 +162,7 @@ func TestIntegersGeneratorHappyPath(t *testing.T) {
 // --- Integers: schema is correct ---
 
 func TestIntegersSchema(t *testing.T) {
+	t.Parallel()
 	g := Integers[int64](-5, 5)
 	bg, ok := g.(*basicGenerator[int64])
 	if !ok {
@@ -181,6 +187,7 @@ func TestIntegersSchema(t *testing.T) {
 
 // TestJustSchema verifies that Just produces a schema with "const" key.
 func TestJustSchema(t *testing.T) {
+	t.Parallel()
 	g := Just(42)
 	bg := g.(*basicGenerator[int])
 	if _, hasConst := bg.schema["const"]; !hasConst {
@@ -194,6 +201,7 @@ func TestJustSchema(t *testing.T) {
 
 // TestJustTransformIgnoresInput verifies that Just always returns the constant value.
 func TestJustTransformIgnoresInput(t *testing.T) {
+	t.Parallel()
 	g := Just("hello")
 	bg := g.(*basicGenerator[string])
 	// transform should ignore the server value and always return "hello"
@@ -209,6 +217,7 @@ func TestJustTransformIgnoresInput(t *testing.T) {
 
 // TestJustE2E verifies that Just always generates the constant value against the real server.
 func TestJustE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw[int](s, Just(42))
@@ -222,6 +231,7 @@ func TestJustE2E(t *testing.T) {
 
 // TestJustNonPrimitive verifies that Just works with non-primitive values (pointer identity).
 func TestJustNonPrimitive(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	type myStruct struct{ x int }
 	val := &myStruct{x: 99}
@@ -241,6 +251,7 @@ func TestJustNonPrimitive(t *testing.T) {
 
 // TestSampledFromEmptyPanics verifies that SampledFrom panics for empty slice.
 func TestSampledFromEmptyPanics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("SampledFrom([]) should panic")
@@ -251,6 +262,7 @@ func TestSampledFromEmptyPanics(t *testing.T) {
 
 // TestSampledFromSchema verifies that SampledFrom produces an integer schema with correct bounds.
 func TestSampledFromSchema(t *testing.T) {
+	t.Parallel()
 	g := SampledFrom([]string{"a", "b", "c"})
 	bg := g.(*basicGenerator[string])
 	if bg.schema["type"] != "integer" {
@@ -269,6 +281,7 @@ func TestSampledFromSchema(t *testing.T) {
 // TestSampledFromTransformMapsIndices verifies that the transform correctly maps
 // integer indices to the corresponding elements.
 func TestSampledFromTransformMapsIndices(t *testing.T) {
+	t.Parallel()
 	items := []string{"x", "y", "z"}
 	g := SampledFrom(items)
 	bg := g.(*basicGenerator[string])
@@ -283,6 +296,7 @@ func TestSampledFromTransformMapsIndices(t *testing.T) {
 
 // TestSampledFromSingleElement verifies that a single-element slice always returns that element.
 func TestSampledFromSingleElement(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		v := Draw[string](s, SampledFrom([]string{"only"}))
@@ -297,6 +311,7 @@ func TestSampledFromSingleElement(t *testing.T) {
 // TestSampledFromE2E verifies that SampledFrom only returns elements from the list
 // and that all elements appear (with enough test cases).
 func TestSampledFromE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	choices := []string{"apple", "banana", "cherry"}
 	seen := map[string]bool{}
@@ -327,6 +342,7 @@ func TestSampledFromE2E(t *testing.T) {
 // TestSampledFromNonPrimitive verifies that SampledFrom preserves pointer identity
 // for non-primitive values.
 func TestSampledFromNonPrimitive(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	type myStruct struct{ x int }
 	obj1 := &myStruct{x: 1}
@@ -347,6 +363,7 @@ func TestSampledFromNonPrimitive(t *testing.T) {
 
 // TestFromRegexSchema verifies that FromRegex produces the correct schema.
 func TestFromRegexSchema(t *testing.T) {
+	t.Parallel()
 	g := FromRegex(`\d+`, true)
 	bg := g.(*basicGenerator[string])
 	if bg.schema["type"] != "regex" {
@@ -362,6 +379,7 @@ func TestFromRegexSchema(t *testing.T) {
 
 // TestFromRegexFullmatchFalse verifies that fullmatch=false is stored correctly.
 func TestFromRegexFullmatchFalse(t *testing.T) {
+	t.Parallel()
 	g := FromRegex(`abc`, false)
 	bg := g.(*basicGenerator[string])
 	if bg.schema["fullmatch"] != false {
@@ -371,6 +389,7 @@ func TestFromRegexFullmatchFalse(t *testing.T) {
 
 // TestFromRegexE2E verifies that FromRegex generates strings that match the pattern.
 func TestFromRegexE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Only digits, 1-5 chars
 	if _err := runHegel(func(s *TestCase) {
@@ -410,6 +429,7 @@ func TestBasicGeneratorGenerateErrorResponse(t *testing.T) {
 // =============================================================================
 
 func TestGeneratorMapOnNonBasic(t *testing.T) {
+	t.Parallel()
 	// A custom generator that is not a basicGenerator.
 	schema := map[string]any{"type": "integer"}
 	inner := &basicGenerator[int64]{schema: schema, transform: func(v any) int64 { return extractInt(v) }}
@@ -429,6 +449,7 @@ func TestGeneratorMapOnNonBasic(t *testing.T) {
 // TestMapBasicGeneratorE2E verifies that mapping Integers[int](0,100) by doubling
 // always produces even values in [0, 200], and the result is still a basicGenerator.
 func TestMapBasicGeneratorE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	gen := Map[int, int](Integers[int](0, 100), func(v int) int {
 		return v * 2
@@ -454,6 +475,7 @@ func TestMapBasicGeneratorE2E(t *testing.T) {
 // preserves the basicGenerator type and composes the transforms correctly.
 // Integers[int](0,100).Map(x+1).Map(x*2): result must be even, in [2, 202].
 func TestMapChainedBasicGeneratorE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	gen := Map[int, int](
 		Map[int, int](Integers[int](0, 100), func(v int) int { return v + 1 }),
@@ -481,6 +503,7 @@ func TestMapChainedBasicGeneratorE2E(t *testing.T) {
 // wraps it in a MAPPED span and applies the transform correctly.
 // The result must be a mappedGenerator (not basicGenerator).
 func TestMapNonBasicGeneratorE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Create a non-basic generator by wrapping a basicGenerator in mappedGenerator.
 	inner := Integers[int](1, 5)
@@ -507,6 +530,7 @@ func TestMapNonBasicGeneratorE2E(t *testing.T) {
 
 // TestMapSchemaPreservedUnit verifies unit-level schema properties of Map on basicGenerator.
 func TestMapSchemaPreservedUnit(t *testing.T) {
+	t.Parallel()
 	base := Integers[int64](0, 100)
 	mapped := Map[int64, int64](base, func(v int64) int64 { return v })
 	bg, ok := mapped.(*basicGenerator[int64])
@@ -566,6 +590,7 @@ func TestMapSchemaPreservedUnit(t *testing.T) {
 // TestFilteredGeneratorFromBasicIsNotBasic verifies that Filter on a basicGenerator
 // returns a filteredGenerator (not a basicGenerator).
 func TestFilteredGeneratorFromBasicIsNotBasic(t *testing.T) {
+	t.Parallel()
 	g := Filter[int64](Integers[int64](0, 100), func(v int64) bool { return true })
 	if _, ok := g.(*filteredGenerator[int64]); !ok {
 		t.Fatalf("Filter on basicGenerator should return *filteredGenerator[int64], got %T", g)
@@ -575,6 +600,7 @@ func TestFilteredGeneratorFromBasicIsNotBasic(t *testing.T) {
 // TestFilteredGeneratorFilterMethod verifies that calling Filter on a filteredGenerator
 // returns another filteredGenerator.
 func TestFilteredGeneratorFilterMethod(t *testing.T) {
+	t.Parallel()
 	g := Filter[int64](
 		Filter[int64](Integers[int64](0, 100), func(v int64) bool { return true }),
 		func(v int64) bool { return true },
@@ -587,6 +613,7 @@ func TestFilteredGeneratorFilterMethod(t *testing.T) {
 // TestFilteredGeneratorMapMethod verifies that calling Map on a filteredGenerator
 // returns a mappedGenerator.
 func TestFilteredGeneratorMapMethod(t *testing.T) {
+	t.Parallel()
 	g := Filter[int64](Integers[int64](0, 100), func(v int64) bool { return true })
 	mapped := Map[int64, int64](g, func(v int64) int64 { return v })
 	if _, ok := mapped.(*mappedGenerator[int64, int64]); !ok {
@@ -597,6 +624,7 @@ func TestFilteredGeneratorMapMethod(t *testing.T) {
 // TestFilteredGeneratorE2EAlwaysPasses verifies an e2e filter with a predicate
 // that values greater than 50.
 func TestFilteredGeneratorE2EAlwaysPasses(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		gen := Filter[int](Integers[int](0, 100), func(v int) bool {
@@ -613,6 +641,7 @@ func TestFilteredGeneratorE2EAlwaysPasses(t *testing.T) {
 
 // TestFilteredGeneratorE2EEvenNumbers verifies filter for even numbers.
 func TestFilteredGeneratorE2EEvenNumbers(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		gen := Filter[int](Integers[int](0, 10), func(v int) bool {
@@ -629,6 +658,7 @@ func TestFilteredGeneratorE2EEvenNumbers(t *testing.T) {
 
 // TestFilterOnNonBasicGenerators verifies that Filter works on non-basic generators.
 func TestFilterOnNonBasicGenerators(t *testing.T) {
+	t.Parallel()
 	// mappedGenerator.Filter
 	mg := &mappedGenerator[int64, int64]{inner: Integers[int64](0, 5), fn: func(v int64) int64 { return v }}
 	fg := Filter[int64](mg, func(v int64) bool { return true })
@@ -663,6 +693,7 @@ func TestFilterOnNonBasicGenerators(t *testing.T) {
 
 // TestBooleansSchema verifies that Booleans produces a schema with type=boolean.
 func TestBooleansSchema(t *testing.T) {
+	t.Parallel()
 	g := Booleans()
 	bg, ok := g.(*basicGenerator[bool])
 	if !ok {
@@ -675,6 +706,7 @@ func TestBooleansSchema(t *testing.T) {
 
 // TestTextSchema verifies that Text produces the correct schema structure.
 func TestTextSchema(t *testing.T) {
+	t.Parallel()
 	g := Text(3, 10)
 	bg, ok := g.(*basicGenerator[string])
 	if !ok {
@@ -699,6 +731,7 @@ func TestTextSchema(t *testing.T) {
 
 // TestTextSchemaNoMax verifies that Text with maxSize<0 omits max_size from schema.
 func TestTextSchemaNoMax(t *testing.T) {
+	t.Parallel()
 	g := Text(0, -1)
 	bg := g.(*basicGenerator[string])
 	if _, hasMax := bg.schema["max_size"]; hasMax {
@@ -712,6 +745,7 @@ func TestTextSchemaNoMax(t *testing.T) {
 
 // TestBinarySchema verifies that Binary produces the correct schema structure.
 func TestBinarySchema(t *testing.T) {
+	t.Parallel()
 	g := Binary(1, 20)
 	bg, ok := g.(*basicGenerator[[]byte])
 	if !ok {
@@ -736,6 +770,7 @@ func TestBinarySchema(t *testing.T) {
 
 // TestBinarySchemaNoMax verifies that Binary with maxSize<0 omits max_size from schema.
 func TestBinarySchemaNoMax(t *testing.T) {
+	t.Parallel()
 	g := Binary(0, -1)
 	bg := g.(*basicGenerator[[]byte])
 	if _, hasMax := bg.schema["max_size"]; hasMax {
@@ -745,6 +780,7 @@ func TestBinarySchemaNoMax(t *testing.T) {
 
 // TestFloatsSchemaWithBounds verifies that Floats with explicit bounds sets all schema fields.
 func TestFloatsSchemaWithBounds(t *testing.T) {
+	t.Parallel()
 	minV := 0.0
 	maxV := 1.0
 	falseV := false
@@ -780,6 +816,7 @@ func TestFloatsSchemaWithBounds(t *testing.T) {
 
 // TestFloatsSchemaUnbounded verifies that Floats with no bounds defaults allow_nan=true, allow_infinity=true.
 func TestFloatsSchemaUnbounded(t *testing.T) {
+	t.Parallel()
 	g := Floats(nil, nil, nil, nil, false, false)
 	bg := g.(*basicGenerator[float64])
 	if bg.schema["allow_nan"] != true {
@@ -798,6 +835,7 @@ func TestFloatsSchemaUnbounded(t *testing.T) {
 
 // TestFloatsSchemaOnlyMin verifies Floats with only min bound: allow_nan=false, allow_infinity=true.
 func TestFloatsSchemaOnlyMin(t *testing.T) {
+	t.Parallel()
 	minV := 0.0
 	g := Floats(&minV, nil, nil, nil, false, false)
 	bg := g.(*basicGenerator[float64])
@@ -812,6 +850,7 @@ func TestFloatsSchemaOnlyMin(t *testing.T) {
 
 // TestFloatsSchemaOnlyMax verifies Floats with only max bound: allow_nan=false, allow_infinity=true.
 func TestFloatsSchemaOnlyMax(t *testing.T) {
+	t.Parallel()
 	maxV := 1.0
 	g := Floats(nil, &maxV, nil, nil, false, false)
 	bg := g.(*basicGenerator[float64])
@@ -826,6 +865,7 @@ func TestFloatsSchemaOnlyMax(t *testing.T) {
 
 // TestFloatsSchemaExcludeBounds verifies that excludeMin/excludeMax are stored correctly.
 func TestFloatsSchemaExcludeBounds(t *testing.T) {
+	t.Parallel()
 	minV := 0.0
 	maxV := 1.0
 	falseV := false
@@ -845,6 +885,7 @@ func TestFloatsSchemaExcludeBounds(t *testing.T) {
 
 // TestFlatMappedGeneratorIsNotBasic verifies that FlatMap returns a *flatMappedGenerator (not basicGenerator).
 func TestFlatMappedGeneratorIsNotBasic(t *testing.T) {
+	t.Parallel()
 	gen := FlatMap[int64, int64](Integers[int64](math.MinInt64, math.MaxInt64), func(v int64) Generator[int64] {
 		return Integers[int64](math.MinInt64, math.MaxInt64)
 	})
@@ -859,6 +900,7 @@ func TestFlatMappedGeneratorIsNotBasic(t *testing.T) {
 
 // TestFlatMappedGeneratorMapReturnsMapped verifies that Map on flatMappedGenerator returns a mappedGenerator.
 func TestFlatMappedGeneratorMapReturnsMapped(t *testing.T) {
+	t.Parallel()
 	gen := FlatMap[int64, int64](Integers[int64](1, 5), func(v int64) Generator[int64] {
 		return Integers[int64](0, 10)
 	})
@@ -871,6 +913,7 @@ func TestFlatMappedGeneratorMapReturnsMapped(t *testing.T) {
 // TestFlatMappedGeneratorE2E verifies that flat_map produces a dependent value.
 // integers(1,5).flat_map(n => text(min=n, max=n)) always produces text of length in [1,5].
 func TestFlatMappedGeneratorE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	gen := FlatMap[int, string](Integers[int](1, 5), func(v int) Generator[string] {
 		return Text(v, v) // exact length = n
@@ -891,6 +934,7 @@ func TestFlatMappedGeneratorE2E(t *testing.T) {
 // on the first generated value. We generate n in [2,4] and a list of exactly n elements.
 // Every list must have length in [2,4] and all elements must be in [0,100].
 func TestFlatMappedGeneratorDependency(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	gen := FlatMap[int64, []int64](Integers[int64](2, 4), func(v int64) Generator[[]int64] {
 		sz := int(v)
@@ -916,6 +960,7 @@ func TestFlatMappedGeneratorDependency(t *testing.T) {
 // =============================================================================
 
 func TestIsSchemaIdentityTrue(t *testing.T) {
+	t.Parallel()
 	bg := &basicGenerator[string]{schema: map[string]any{"type": "string"}}
 	if !bg.isSchemaIdentity() {
 		t.Error("expected identity when transform is nil")
@@ -923,6 +968,7 @@ func TestIsSchemaIdentityTrue(t *testing.T) {
 }
 
 func TestIsSchemaIdentityFalse(t *testing.T) {
+	t.Parallel()
 	bg := &basicGenerator[string]{
 		schema:    map[string]any{"type": "string"},
 		transform: func(v any) string { return v.(string) },
@@ -937,30 +983,35 @@ func TestIsSchemaIdentityFalse(t *testing.T) {
 // =============================================================================
 
 func TestExtractFloatFloat64(t *testing.T) {
+	t.Parallel()
 	if extractFloat(float64(1.5)) != 1.5 {
 		t.Error("float64 branch failed")
 	}
 }
 
 func TestExtractFloatFloat32(t *testing.T) {
+	t.Parallel()
 	if extractFloat(float32(1.5)) != float64(float32(1.5)) {
 		t.Error("float32 branch failed")
 	}
 }
 
 func TestExtractFloatInt64(t *testing.T) {
+	t.Parallel()
 	if extractFloat(int64(42)) != 42.0 {
 		t.Error("int64 branch failed")
 	}
 }
 
 func TestExtractFloatUint64(t *testing.T) {
+	t.Parallel()
 	if extractFloat(uint64(42)) != 42.0 {
 		t.Error("uint64 branch failed")
 	}
 }
 
 func TestExtractFloatPanicsOnInvalidType(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for invalid type")
@@ -974,12 +1025,14 @@ func TestExtractFloatPanicsOnInvalidType(t *testing.T) {
 // =============================================================================
 
 func TestExtractIntUint64(t *testing.T) {
+	t.Parallel()
 	if extractInt(uint64(99)) != 99 {
 		t.Error("uint64 branch failed")
 	}
 }
 
 func TestExtractIntBigIntValue(t *testing.T) {
+	t.Parallel()
 	v := *new(big.Int).SetInt64(456)
 	if extractInt(v) != 456 {
 		t.Error("big.Int value branch failed")
@@ -987,6 +1040,7 @@ func TestExtractIntBigIntValue(t *testing.T) {
 }
 
 func TestExtractIntBigIntPointer(t *testing.T) {
+	t.Parallel()
 	v := new(big.Int).SetInt64(123)
 	if extractInt(v) != 123 {
 		t.Error("*big.Int branch failed")
@@ -994,6 +1048,7 @@ func TestExtractIntBigIntPointer(t *testing.T) {
 }
 
 func TestExtractIntPanicsOnInvalidType(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for invalid type")
@@ -1007,6 +1062,7 @@ func TestExtractIntPanicsOnInvalidType(t *testing.T) {
 // =============================================================================
 
 func TestFloatsSchemaExplicitNaNNilInf(t *testing.T) {
+	t.Parallel()
 	nan := true
 	g := Floats(nil, nil, &nan, nil, false, false)
 	bg := g.(*basicGenerator[float64])
@@ -1023,6 +1079,7 @@ func TestFloatsSchemaExplicitNaNNilInf(t *testing.T) {
 // =============================================================================
 
 func TestFloatsSchemaExplicitInfNilNaN(t *testing.T) {
+	t.Parallel()
 	inf := true
 	g := Floats(nil, nil, nil, &inf, false, false)
 	bg := g.(*basicGenerator[float64])
@@ -1039,12 +1096,14 @@ func TestFloatsSchemaExplicitInfNilNaN(t *testing.T) {
 // =============================================================================
 
 func TestStartSpanAborted(t *testing.T) {
+	t.Parallel()
 	s := &TestCase{aborted: true}
 	// Should be a no-op, not panic.
 	startSpan(s, labelOneOf)
 }
 
 func TestStopSpanAborted(t *testing.T) {
+	t.Parallel()
 	s := &TestCase{aborted: true}
 	// Should be a no-op, not panic.
 	stopSpan(s, false)
@@ -1055,6 +1114,7 @@ func TestStopSpanAborted(t *testing.T) {
 // =============================================================================
 
 func TestRejectFinishedCollection(t *testing.T) {
+	t.Parallel()
 	c := &collection{finished: true}
 	s := &TestCase{}
 	// Should be a no-op since finished = true.
@@ -1085,6 +1145,7 @@ func TestRejectE2E(t *testing.T) {
 // =============================================================================
 
 func TestListsNegativeMinSizeSchema(t *testing.T) {
+	t.Parallel()
 	gen := Lists(Integers[int64](0, 10), ListMinSize(-5), ListMaxSize(10))
 	bg, ok := gen.(*basicGenerator[[]int64])
 	if !ok {

--- a/lists_test.go
+++ b/lists_test.go
@@ -14,6 +14,7 @@ import (
 // TestListsBasicElementSchema verifies that Lists on a basicGenerator[int64] (no transform)
 // produces a basicGenerator[[]int64] with the correct list schema.
 func TestListsBasicElementSchema(t *testing.T) {
+	t.Parallel()
 	elem := Integers[int64](0, 100)
 	gen := Lists(elem, ListMinSize(2), ListMaxSize(10))
 	bg, ok := gen.(*basicGenerator[[]int64])
@@ -42,6 +43,7 @@ func TestListsBasicElementSchema(t *testing.T) {
 
 // TestListsBasicElementNoMaxSchema verifies that when MaxSize < 0, max_size is omitted.
 func TestListsBasicElementNoMaxSchema(t *testing.T) {
+	t.Parallel()
 	elem := Integers[int64](0, 100)
 	gen := Lists(elem, ListMaxSize(-1))
 	bg, ok := gen.(*basicGenerator[[]int64])
@@ -56,6 +58,7 @@ func TestListsBasicElementNoMaxSchema(t *testing.T) {
 // TestListsBasicElementWithTransformSchema verifies that Lists on a basicGenerator with
 // a transform applies the transform element-wise in the list transform.
 func TestListsBasicElementWithTransformSchema(t *testing.T) {
+	t.Parallel()
 	// Integers[int64](0, 100) mapped to double: basicGenerator with transform.
 	elem := Map(Integers[int64](0, 100), func(n int64) int64 {
 		return n * 2
@@ -87,6 +90,7 @@ func TestListsBasicElementWithTransformSchema(t *testing.T) {
 // TestListsBasicElementWithTransformNonSlicePassthrough verifies that the list transform
 // returns nil for non-slice values (defensive path in transform).
 func TestListsBasicElementWithTransformNonSlicePassthrough(t *testing.T) {
+	t.Parallel()
 	elem := Map(Integers[int64](0, 10), func(n int64) int64 { return n })
 	gen := Lists(elem, ListMaxSize(5))
 	bg, ok := gen.(*basicGenerator[[]int64])
@@ -103,6 +107,7 @@ func TestListsBasicElementWithTransformNonSlicePassthrough(t *testing.T) {
 // TestListsBasicElementNoTransformNonSlicePassthrough verifies that the list transform
 // for a basic element with no transform returns nil for non-slice values.
 func TestListsBasicElementNoTransformNonSlicePassthrough(t *testing.T) {
+	t.Parallel()
 	elem := Booleans()
 	gen := Lists(elem, ListMaxSize(5))
 	bg, ok := gen.(*basicGenerator[[]bool])
@@ -119,6 +124,7 @@ func TestListsBasicElementNoTransformNonSlicePassthrough(t *testing.T) {
 // TestListsNonBasicElementReturnsComposite verifies that Lists on a non-basic generator
 // returns a compositeListGenerator (not a basicGenerator).
 func TestListsNonBasicElementReturnsComposite(t *testing.T) {
+	t.Parallel()
 	// mappedGenerator is non-basic.
 	inner := Integers[int64](0, 10)
 	nonBasic := &mappedGenerator[int64, int64]{inner: inner, fn: func(v int64) int64 { return v }}
@@ -130,6 +136,7 @@ func TestListsNonBasicElementReturnsComposite(t *testing.T) {
 
 // TestListsNegativeMinSizeClampedToZero verifies that a negative MinSize is clamped to 0.
 func TestListsNegativeMinSizeClampedToZero(t *testing.T) {
+	t.Parallel()
 	elem := Integers[int64](0, 100)
 	gen := Lists(elem, ListMinSize(-5), ListMaxSize(10))
 	bg, ok := gen.(*basicGenerator[[]int64])
@@ -149,6 +156,7 @@ func TestListsNegativeMinSizeClampedToZero(t *testing.T) {
 // TestListsBasicIntegersE2E verifies that Lists(Integers[int](0,100)) always produces
 // a list where every element is in [0, 100].
 func TestListsBasicIntegersE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		xs := Lists(Integers[int](0, 100), ListMaxSize(10)).draw(s)
@@ -165,6 +173,7 @@ func TestListsBasicIntegersE2E(t *testing.T) {
 // TestListsWithSizeBoundsE2E verifies that Lists with min_size and max_size constraints
 // always produces slices whose length is within the specified bounds.
 func TestListsWithSizeBoundsE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		xs := Lists(Booleans(), ListMinSize(3), ListMaxSize(5)).draw(s)
@@ -179,6 +188,7 @@ func TestListsWithSizeBoundsE2E(t *testing.T) {
 // TestListsNonBasicElementE2E verifies that Lists with a non-basic element generator
 // (mapped integers) always produces elements satisfying the mapped condition.
 func TestListsNonBasicElementE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Mapped generator: integers in [0,100] then round to nearest even.
 	mapped := Map(Integers[int](0, 100), func(n int) int {
@@ -201,6 +211,7 @@ func TestListsNonBasicElementE2E(t *testing.T) {
 // TestListsNestedE2E verifies that nested lists work correctly:
 // Lists(Lists(Booleans)) produces a list of lists of booleans.
 func TestListsNestedE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		outer := Lists(Lists(Booleans(), ListMaxSize(3)), ListMaxSize(3)).draw(s)
@@ -220,6 +231,7 @@ func TestListsNestedE2E(t *testing.T) {
 // TestListsBasicWithTransformE2E verifies that Lists on a basicGenerator with a transform
 // applies the transform element-wise to the result.
 func TestListsBasicWithTransformE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Map Integers[int](0,10) -> double. Lists wraps this into a list schema with element transform.
 	doubled := Map(Integers[int](0, 10), func(n int) int {

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -15,6 +15,7 @@ import (
 // TestOneOfPath1Schema verifies that OneOf with all-identity-transform basic
 // generators produces a simple {"one_of": [...]} schema.
 func TestOneOfPath1Schema(t *testing.T) {
+	t.Parallel()
 	g1 := Booleans()
 	g2 := Booleans()
 	combined := OneOf(g1, g2)
@@ -53,6 +54,7 @@ func TestOneOfPath1Schema(t *testing.T) {
 
 // TestOneOfPath1E2E verifies that OneOf path 1 generates values from both branches.
 func TestOneOfPath1E2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	sawShort := false
 	sawLong := false
@@ -83,6 +85,7 @@ func TestOneOfPath1E2E(t *testing.T) {
 // TestOneOfPath2Schema verifies that OneOf with mapped basicGenerators produces
 // a tagged-tuple schema.
 func TestOneOfPath2Schema(t *testing.T) {
+	t.Parallel()
 	gen1 := Map(Just(int64(1)), func(v int64) int64 { return v * 2 })
 	gen2 := Map(Just(int64(2)), func(v int64) int64 { return v * 3 })
 	combined := OneOf(gen1, gen2)
@@ -131,6 +134,7 @@ func TestOneOfPath2Schema(t *testing.T) {
 
 // TestOneOfPath2Transform verifies the tagged transform dispatching logic.
 func TestOneOfPath2Transform(t *testing.T) {
+	t.Parallel()
 	// just(1).map(*2) -> always 2; just(2).map(*3) -> always 6
 	gen1 := Map(Just(int64(1)), func(v int64) int64 { return v * 2 })
 	gen2 := Map(Just(int64(2)), func(v int64) int64 { return v * 3 })
@@ -154,6 +158,7 @@ func TestOneOfPath2Transform(t *testing.T) {
 // TestOneOfPath2TransformNilBranch verifies that when one branch has a nil transform,
 // the tagged dispatcher returns the raw value for that branch.
 func TestOneOfPath2TransformNilBranch(t *testing.T) {
+	t.Parallel()
 	// Mix: one identity branch (no transform), one with transform.
 	// Booleans has no transform (identity), Just(true) has a transform.
 	gen1 := Booleans()                                       // nil transform
@@ -178,6 +183,7 @@ func TestOneOfPath2TransformNilBranch(t *testing.T) {
 
 // TestOneOfPath2TransformShortTuple verifies graceful handling of malformed tuple.
 func TestOneOfPath2TransformShortTuple(t *testing.T) {
+	t.Parallel()
 	gen1 := Map(Just(int64(1)), func(v int64) int64 { return v })
 	gen2 := Map(Just(int64(2)), func(v int64) int64 { return v })
 	combined := OneOf(gen1, gen2)
@@ -195,6 +201,7 @@ func TestOneOfPath2TransformShortTuple(t *testing.T) {
 
 // TestOneOfPath2E2E verifies that Path 2 generates correctly through the real server.
 func TestOneOfPath2E2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	gen1 := Map(Just(int(1)), func(v int) int { return v * 2 })
 	gen2 := Map(Just(int(2)), func(v int) int { return v * 3 })
@@ -217,6 +224,7 @@ func TestOneOfPath2E2E(t *testing.T) {
 // TestOneOfPath3IsComposite verifies that OneOf with a non-basic generator
 // returns a compositeOneOfGenerator.
 func TestOneOfPath3IsComposite(t *testing.T) {
+	t.Parallel()
 	// A mappedGenerator is not a basicGenerator.
 	nonBasic := &mappedGenerator[int64, int64]{
 		inner: Integers[int64](0, 10),
@@ -232,6 +240,7 @@ func TestOneOfPath3IsComposite(t *testing.T) {
 // TestOneOfPath3MapReturnsMapGen verifies that mapping a compositeOneOfGenerator
 // returns a mappedGenerator.
 func TestOneOfPath3MapReturnsMapGen(t *testing.T) {
+	t.Parallel()
 	nonBasic := &mappedGenerator[int64, int64]{inner: Integers[int64](0, 10), fn: func(v int64) int64 { return v }}
 	combined := OneOf[int64](nonBasic, Integers[int64](0, 5))
 	mapped := Map(combined, func(v int64) int64 { return v })
@@ -243,6 +252,7 @@ func TestOneOfPath3MapReturnsMapGen(t *testing.T) {
 // TestOneOfPath3E2E verifies that Path 3 generates values from both branches
 // using the real hegel binary.
 func TestOneOfPath3E2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// nonBasic: a mappedGenerator (not a *basicGenerator)
 	nonBasic := &mappedGenerator[int, int]{
@@ -298,6 +308,7 @@ func TestOneOfPanicsWithZeroGenerators(t *testing.T) {
 
 // TestOptionalSchema verifies that Optional returns an optionalGenerator.
 func TestOptionalSchema(t *testing.T) {
+	t.Parallel()
 	g := Optional(Integers[int64](0, 10))
 	if _, ok := g.(*optionalGenerator[int64]); !ok {
 		t.Fatalf("Optional(Integers) should return *optionalGenerator[int64], got %T", g)
@@ -306,6 +317,7 @@ func TestOptionalSchema(t *testing.T) {
 
 // TestOptionalE2E verifies that Optional generates both nil and integer values.
 func TestOptionalE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	sawNil := false
 	sawInt := false
@@ -334,6 +346,7 @@ func TestOptionalE2E(t *testing.T) {
 // TestOptionalNonBasicE2E verifies that Optional with a non-basic element
 // works correctly (optionalGenerator handles any inner generator).
 func TestOptionalNonBasicE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	nonBasic := &mappedGenerator[int, int]{inner: Integers[int](0, 10), fn: func(v int) int { return v }}
 	g := Optional[int](nonBasic)
@@ -366,6 +379,7 @@ func TestOptionalNonBasicE2E(t *testing.T) {
 
 // TestIPAddressesV4Schema verifies that IPAddresses(v4) produces {"type":"ipv4"}.
 func TestIPAddressesV4Schema(t *testing.T) {
+	t.Parallel()
 	g := IPAddresses(IPv4())
 	bg, ok := g.(*basicGenerator[netip.Addr])
 	if !ok {
@@ -378,6 +392,7 @@ func TestIPAddressesV4Schema(t *testing.T) {
 
 // TestIPAddressesV6Schema verifies that IPAddresses(v6) produces {"type":"ipv6"}.
 func TestIPAddressesV6Schema(t *testing.T) {
+	t.Parallel()
 	g := IPAddresses(IPv6())
 	bg, ok := g.(*basicGenerator[netip.Addr])
 	if !ok {
@@ -390,6 +405,7 @@ func TestIPAddressesV6Schema(t *testing.T) {
 
 // TestIPAddressesDefaultIsOneOf verifies that IPAddresses(no version) returns a OneOf generator.
 func TestIPAddressesDefaultIsOneOf(t *testing.T) {
+	t.Parallel()
 	g := IPAddresses()
 	bg, ok := g.(*basicGenerator[netip.Addr])
 	if !ok {
@@ -408,6 +424,7 @@ func TestIPAddressesDefaultIsOneOf(t *testing.T) {
 
 // TestIPAddressesV4E2E verifies IPv4 addresses contain dots.
 func TestIPAddressesV4E2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	g := IPAddresses(IPv4())
 	if _err := runHegel(func(s *TestCase) {
@@ -422,6 +439,7 @@ func TestIPAddressesV4E2E(t *testing.T) {
 
 // TestIPAddressesV6E2E verifies IPv6 addresses contain colons.
 func TestIPAddressesV6E2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	g := IPAddresses(IPv6())
 	if _err := runHegel(func(s *TestCase) {
@@ -436,6 +454,7 @@ func TestIPAddressesV6E2E(t *testing.T) {
 
 // TestIPAddressesDefaultE2E verifies default produces both IPv4 and IPv6.
 func TestIPAddressesDefaultE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	sawV4 := false
 	sawV6 := false
@@ -461,6 +480,7 @@ func TestIPAddressesDefaultE2E(t *testing.T) {
 // TestOneOfWithMapMixedTypesE2E verifies that OneOf combining mapped and identity
 // generators produces correct values.
 func TestOneOfWithMapMixedTypesE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// Integers[int](0,10).Map(*2): always even numbers; Just(int(0)): always 0
 	gen := OneOf(
@@ -483,6 +503,7 @@ func TestOneOfWithMapMixedTypesE2E(t *testing.T) {
 // TestOneOfAllBranchesAppear verifies that both branches of OneOf appear
 // across enough test cases.
 func TestOneOfAllBranchesAppear(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	sawA := false
 	sawB := false

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -28,6 +28,7 @@ func TestIntegersFullRangeE2E(t *testing.T) {
 }
 
 func TestFloatsE2E_WithBounds(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	falseBool := false
 	if _err := runHegel(func(s *TestCase) {
@@ -47,6 +48,7 @@ func TestFloatsE2E_WithBounds(t *testing.T) {
 }
 
 func TestFloatsE2E_Unbounded(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		// Unbounded floats may produce NaN or Inf -- any float64 is valid.
@@ -57,6 +59,7 @@ func TestFloatsE2E_Unbounded(t *testing.T) {
 }
 
 func TestFloatsE2E_OnlyMin(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		fv := Draw[float64](s, Floats(floatPtr(0.0), nil, nil, nil, false, false))
@@ -71,6 +74,7 @@ func TestFloatsE2E_OnlyMin(t *testing.T) {
 }
 
 func TestBooleansE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		b := Draw[bool](s, Booleans())
@@ -84,6 +88,7 @@ func TestBooleansE2E(t *testing.T) {
 }
 
 func TestTextE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		sv := Draw[string](s, Text(2, 8))
@@ -97,6 +102,7 @@ func TestTextE2E(t *testing.T) {
 }
 
 func TestTextE2E_Unbounded(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		sv := Draw[string](s, Text(0, -1))
@@ -109,6 +115,7 @@ func TestTextE2E_Unbounded(t *testing.T) {
 }
 
 func TestBinaryE2E(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		bv := Draw[[]byte](s, Binary(1, 10))
@@ -121,6 +128,7 @@ func TestBinaryE2E(t *testing.T) {
 }
 
 func TestBinaryE2E_Unbounded(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		_ = Draw[[]byte](s, Binary(0, -1))

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -86,6 +86,7 @@ func roundtrip(t *testing.T, pkt packet) packet {
 // --- Constants ---
 
 func TestConstants(t *testing.T) {
+	t.Parallel()
 	if magic != 0x4845474C {
 		t.Errorf("magic = 0x%08X, want 0x4845474C", magic)
 	}
@@ -106,6 +107,7 @@ func TestConstants(t *testing.T) {
 // --- packet round-trip tests ---
 
 func TestPacketRoundtripBasic(t *testing.T) {
+	t.Parallel()
 	pkt := packet{ChannelID: 0, MessageID: 1, IsReply: false, Payload: []byte("hello")}
 	got := roundtrip(t, pkt)
 	if !packetsEqual(got, pkt) {
@@ -114,6 +116,7 @@ func TestPacketRoundtripBasic(t *testing.T) {
 }
 
 func TestPacketRoundtripEmptyPayload(t *testing.T) {
+	t.Parallel()
 	pkt := packet{ChannelID: 0, MessageID: 1, IsReply: false, Payload: []byte{}}
 	got := roundtrip(t, pkt)
 	if got.ChannelID != pkt.ChannelID || got.MessageID != pkt.MessageID || got.IsReply != pkt.IsReply || len(got.Payload) != 0 {
@@ -122,6 +125,7 @@ func TestPacketRoundtripEmptyPayload(t *testing.T) {
 }
 
 func TestPacketRoundtripReply(t *testing.T) {
+	t.Parallel()
 	pkt := packet{ChannelID: 1, MessageID: 42, IsReply: true, Payload: []byte("response")}
 	got := roundtrip(t, pkt)
 	if !packetsEqual(got, pkt) {
@@ -130,6 +134,7 @@ func TestPacketRoundtripReply(t *testing.T) {
 }
 
 func TestPacketRoundtripLargeChannelID(t *testing.T) {
+	t.Parallel()
 	pkt := packet{ChannelID: 0xFFFFFFFF, MessageID: 1, IsReply: false, Payload: []byte("data")}
 	got := roundtrip(t, pkt)
 	if !packetsEqual(got, pkt) {
@@ -138,6 +143,7 @@ func TestPacketRoundtripLargeChannelID(t *testing.T) {
 }
 
 func TestPacketRoundtripLargeMessageID(t *testing.T) {
+	t.Parallel()
 	pkt := packet{ChannelID: 0, MessageID: (1 << 31) - 1, IsReply: false, Payload: []byte("data")}
 	got := roundtrip(t, pkt)
 	if !packetsEqual(got, pkt) {
@@ -146,6 +152,7 @@ func TestPacketRoundtripLargeMessageID(t *testing.T) {
 }
 
 func TestPacketRoundtripBinaryPayload(t *testing.T) {
+	t.Parallel()
 	payload := make([]byte, 256)
 	for i := range payload {
 		payload[i] = byte(i)
@@ -160,6 +167,7 @@ func TestPacketRoundtripBinaryPayload(t *testing.T) {
 // --- recvExact error tests ---
 
 func TestRecvExactConnectionClosedWithPartialData(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	// Send 3 bytes then close — reader will block asking for 10.
 	go func() {
@@ -176,6 +184,7 @@ func TestRecvExactConnectionClosedWithPartialData(t *testing.T) {
 }
 
 func TestRecvExactConnectionClosedNoData(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	go writer.Close()
 	_, err := recvExact(reader, 10)
@@ -189,6 +198,7 @@ func TestRecvExactConnectionClosedNoData(t *testing.T) {
 }
 
 func TestRecvExactZeroBytes(t *testing.T) {
+	t.Parallel()
 	reader, _ := socketPair(t)
 	data, err := recvExact(reader, 0)
 	if err != nil {
@@ -200,6 +210,7 @@ func TestRecvExactZeroBytes(t *testing.T) {
 }
 
 func TestReadPacketInvalidMagic(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	raw := makeRawPacket(0xDEADBEEF, 0, 0, 1, []byte("payload"), terminator)
 	sendRaw(writer, raw)
@@ -213,6 +224,7 @@ func TestReadPacketInvalidMagic(t *testing.T) {
 }
 
 func TestReadPacketInvalidTerminator(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	raw := makeRawPacket(magic, 0, 0, 1, []byte("payload"), 0xFF)
 	sendRaw(writer, raw)
@@ -226,6 +238,7 @@ func TestReadPacketInvalidTerminator(t *testing.T) {
 }
 
 func TestReadPacketBadChecksum(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	// Build a packet with a deliberately wrong checksum.
 	var badChecksum uint32 = 0x12345678
@@ -251,6 +264,7 @@ func TestReadPacketBadChecksum(t *testing.T) {
 // --- partialPacketError ---
 
 func TestPartialPacketErrorMessage(t *testing.T) {
+	t.Parallel()
 	err := &partialPacketError{"test message"}
 	if err.Error() != "test message" {
 		t.Errorf("Error() = %q, want %q", err.Error(), "test message")
@@ -258,6 +272,7 @@ func TestPartialPacketErrorMessage(t *testing.T) {
 }
 
 func TestIsPartialPacketErrorNilTarget(t *testing.T) {
+	t.Parallel()
 	err := &partialPacketError{"msg"}
 	if !isPartialPacketError(err, nil) {
 		t.Error("isPartialPacketError with nil target should return true for partialPacketError")
@@ -265,6 +280,7 @@ func TestIsPartialPacketErrorNilTarget(t *testing.T) {
 }
 
 func TestIsPartialPacketErrorFalseForOther(t *testing.T) {
+	t.Parallel()
 	err := fmt.Errorf("some other error")
 	var ppe *partialPacketError
 	if isPartialPacketError(err, &ppe) {
@@ -287,6 +303,7 @@ func (c *errConn) SetWriteDeadline(time.Time) error { return nil }
 // --- recvExact non-EOF error ---
 
 func TestRecvExactNonEOFError(t *testing.T) {
+	t.Parallel()
 	// Use a fake conn that returns a non-EOF error to hit the unhandled error branch.
 	customErr := fmt.Errorf("custom network error")
 	conn := &errConn{err: customErr}
@@ -302,6 +319,7 @@ func TestRecvExactNonEOFError(t *testing.T) {
 // --- readPacket error paths ---
 
 func TestReadPacketConnectionClosedDuringHeader(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	// Close writer immediately — no header bytes sent.
 	go writer.Close()
@@ -312,6 +330,7 @@ func TestReadPacketConnectionClosedDuringHeader(t *testing.T) {
 }
 
 func TestReadPacketConnectionClosedDuringPayload(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	// Send a valid header claiming 10 bytes of payload, then close.
 	go func() {
@@ -331,6 +350,7 @@ func TestReadPacketConnectionClosedDuringPayload(t *testing.T) {
 }
 
 func TestReadPacketConnectionClosedDuringTerminator(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	// Send a valid header + payload (0 bytes), then close without terminator.
 	go func() {
@@ -360,6 +380,7 @@ func TestReadPacketConnectionClosedDuringTerminator(t *testing.T) {
 // --- CRC32 verification ---
 
 func TestCRC32KnownVector(t *testing.T) {
+	t.Parallel()
 	// CRC32 IEEE of empty byte slice = 0
 	if c := crc32.ChecksumIEEE([]byte{}); c != 0 {
 		t.Errorf("CRC32('') = 0x%08X, want 0", c)
@@ -371,6 +392,7 @@ func TestCRC32KnownVector(t *testing.T) {
 }
 
 func TestWritePacketProducesValidCRC(t *testing.T) {
+	t.Parallel()
 	reader, writer := socketPair(t)
 	pkt := packet{ChannelID: 5, MessageID: 10, IsReply: false, Payload: []byte("test")}
 	go func() { writePacket(writer, pkt) }() //nolint:errcheck

--- a/runner.go
+++ b/runner.go
@@ -234,9 +234,10 @@ func isHegelFrame(fn string) bool {
 // --- Client: manages a single connection's test lifecycle ---
 
 // client wraps a connection for running property tests.
+// Multiple goroutines may call runTest concurrently — each call creates its
+// own test channel and the underlying connection multiplexes via channels.
 type client struct {
 	conn *connection
-	mu   sync.Mutex // serializes runTest calls
 }
 
 func newClient(conn *connection) *client {
@@ -245,11 +246,6 @@ func newClient(conn *connection) *client {
 
 // runTest executes one property test against the server.
 func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) error {
-	// Serialize the entire test run — the control channel and connection
-	// are not thread-safe for concurrent access across goroutines.
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	testCh := c.conn.NewChannel("Test")
 
 	payload, err := encodeCBOR(map[string]any{
@@ -261,13 +257,8 @@ func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) erro
 		panic(fmt.Sprintf("hegel: runTest encode: %v", err)) //nocov
 	}
 
-	ctrl := c.conn.ControlChannel()
-	pending, err := ctrl.Request(payload)
-	if err != nil { //nocov
-		return fmt.Errorf("hegel: run_test send: %w", err) //nocov
-	}
-	if _, err := pending.Get(); err != nil { //nocov
-		return fmt.Errorf("hegel: run_test ack: %w", err) //nocov
+	if _, err := c.conn.SendControlRequest(payload); err != nil {
+		return fmt.Errorf("hegel: run_test send: %w", err)
 	}
 
 	// Event loop.
@@ -443,6 +434,7 @@ func (c *client) runTestCase(ch *channel, fn testBody, isFinal bool, noteFn func
 // --- Session: manages the hegel subprocess ---
 
 // hegelSession manages a shared hegel subprocess for the entire test suite.
+// Concurrent Run() calls multiplex over a single connection via channels.
 type hegelSession struct {
 	mu             sync.Mutex
 	conn           *connection
@@ -462,15 +454,12 @@ func newHegelSession() *hegelSession {
 	return &hegelSession{}
 }
 
-func (s *hegelSession) hasWorkingClient() bool {
-	return s.cli != nil && s.conn != nil && s.conn.Live()
-}
-
 // start starts the hegel subprocess and connects to it (idempotent).
 func (s *hegelSession) start() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.hasWorkingClient() {
+
+	if s.conn != nil {
 		return nil
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -74,6 +74,7 @@ func TestRunHegelTestAllInvalid(t *testing.T) {
 // --- RunHegelTest: assume(true) -> no effect ---
 
 func TestAssumeTrue(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		s.Assume(true)
@@ -90,6 +91,7 @@ func TestAssumeTrue(t *testing.T) {
 // --- note(): not printed when not final ---
 
 func TestNoteNotFinal(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	// note() should not panic or error when called outside final run
 	if _err := runHegel(func(s *TestCase) {
@@ -103,6 +105,7 @@ func TestNoteNotFinal(t *testing.T) {
 // --- target(): sends target command ---
 
 func TestTargetSendsCommand(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		x := Draw[int](s, Integers[int](0, 100))
@@ -178,6 +181,7 @@ func TestErrorResponse(t *testing.T) {
 // --- Draw outside context: calling Draw with nil-channel state panics ---
 
 func TestDrawWithNilChannelState(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		r := recover()
 		if r == nil {
@@ -191,6 +195,7 @@ func TestDrawWithNilChannelState(t *testing.T) {
 // --- Assume outside context raises ---
 
 func TestAssumeOutsideContext(t *testing.T) {
+	t.Parallel()
 	// Assume(false) on a nil *TestCase should panic.
 	defer func() {
 		r := recover()
@@ -205,6 +210,7 @@ func TestAssumeOutsideContext(t *testing.T) {
 // --- Note outside context is no-op (isFinal defaults false) ---
 
 func TestNoteOutsideContext(t *testing.T) {
+	t.Parallel()
 	// Note() on a zero-value *TestCase should not panic (isFinal=false).
 	s := &TestCase{}
 	s.Note("outside context -- safe")
@@ -213,6 +219,7 @@ func TestNoteOutsideContext(t *testing.T) {
 // --- Target outside context raises ---
 
 func TestTargetOutsideContext(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		r := recover()
 		if r == nil {
@@ -226,6 +233,7 @@ func TestTargetOutsideContext(t *testing.T) {
 // --- findHegel: venv path ---
 
 func TestFindHegelInVenv(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	binDir := tmp + "/bin"
 	os.MkdirAll(binDir, 0o755) //nolint:errcheck
@@ -259,6 +267,7 @@ func TestFindHegelVenvViaCwd(t *testing.T) {
 // --- findHegel: not in dir returns empty ---
 
 func TestFindHegelInDirMissing(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	result := findHegelInDir(tmp)
 	if result != "" {
@@ -269,6 +278,7 @@ func TestFindHegelInDirMissing(t *testing.T) {
 // --- hegelSession: start and cleanup ---
 
 func TestHegelSessionStartAndCleanup(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	s := newHegelSession()
 	if err := s.start(); err != nil {
@@ -286,6 +296,7 @@ func TestHegelSessionStartAndCleanup(t *testing.T) {
 // --- hegelSession: cleanup with nil fields is safe ---
 
 func TestHegelSessionCleanupEmpty(t *testing.T) {
+	t.Parallel()
 	s := newHegelSession()
 	s.cleanup() // Should not panic when nothing started.
 }
@@ -293,6 +304,7 @@ func TestHegelSessionCleanupEmpty(t *testing.T) {
 // --- hegelSession: timeout when hegel doesn't appear ---
 
 func TestHegelSessionStartTimeout(t *testing.T) {
+	t.Parallel()
 	// Use `false` (exits immediately) so the socket never appears.
 	falseBin, err := exec.LookPath("false")
 	if err != nil {
@@ -311,6 +323,7 @@ func TestHegelSessionStartTimeout(t *testing.T) {
 // --- hegelSession: concurrent starts (double-checked locking) ---
 
 func TestHegelSessionConcurrentStart(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	s := newHegelSession()
 	defer s.cleanup()
@@ -388,6 +401,7 @@ func TestRunHegelTestESuccess(t *testing.T) {
 // --- WithTestCases option ---
 
 func TestWithTestCasesOption(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	count := 0
 	if _err := runHegel(func(s *TestCase) {
@@ -431,6 +445,7 @@ func TestStopTestOnNewCollection(t *testing.T) {
 // We capture whether isFinal was true via the state in the closure.
 
 func TestNoteOnFinalRun(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	noted := false
 	noteFunc := func(s *TestCase) {
@@ -453,6 +468,7 @@ func TestNoteOnFinalRun(t *testing.T) {
 // --- runTest: connection error in test function is re-raised ---
 
 func TestConnectionErrorInTestFunction(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	err := runHegel(func(_ *TestCase) {
 		panic(&connectionError{msg: "test connection lost"})
@@ -468,6 +484,7 @@ func TestConnectionErrorInTestFunction(t *testing.T) {
 // --- assumeRejected.Error() ---
 
 func TestAssumeRejectedError(t *testing.T) {
+	t.Parallel()
 	e := assumeRejected{}
 	if e.Error() != "assume rejected" {
 		t.Errorf("assumeRejected.Error() = %q", e.Error())
@@ -477,6 +494,7 @@ func TestAssumeRejectedError(t *testing.T) {
 // --- dataExhausted.Error() ---
 
 func TestDataExhaustedError(t *testing.T) {
+	t.Parallel()
 	e := &dataExhausted{msg: "exhausted"}
 	if e.Error() != "exhausted" {
 		t.Errorf("dataExhausted.Error() = %q", e.Error())
@@ -486,6 +504,7 @@ func TestDataExhaustedError(t *testing.T) {
 // --- connectionError.Error() ---
 
 func TestConnectionErrorError(t *testing.T) {
+	t.Parallel()
 	e := &connectionError{msg: "conn lost"}
 	if e.Error() != "conn lost" {
 		t.Errorf("connectionError.Error() = %q", e.Error())
@@ -495,6 +514,7 @@ func TestConnectionErrorError(t *testing.T) {
 // --- aborted flag: set directly on state ---
 
 func TestAbortedFlagDirect(t *testing.T) {
+	t.Parallel()
 	state := &TestCase{}
 	state.aborted = true
 	if !state.aborted {
@@ -505,6 +525,7 @@ func TestAbortedFlagDirect(t *testing.T) {
 // --- generateFromSchema: connection error (Request fails) ---
 
 func TestGenerateFromSchemaConnectionError(t *testing.T) {
+	t.Parallel()
 	s, c := socketPair(t)
 	conn := newConnection(s, "C")
 	c.Close()
@@ -535,6 +556,7 @@ func TestGenerateFromSchemaConnectionError(t *testing.T) {
 // --- Target: error path when Request fails ---
 
 func TestTargetConnectionError(t *testing.T) {
+	t.Parallel()
 	s, _ := socketPair(t)
 	conn := newConnection(s, "C")
 	conn.state = stateClient
@@ -572,6 +594,7 @@ func TestIsHegelFrame(t *testing.T) {
 // --- extractPanicOrigin: non-error value ---
 
 func TestExtractPanicOriginNonError(t *testing.T) {
+	t.Parallel()
 	origin := extractPanicOrigin("just a string")
 	// Should include the type (string) and file info.
 	if origin == "" {
@@ -582,6 +605,7 @@ func TestExtractPanicOriginNonError(t *testing.T) {
 // --- extractPanicOrigin: error value ---
 
 func TestExtractPanicOriginError(t *testing.T) {
+	t.Parallel()
 	origin := extractPanicOrigin(errors.New("test"))
 	if origin == "" {
 		t.Error("expected non-empty origin from extractPanicOrigin with error")
@@ -591,6 +615,7 @@ func TestExtractPanicOriginError(t *testing.T) {
 // --- Note: isFinal=true prints to stderr ---
 
 func TestNoteIsFinalTrue(t *testing.T) {
+	t.Parallel()
 	state := &TestCase{isFinal: true, noteFn: stderrNoteFn}
 	// Should not panic.
 	state.Note("test note on final")
@@ -599,6 +624,7 @@ func TestNoteIsFinalTrue(t *testing.T) {
 // --- findHegel: fallback when not in venv or PATH ---
 
 func TestFindHegelFallback(t *testing.T) {
+	t.Parallel()
 	// findHegel should return "hegel" as fallback when nothing found.
 	// We can't easily test this without mocking, but we can test findHegelInDir.
 	result := findHegelInDir("/nonexistent/path")
@@ -610,6 +636,7 @@ func TestFindHegelFallback(t *testing.T) {
 // --- hegelSession: start with spawn error ---
 
 func TestHegelSessionSpawnError(t *testing.T) {
+	t.Parallel()
 	s := newHegelSession()
 	s.hegelCmd = "/nonexistent/binary/that/does/not/exist"
 	err := s.start()
@@ -622,6 +649,7 @@ func TestHegelSessionSpawnError(t *testing.T) {
 // --- hegelSession: cleanup with erroring close ---
 
 func TestHegelSessionCleanupWithErrors(t *testing.T) {
+	t.Parallel()
 	s := newHegelSession()
 	// Set conn to a closed connection so Close() might error.
 	sc, cc := socketPair(t)
@@ -694,6 +722,7 @@ func TestRunHegelTestECallsRunTest(t *testing.T) {
 // --- hegelSession.runTest: covered via integration ---
 
 func TestHegelSessionRunTest(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	s := newHegelSession()
 	defer s.cleanup()
@@ -711,6 +740,7 @@ func TestHegelSessionRunTest(t *testing.T) {
 // --- findHegel: uses cwd venv or PATH ---
 
 func TestFindHegel(t *testing.T) {
+	t.Parallel()
 	// Just verify it returns a non-empty string.
 	result := findHegel()
 	if result == "" {
@@ -721,6 +751,7 @@ func TestFindHegel(t *testing.T) {
 // --- hegelSession.start: double-checked locking (inner check) ---
 
 func TestHegelSessionStartInnerCheck(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	s := newHegelSession()
 	defer s.cleanup()
@@ -738,6 +769,7 @@ func TestHegelSessionStartInnerCheck(t *testing.T) {
 // --- hegelSession.start: hegelCmd field used ---
 
 func TestHegelSessionStartHegelCmd(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	path, _ := exec.LookPath("hegel")
 	s := newHegelSession()
@@ -751,6 +783,7 @@ func TestHegelSessionStartHegelCmd(t *testing.T) {
 // --- hegelSession.cleanup: conn/process/tempDir paths via integration ---
 
 func TestHegelSessionCleanupAllPaths(t *testing.T) {
+	t.Parallel()
 	hegelBinPath(t)
 	s := newHegelSession()
 	if err := s.start(); err != nil {
@@ -772,12 +805,14 @@ func TestHegelSessionCleanupAllPaths(t *testing.T) {
 // --- runTest: multi-interesting, single error (len(errs)==1 branch) ---
 
 func TestRunTestMultiInterestingSingleError(t *testing.T) {
+	t.Parallel()
 	t.Skip("len(errs)==1 in multi-interesting is unreachable when nInteresting>1")
 }
 
 // --- extractPanicOrigin: all frames are hegel frames ---
 
 func TestExtractPanicOriginAllHegelFrames(t *testing.T) {
+	t.Parallel()
 	origin := extractPanicOrigin("test panic")
 	if origin == "" {
 		t.Error("expected non-empty origin")
@@ -825,6 +860,7 @@ func TestHegelSessionStartMkdirTempError(t *testing.T) {
 // --- hegelSession.start: handshake error ---
 
 func TestHegelSessionStartHandshakeError(t *testing.T) {
+	t.Parallel()
 	// Write a fake hegel binary that creates the socket, accepts one connection,
 	// sends bad handshake data, then exits. This causes SendHandshakeVersion to fail.
 	tmp := t.TempDir()
@@ -879,6 +915,7 @@ func TestFindHegelLookPathAndFallback(t *testing.T) {
 // =============================================================================
 
 func TestFatalSentinelError(t *testing.T) {
+	t.Parallel()
 	f := fatalSentinel{msg: "test fatal"}
 	if f.Error() != "test fatal" {
 		t.Errorf("got %q", f.Error())
@@ -890,6 +927,7 @@ func TestFatalSentinelError(t *testing.T) {
 // =============================================================================
 
 func TestToInt64Int64(t *testing.T) {
+	t.Parallel()
 	v, ok := toInt64(int64(-7))
 	if !ok || v != -7 {
 		t.Errorf("got %d, %v", v, ok)
@@ -897,6 +935,7 @@ func TestToInt64Int64(t *testing.T) {
 }
 
 func TestToInt64Uint64(t *testing.T) {
+	t.Parallel()
 	v, ok := toInt64(uint64(42))
 	if !ok || v != 42 {
 		t.Errorf("got %d, %v", v, ok)
@@ -904,6 +943,7 @@ func TestToInt64Uint64(t *testing.T) {
 }
 
 func TestToInt64Invalid(t *testing.T) {
+	t.Parallel()
 	_, ok := toInt64("not a number")
 	if ok {
 		t.Error("expected false for invalid type")
@@ -1040,10 +1080,26 @@ func TestHegelSessionStartMkdirFail(t *testing.T) {
 // =============================================================================
 
 func TestFindHegelReturnsNonEmpty(t *testing.T) {
+	t.Parallel()
 	result := findHegel()
 	if result == "" {
 		t.Error("findHegel should return non-empty string")
 	}
+}
+
+// --- runTest: SendControlRequest error (closed connection) ---
+
+func TestRunTestSendControlRequestError(t *testing.T) {
+	t.Parallel()
+	conn, remote := clientConnPair(t)
+	remote.Close()
+
+	cl := newClient(conn)
+	err := cl.runTest(func(_ *TestCase) {}, runOptions{testCases: 1}, stderrNoteFn)
+	if err == nil {
+		t.Fatal("expected error from runTest on closed conn")
+	}
+	mustContainStr(t, err.Error(), "run_test send")
 }
 
 // --- helpers ---

--- a/state_test.go
+++ b/state_test.go
@@ -18,6 +18,7 @@ func makeFakeT(t *testing.T) *T {
 // =============================================================================
 
 func TestTFatalPanicsWithSentinel(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	defer func() {
 		r := recover()
@@ -36,6 +37,7 @@ func TestTFatalPanicsWithSentinel(t *testing.T) {
 }
 
 func TestTFatalfPanicsWithSentinel(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	defer func() {
 		r := recover()
@@ -54,6 +56,7 @@ func TestTFatalfPanicsWithSentinel(t *testing.T) {
 }
 
 func TestTFailNowPanicsWithSentinel(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	defer func() {
 		r := recover()
@@ -76,6 +79,7 @@ func TestTFailNowPanicsWithSentinel(t *testing.T) {
 // =============================================================================
 
 func TestTSkipPanicsWithAssumeRejected(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	defer func() {
 		r := recover()
@@ -90,6 +94,7 @@ func TestTSkipPanicsWithAssumeRejected(t *testing.T) {
 }
 
 func TestTSkipfPanicsWithAssumeRejected(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	defer func() {
 		r := recover()
@@ -104,6 +109,7 @@ func TestTSkipfPanicsWithAssumeRejected(t *testing.T) {
 }
 
 func TestTSkipNowPanicsWithAssumeRejected(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	defer func() {
 		r := recover()
@@ -122,6 +128,7 @@ func TestTSkipNowPanicsWithAssumeRejected(t *testing.T) {
 // =============================================================================
 
 func TestTErrorSetsFailedAndCallsNote(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	// Make state final so Note actually fires (verify no panic).
 	ht.TestCase.isFinal = true
@@ -137,6 +144,7 @@ func TestTErrorSetsFailedAndCallsNote(t *testing.T) {
 }
 
 func TestTErrorfSetsFailedAndCallsNote(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	ht.TestCase.isFinal = true
 	noted := false
@@ -155,6 +163,7 @@ func TestTErrorfSetsFailedAndCallsNote(t *testing.T) {
 // =============================================================================
 
 func TestTFailSetsFailed(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	if ht.Failed() {
 		t.Error("expected Failed() to be false initially")
@@ -170,6 +179,7 @@ func TestTFailSetsFailed(t *testing.T) {
 // =============================================================================
 
 func TestTLogCallsNote(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	ht.TestCase.isFinal = true
 	var gotMsg string
@@ -181,6 +191,7 @@ func TestTLogCallsNote(t *testing.T) {
 }
 
 func TestTLogfCallsNote(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	ht.TestCase.isFinal = true
 	var gotMsg string
@@ -196,6 +207,7 @@ func TestTLogfCallsNote(t *testing.T) {
 // =============================================================================
 
 func TestTRunPanics(t *testing.T) {
+	t.Parallel()
 	ht := makeFakeT(t)
 	defer func() {
 		r := recover()


### PR DESCRIPTION
Refactor the connection / channel logic to support concurrent test runs. The previous dispatch logic for reading from the API socket was pretty hard to follow and led to timeouts when running the tests.

The new implementation just uses a reader goroutine which fans out to registered channels.

Running the whole test suite went from ~40s to ~16s on my machine.