### PR TITLE
Reword SDK to library/client

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Hegel SDK for go
+# Hegel for Go
 
 ## Build Commands
 
@@ -17,20 +17,20 @@ Tests must use `PATH="$(pwd)/.venv/bin:$PATH"` (absolute path) so the `hegel` bi
 
 ## What This Is
 
-A go implementation of the Hegel property-based testing SDK. Hegel is a
+A Go implementation of the Hegel property-based testing library. Hegel is a
 universal property-based testing framework powered by Hypothesis on the backend.
-SDKs communicate with the `hegel` binary (a Python server) via Unix sockets using
+Client libraries communicate with the `hegel` binary (a Python server) via Unix sockets using
 a custom binary protocol.
 
-## SDK Architecture
+## Architecture
 
-The SDK is structured in layers, each building on the previous:
+The library is structured in layers, each building on the previous:
 
 1. **Protocol Layer** — Binary wire protocol with 20-byte header, CBOR payload, CRC32
 2. **Connection & Channels** — Unix socket multiplexing with demand-driven reader
 3. **Test Runner** — Spawns `hegel` subprocess, manages test lifecycle
 4. **Generators** — Type-safe generator abstraction, span system, collection protocol
-5. **Conformance** — Test binaries that validate SDK correctness against the framework
+5. **Conformance** — Test binaries that validate library correctness against the framework
 
 ### Key Pattern: Demand-Driven Reader
 
@@ -58,7 +58,7 @@ or sessions manually — `run_hegel_test()` is a plain free function.
 - **Use the real `hegel` binary** for integration tests. Never write a mock server.
   The real binary runs as a subprocess, so there is zero threading contention.
   In-process mocks with threads cause deadlocks — they have wasted hundreds of
-  agent turns in previous SDK generations.
+  agent turns in previous library generations.
 - **Socket pairs** (`socketpair()`) for unit testing Connection/Channel in isolation.
 
 ### HEGEL_PROTOCOL_TEST_MODE — Error Injection
@@ -77,7 +77,7 @@ trigger server-side error injection:
 
 ## Critical: StopTest Handling
 
-When the server sends StopTest, the SDK MUST:
+When the server sends StopTest, the client MUST:
 1. Raise a language-specific exception (DataExhausted/StopTest) to unwind the test body
 2. NOT send `mark_complete` after receiving StopTest
 3. Track a per-test-case `test_aborted` flag to suppress further commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,6 @@ Rework the API to integrate better with testing.T
 
 ## 0.0.1 - 2026-02-27
 
-Complete rewrite of the Go SDK with full protocol implementation, generator
+Complete rewrite with full protocol implementation, generator
 combinators, type-directed derivation, conformance tests, and getting-started
 documentation. Adds release automation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@
 go get github.com/hegeldev/hegel-go@latest
 ```
 
-The SDK requires the `hegel` CLI on your PATH:
+The library requires the `hegel` CLI on your PATH:
 
 ```bash
 pip install "hegel @ git+https://github.com/hegeldev/hegel-core"

--- a/hegel.go
+++ b/hegel.go
@@ -1,7 +1,7 @@
-// Package hegel provides a Go SDK for the Hegel property-based testing framework.
+// Package hegel provides a Go library for the Hegel property-based testing framework.
 //
 // Hegel is a universal property-based testing framework backed by Hypothesis.
-// This SDK communicates with the hegel binary.
+// This library communicates with the hegel binary.
 //
 // # Quick Start
 //

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# Hegel SDK for go
+# Hegel for Go
 # This justfile provides the standard build recipes.
 
 export PATH := "/usr/local/go/bin:" + env("HOME") + "/go/bin:" + env("PATH")

--- a/runner.go
+++ b/runner.go
@@ -521,7 +521,7 @@ func (s *hegelSession) start() error {
 		return fmt.Errorf("hegel: timeout waiting for hegel to start")
 	}
 
-	conn := newConnection(sock, "SDK")
+	conn := newConnection(sock, "Client")
 	version, err := conn.SendHandshakeVersion()
 	if err != nil {
 		sock.Close()       //nolint:errcheck

--- a/runner_test.go
+++ b/runner_test.go
@@ -120,7 +120,7 @@ func TestTargetSendsCommand(t *testing.T) {
 func TestStopTestOnGenerate(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_generate")
-	// Should complete without error: SDK handles StopTest cleanly.
+	// Should complete without error: client handles StopTest cleanly.
 	if _err := runHegel(func(s *TestCase) {
 		Draw[bool](s, Booleans())
 	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -1,6 +1,6 @@
-"""Conformance tests for the Hegel Go SDK.
+"""Conformance tests for Hegel for Go.
 
-These tests validate that the Go SDK correctly implements the Hegel protocol
+These tests validate that Hegel for Go correctly implements the Hegel protocol
 by running compiled Go binaries against the real hegel server and checking
 that the generated values satisfy the expected constraints.
 """
@@ -58,5 +58,5 @@ def conformance_tests() -> list:
 
 
 def test_conformance(conformance_tests, subtests):
-    """Run all conformance tests for the Go SDK."""
+    """Run all conformance tests for Hegel for Go."""
     run_conformance_tests(conformance_tests, subtests)


### PR DESCRIPTION
I have an allergic reaction to the term "SDK", which is usually used by corporations to refer to low-effort language wrappers around a core library. This is totally not what we're doing and we shouldn't give that association!