### PR TITLE
all: replace functional options with builder pattern

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Migrate generators to builder style options instead of functional options.

--- a/cmd/conformance/test_floats/main.go
+++ b/cmd/conformance/test_floats/main.go
@@ -19,44 +19,40 @@ func main() {
 		}
 	}
 
-	var minPtr, maxPtr *float64
-	var allowNaN, allowInfinity *bool
+	g := hegel.Floats[float64]()
 
 	if v, ok := params["min_value"]; ok && v != nil {
 		if x, ok := v.(float64); ok {
-			minPtr = &x
+			g = g.Min(x)
 		}
 	}
 	if v, ok := params["max_value"]; ok && v != nil {
 		if x, ok := v.(float64); ok {
-			maxPtr = &x
+			g = g.Max(x)
 		}
 	}
 	if v, ok := params["allow_nan"]; ok && v != nil {
 		if x, ok := v.(bool); ok {
-			allowNaN = &x
+			g = g.AllowNaN(x)
 		}
 	}
 	if v, ok := params["allow_infinity"]; ok && v != nil {
 		if x, ok := v.(bool); ok {
-			allowInfinity = &x
+			g = g.AllowInfinity(x)
 		}
 	}
-
-	excludeMin := false
-	excludeMax := false
 	if v, ok := params["exclude_min"]; ok {
-		if x, ok := v.(bool); ok {
-			excludeMin = x
+		if x, ok := v.(bool); ok && x {
+			g = g.ExcludeMin()
 		}
 	}
 	if v, ok := params["exclude_max"]; ok {
-		if x, ok := v.(bool); ok {
-			excludeMax = x
+		if x, ok := v.(bool); ok && x {
+			g = g.ExcludeMax()
 		}
 	}
 
-	gen := hegel.Floats(minPtr, maxPtr, allowNaN, allowInfinity, excludeMin, excludeMax)
+	gen := g
 	n := conformance.GetTestCases()
 	hegel.MustRun(func(s *hegel.TestCase) {
 		val := hegel.Draw(s, gen)

--- a/cmd/conformance/test_hashmaps/main.go
+++ b/cmd/conformance/test_hashmaps/main.go
@@ -69,12 +69,11 @@ func main() {
 	}
 
 	valsGen := hegel.Integers[int](minVal, maxVal)
-	opts := []hegel.DictOption{hegel.DictMinSize(minSize), hegel.DictMaxSize(maxSize)}
 	n := conformance.GetTestCases()
 
 	if keyType == "string" {
 		keysGen := hegel.Text(0, -1)
-		gen := hegel.Dicts(keysGen, valsGen, opts...)
+		gen := hegel.Dicts(keysGen, valsGen).MinSize(minSize).MaxSize(maxSize)
 
 		hegel.MustRun(func(s *hegel.TestCase) {
 			m := hegel.Draw(s, gen)
@@ -120,7 +119,7 @@ func main() {
 		}, hegel.WithTestCases(n))
 	} else {
 		keysGen := hegel.Integers[int](minKey, maxKey)
-		gen := hegel.Dicts(keysGen, valsGen, opts...)
+		gen := hegel.Dicts(keysGen, valsGen).MinSize(minSize).MaxSize(maxSize)
 
 		hegel.MustRun(func(s *hegel.TestCase) {
 			m := hegel.Draw(s, gen)

--- a/cmd/conformance/test_lists/main.go
+++ b/cmd/conformance/test_lists/main.go
@@ -61,9 +61,17 @@ func main() {
 	var gen hegel.Generator[[]int]
 	if strings.Contains(testMode, "collection") {
 		filtered := hegel.Filter(elemGen, func(v int) bool { return true })
-		gen = hegel.Lists(filtered, hegel.ListMinSize(minSize), hegel.ListMaxSize(maxSize))
+		builder := hegel.Lists(filtered).MinSize(minSize)
+		if maxSize >= 0 {
+			builder = builder.MaxSize(maxSize)
+		}
+		gen = builder
 	} else {
-		gen = hegel.Lists(elemGen, hegel.ListMinSize(minSize), hegel.ListMaxSize(maxSize))
+		builder := hegel.Lists(elemGen).MinSize(minSize)
+		if maxSize >= 0 {
+			builder = builder.MaxSize(maxSize)
+		}
+		gen = builder
 	}
 
 	n := conformance.GetTestCases()

--- a/collections.go
+++ b/collections.go
@@ -4,44 +4,54 @@ import "fmt"
 
 // --- Lists generator ---
 
-// ListOption configures optional behavior for the [Lists] generator.
-type ListOption func(*listConfig)
-
-type listConfig struct {
-	minSize int
-	maxSize int
-}
-
-// ListMinSize sets the minimum number of elements (inclusive). Defaults to 0.
-func ListMinSize(n int) ListOption {
-	return func(cfg *listConfig) { cfg.minSize = n }
-}
-
-// ListMaxSize sets the maximum number of elements (inclusive). Negative means unbounded.
-func ListMaxSize(n int) ListOption {
-	return func(cfg *listConfig) { cfg.maxSize = n }
+// ListGenerator configures and generates slices of values from an element generator.
+// Use [Lists] to create one, then chain builder methods to configure bounds.
+// Invalid configurations panic on the first [Draw] call.
+type ListGenerator[T any] struct {
+	elements Generator[T]
+	minSize  int
+	maxSize  int
+	hasMax   bool
 }
 
 // Lists returns a Generator that produces slices of values from the elements generator.
-func Lists[T any](elements Generator[T], opts ...ListOption) Generator[[]T] {
-	cfg := listConfig{maxSize: -1}
-	for _, o := range opts {
-		o(&cfg)
+func Lists[T any](elements Generator[T]) ListGenerator[T] {
+	return ListGenerator[T]{elements: elements}
+}
+
+// MinSize sets the minimum number of elements (inclusive). Default: 0.
+func (g ListGenerator[T]) MinSize(n int) ListGenerator[T] {
+	g.minSize = n
+	return g
+}
+
+// MaxSize sets the maximum number of elements (inclusive).
+func (g ListGenerator[T]) MaxSize(n int) ListGenerator[T] {
+	g.maxSize = n
+	g.hasMax = true
+	return g
+}
+
+func (g ListGenerator[T]) buildGenerator() Generator[[]T] {
+	if g.minSize < 0 {
+		panic(fmt.Sprintf("hegel: min_size=%d must be non-negative", g.minSize))
+	}
+	if g.hasMax && g.maxSize < 0 {
+		panic(fmt.Sprintf("hegel: max_size=%d must be non-negative", g.maxSize))
+	}
+	if g.hasMax && g.minSize > g.maxSize {
+		panic(fmt.Sprintf("hegel: Cannot have max_size=%d < min_size=%d", g.maxSize, g.minSize))
 	}
 
-	minSize := max(cfg.minSize, 0)
-	if cfg.maxSize >= 0 && minSize > cfg.maxSize {
-		panic(fmt.Sprintf("hegel: Cannot have max_size=%d < min_size=%d", cfg.maxSize, minSize))
-	}
-
+	elements := unwrapGenerator(g.elements)
 	if bg, ok := elements.(*basicGenerator[T]); ok {
 		rawSchema := map[string]any{
 			"type":     "list",
 			"elements": bg.schema,
-			"min_size": int64(minSize),
+			"min_size": int64(g.minSize),
 		}
-		if cfg.maxSize >= 0 {
-			rawSchema["max_size"] = int64(cfg.maxSize)
+		if g.hasMax {
+			rawSchema["max_size"] = int64(g.maxSize)
 		}
 		if bg.transform != nil {
 			t := bg.transform
@@ -76,11 +86,20 @@ func Lists[T any](elements Generator[T], opts ...ListOption) Generator[[]T] {
 		}
 	}
 
+	maxSize := -1
+	if g.hasMax {
+		maxSize = g.maxSize
+	}
 	return &compositeListGenerator[T]{
 		elements: elements,
-		minSize:  minSize,
-		maxSize:  cfg.maxSize,
+		minSize:  g.minSize,
+		maxSize:  maxSize,
 	}
+}
+
+// draw produces a list by delegating to the effective generator.
+func (g ListGenerator[T]) draw(s *TestCase) []T {
+	return g.buildGenerator().draw(s)
 }
 
 // compositeListGenerator generates a list using the collection protocol.
@@ -108,37 +127,48 @@ func (g *compositeListGenerator[T]) draw(s *TestCase) []T {
 
 // --- Dicts generator ---
 
-// DictOption configures optional behavior for the [Dicts] generator.
-type DictOption func(*dictConfig)
-
-type dictConfig struct {
+// DictGenerator configures and generates map[K]V values.
+// Use [Dicts] to create one, then chain builder methods to configure bounds.
+// Invalid configurations panic on the first [Draw] call.
+type DictGenerator[K comparable, V any] struct {
+	keys    Generator[K]
+	values  Generator[V]
 	minSize int
 	maxSize int
 	hasMax  bool
 }
 
-// DictMinSize sets the minimum number of key-value pairs. Defaults to 0.
-func DictMinSize(n int) DictOption {
-	return func(cfg *dictConfig) { cfg.minSize = n }
-}
-
-// DictMaxSize sets the maximum number of key-value pairs.
-func DictMaxSize(n int) DictOption {
-	return func(cfg *dictConfig) { cfg.maxSize = n; cfg.hasMax = true }
-}
-
 // Dicts returns a Generator that produces map[K]V values.
-func Dicts[K comparable, V any](keys Generator[K], values Generator[V], opts ...DictOption) Generator[map[K]V] {
-	var cfg dictConfig
-	for _, o := range opts {
-		o(&cfg)
+func Dicts[K comparable, V any](keys Generator[K], values Generator[V]) DictGenerator[K, V] {
+	return DictGenerator[K, V]{keys: keys, values: values}
+}
+
+// MinSize sets the minimum number of key-value pairs. Default: 0.
+func (g DictGenerator[K, V]) MinSize(n int) DictGenerator[K, V] {
+	g.minSize = n
+	return g
+}
+
+// MaxSize sets the maximum number of key-value pairs.
+func (g DictGenerator[K, V]) MaxSize(n int) DictGenerator[K, V] {
+	g.maxSize = n
+	g.hasMax = true
+	return g
+}
+
+func (g DictGenerator[K, V]) buildGenerator() Generator[map[K]V] {
+	if g.minSize < 0 {
+		panic(fmt.Sprintf("hegel: min_size=%d must be non-negative", g.minSize))
 	}
-	if cfg.minSize < 0 {
-		panic(fmt.Sprintf("hegel: min_size=%d must be non-negative", cfg.minSize))
+	if g.hasMax && g.maxSize < 0 {
+		panic(fmt.Sprintf("hegel: max_size=%d must be non-negative", g.maxSize))
 	}
-	if cfg.hasMax && cfg.minSize > cfg.maxSize {
-		panic(fmt.Sprintf("hegel: Cannot have max_size=%d < min_size=%d", cfg.maxSize, cfg.minSize))
+	if g.hasMax && g.minSize > g.maxSize {
+		panic(fmt.Sprintf("hegel: Cannot have max_size=%d < min_size=%d", g.maxSize, g.minSize))
 	}
+
+	keys := unwrapGenerator(g.keys)
+	values := unwrapGenerator(g.values)
 	keyBasic, keyIsBasic := keys.(*basicGenerator[K])
 	valBasic, valIsBasic := values.(*basicGenerator[V])
 	if keyIsBasic && valIsBasic {
@@ -146,10 +176,10 @@ func Dicts[K comparable, V any](keys Generator[K], values Generator[V], opts ...
 			"type":     "dict",
 			"keys":     keyBasic.schema,
 			"values":   valBasic.schema,
-			"min_size": int64(cfg.minSize),
+			"min_size": int64(g.minSize),
 		}
-		if cfg.hasMax {
-			rawSchema["max_size"] = int64(cfg.maxSize)
+		if g.hasMax {
+			rawSchema["max_size"] = int64(g.maxSize)
 		}
 		keyTransform := keyBasic.transform
 		valTransform := valBasic.transform
@@ -163,10 +193,15 @@ func Dicts[K comparable, V any](keys Generator[K], values Generator[V], opts ...
 	return &compositeDictGenerator[K, V]{
 		keys:    keys,
 		values:  values,
-		minSize: cfg.minSize,
-		maxSize: cfg.maxSize,
-		hasMax:  cfg.hasMax,
+		minSize: g.minSize,
+		maxSize: g.maxSize,
+		hasMax:  g.hasMax,
 	}
+}
+
+// draw produces a map by delegating to the effective generator.
+func (g DictGenerator[K, V]) draw(s *TestCase) map[K]V {
+	return g.buildGenerator().draw(s)
 }
 
 // pairsToMap converts a CBOR-decoded pair list [[k,v], ...] to a map[K]V.

--- a/combinators.go
+++ b/combinators.go
@@ -40,9 +40,14 @@ func OneOf[T any](generators ...Generator[T]) Generator[T] {
 		panic("hegel: OneOf requires at least one generator")
 	}
 
+	resolved := make([]Generator[T], len(generators))
+	for i, g := range generators {
+		resolved[i] = unwrapGenerator(g)
+	}
+
 	// Check if all generators are basic.
 	allBasic := true
-	for _, g := range generators {
+	for _, g := range resolved {
 		if _, ok := g.(*basicGenerator[T]); !ok {
 			allBasic = false
 			break
@@ -50,13 +55,13 @@ func OneOf[T any](generators ...Generator[T]) Generator[T] {
 	}
 
 	if !allBasic {
-		gens := make([]Generator[T], len(generators))
-		copy(gens, generators)
+		gens := make([]Generator[T], len(resolved))
+		copy(gens, resolved)
 		return &compositeOneOfGenerator[T]{generators: gens}
 	}
 
-	basics := make([]*basicGenerator[T], len(generators))
-	for i, g := range generators {
+	basics := make([]*basicGenerator[T], len(resolved))
+	for i, g := range resolved {
 		basics[i] = g.(*basicGenerator[T])
 	}
 
@@ -147,47 +152,51 @@ func (g *optionalGenerator[T]) draw(s *TestCase) *T {
 
 // --- IPAddresses generator ---
 
-// IPAddressOption configures optional behavior for the [IPAddresses] generator.
-type IPAddressOption func(*ipAddressConfig)
-
-type ipAddressConfig struct {
+// IPAddressGenerator configures and generates IP addresses.
+// Use [IPAddresses] to create one, then chain builder methods to configure it.
+type IPAddressGenerator struct {
 	version string
 }
 
+// IPAddresses returns a Generator that produces IP addresses.
+func IPAddresses() IPAddressGenerator {
+	return IPAddressGenerator{}
+}
+
 // IPv4 restricts the generator to IPv4 addresses only.
-func IPv4() IPAddressOption {
-	return func(cfg *ipAddressConfig) { cfg.version = "ipv4" }
+func (g IPAddressGenerator) IPv4() IPAddressGenerator {
+	g.version = "ipv4"
+	return g
 }
 
 // IPv6 restricts the generator to IPv6 addresses only.
-func IPv6() IPAddressOption {
-	return func(cfg *ipAddressConfig) { cfg.version = "ipv6" }
+func (g IPAddressGenerator) IPv6() IPAddressGenerator {
+	g.version = "ipv6"
+	return g
 }
 
-// IPAddresses returns a Generator that produces IP address strings.
-func IPAddresses(opts ...IPAddressOption) Generator[netip.Addr] {
-	var cfg ipAddressConfig
-	for _, o := range opts {
-		o(&cfg)
-	}
+func (g IPAddressGenerator) buildGenerator() Generator[netip.Addr] {
 	addrTransform := func(a any) netip.Addr {
 		return netip.MustParseAddr(a.(string))
 	}
-	if cfg.version != "" {
+	if g.version != "" {
 		return &basicGenerator[netip.Addr]{
-			schema:    map[string]any{"type": cfg.version},
+			schema:    map[string]any{"type": g.version},
 			transform: addrTransform,
 		}
-	} else {
-		return OneOf(
-			&basicGenerator[netip.Addr]{
-				schema:    map[string]any{"type": "ipv4"},
-				transform: addrTransform,
-			},
-			&basicGenerator[netip.Addr]{
-				schema:    map[string]any{"type": "ipv6"},
-				transform: addrTransform,
-			},
-		)
 	}
+	return OneOf(
+		&basicGenerator[netip.Addr]{
+			schema:    map[string]any{"type": "ipv4"},
+			transform: addrTransform,
+		},
+		&basicGenerator[netip.Addr]{
+			schema:    map[string]any{"type": "ipv6"},
+			transform: addrTransform,
+		},
+	)
+}
+
+func (g IPAddressGenerator) draw(s *TestCase) netip.Addr {
+	return g.buildGenerator().draw(s)
 }

--- a/dicts_test.go
+++ b/dicts_test.go
@@ -13,17 +13,14 @@ import (
 // Dicts: schema unit tests (no server)
 // =============================================================================
 
-// TestDictsBasicSchema verifies that Dicts with two basic generators produces
-// a basicGenerator with a dict schema containing the expected fields.
+// TestDictsBasicSchema verifies that Dicts with two basic generators builds
+// a dict schema containing the expected fields.
 func TestDictsBasicSchema(t *testing.T) {
 	t.Parallel()
 	keys := Text(0, 5)
 	vals := Integers[int64](0, 100)
-	gen := Dicts(keys, vals, DictMaxSize(3))
-	bg, ok := gen.(*basicGenerator[map[string]int64])
-	if !ok {
-		t.Fatalf("Dicts(basic, basic) should return *basicGenerator[map[string]int64], got %T", gen)
-	}
+	gen := Dicts(keys, vals).MaxSize(3)
+	bg := gen.buildGenerator().(*basicGenerator[map[string]int64])
 	if bg.schema["type"] != "dict" {
 		t.Errorf("schema type: expected 'dict', got %v", bg.schema["type"])
 	}
@@ -54,11 +51,8 @@ func TestDictsBasicSchema(t *testing.T) {
 // TestDictsBasicSchemaNoMaxSize verifies that when HasMaxSize=false, max_size is omitted.
 func TestDictsBasicSchemaNoMaxSize(t *testing.T) {
 	t.Parallel()
-	gen := Dicts(Text(0, 5), Integers[int64](0, 100), DictMinSize(1))
-	bg, ok := gen.(*basicGenerator[map[string]int64])
-	if !ok {
-		t.Fatalf("expected *basicGenerator[map[string]int64], got %T", gen)
-	}
+	gen := Dicts(Text(0, 5), Integers[int64](0, 100)).MinSize(1)
+	bg := gen.buildGenerator().(*basicGenerator[map[string]int64])
 	if _, has := bg.schema["max_size"]; has {
 		t.Error("max_size should not be present when HasMaxSize=false")
 	}
@@ -67,28 +61,25 @@ func TestDictsBasicSchemaNoMaxSize(t *testing.T) {
 // TestDictsBasicSchemaMinSize verifies that MinSize is propagated to the schema.
 func TestDictsBasicSchemaMinSize(t *testing.T) {
 	t.Parallel()
-	gen := Dicts(Text(0, 5), Integers[int64](0, 100), DictMinSize(2), DictMaxSize(5))
-	bg, ok := gen.(*basicGenerator[map[string]int64])
-	if !ok {
-		t.Fatalf("expected *basicGenerator[map[string]int64], got %T", gen)
-	}
+	gen := Dicts(Text(0, 5), Integers[int64](0, 100)).MinSize(2).MaxSize(5)
+	bg := gen.buildGenerator().(*basicGenerator[map[string]int64])
 	minSz, _ := extractCBORInt(bg.schema["min_size"])
 	if minSz != 2 {
 		t.Errorf("min_size: expected 2, got %d", minSz)
 	}
 }
 
-// TestDictsBasicIsBasicGenerator verifies basicGenerator path via type assertion.
-func TestDictsBasicIsBasicGenerator(t *testing.T) {
+// TestDictsBasicBuildsBasicGenerator verifies the direct schema path.
+func TestDictsBasicBuildsBasicGenerator(t *testing.T) {
 	t.Parallel()
 	gen := Dicts(Text(0, 5), Integers[int64](0, 100))
-	if _, ok := gen.(*basicGenerator[map[string]int64]); !ok {
-		t.Errorf("Dicts(basic,basic) should be *basicGenerator[map[string]int64], got %T", gen)
+	if _, ok := gen.buildGenerator().(*basicGenerator[map[string]int64]); !ok {
+		t.Errorf("Dicts(basic,basic) should build *basicGenerator[map[string]int64], got %T", gen.buildGenerator())
 	}
 }
 
-// TestDictsCompositeIsNotBasicGenerator verifies compositeDictGenerator is not a basicGenerator.
-func TestDictsCompositeIsNotBasicGenerator(t *testing.T) {
+// TestDictsCompositeBuildsComposite verifies non-basic input uses the collection protocol.
+func TestDictsCompositeBuildsComposite(t *testing.T) {
 	t.Parallel()
 	// Use a non-basic key generator (mappedGenerator wrapping a basic generator)
 	nonBasicKeys := &mappedGenerator[int64, int64]{
@@ -96,8 +87,8 @@ func TestDictsCompositeIsNotBasicGenerator(t *testing.T) {
 		fn:    func(v int64) int64 { return v },
 	}
 	gen := Dicts(nonBasicKeys, Integers[int64](0, 10))
-	if _, ok := gen.(*basicGenerator[map[int64]int64]); ok {
-		t.Error("Dicts(non-basic, basic) should not be *basicGenerator")
+	if _, ok := gen.buildGenerator().(*basicGenerator[map[int64]int64]); ok {
+		t.Error("Dicts(non-basic, basic) should not build *basicGenerator")
 	}
 }
 
@@ -234,7 +225,7 @@ func TestDictsStopTestOnNewCollection(t *testing.T) {
 			inner: Integers[int64](0, 10),
 			fn:    func(v int64) int64 { return v },
 		}
-		gen := Dicts(nonBasicKeys, Integers[int64](0, 100), DictMaxSize(3))
+		gen := Dicts(nonBasicKeys, Integers[int64](0, 100)).MaxSize(3)
 		_ = gen.draw(s)
 	}, stderrNoteFn, nil)
 	// StopTest causes test to be skipped or aborted, not fail
@@ -251,7 +242,7 @@ func TestDictsStopTestOnCollectionMore(t *testing.T) {
 			inner: Integers[int64](0, 10),
 			fn:    func(v int64) int64 { return v },
 		}
-		gen := Dicts(nonBasicKeys, Integers[int64](0, 100), DictMaxSize(3))
+		gen := Dicts(nonBasicKeys, Integers[int64](0, 100)).MaxSize(3)
 		_ = gen.draw(s)
 	}, stderrNoteFn, nil)
 	_ = err
@@ -267,7 +258,7 @@ func TestDictsBasicE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
-		gen := Dicts(Text(0, 5), Integers[int](0, 100), DictMaxSize(3))
+		gen := Dicts(Text(0, 5), Integers[int](0, 100)).MaxSize(3)
 		m := gen.draw(s)
 		if len(m) > 3 {
 			panic(fmt.Sprintf("Dicts: expected at most 3 entries, got %d", len(m)))
@@ -291,7 +282,7 @@ func TestDictsBasicWithBoundsE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
-		gen := Dicts(Integers[int](0, 10), Booleans(), DictMinSize(1), DictMaxSize(3))
+		gen := Dicts(Integers[int](0, 10), Booleans()).MinSize(1).MaxSize(3)
 		m := gen.draw(s)
 		if len(m) < 1 || len(m) > 3 {
 			panic(fmt.Sprintf("Dicts bounded: expected 1-3 entries, got %d", len(m)))
@@ -315,7 +306,7 @@ func TestDictsCompositeNoMaxE2E(t *testing.T) {
 			inner: Integers[int64](0, 100),
 			fn:    func(n int64) int64 { return n },
 		}
-		// Omit DictMaxSize to trigger the !g.hasMax branch.
+		// Omit MaxSize to trigger the !g.hasMax branch.
 		gen := Dicts(nonBasicKeys, Just("v"))
 		m := gen.draw(s)
 		_ = m // just verify it doesn't panic
@@ -340,7 +331,7 @@ func TestDictsCompositeE2E(t *testing.T) {
 				return int64(6) // clamp to > 5
 			},
 		}
-		gen := Dicts(nonBasicKeys, Just("val"), DictMaxSize(3))
+		gen := Dicts(nonBasicKeys, Just("val")).MaxSize(3)
 		m := gen.draw(s)
 		// All values must be "val"
 		for k, val := range m {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,8 +146,7 @@ t.Run("list_with_valid_index", hegel.Case(func(ht *hegel.T) {
 	n := hegel.Draw(ht, hegel.Integers(1, 10))
 	lst := hegel.Draw(ht, hegel.Lists(
 		hegel.Integers(math.MinInt, math.MaxInt),
-		hegel.ListMinSize(int(n)), hegel.ListMaxSize(int(n)),
-	))
+	).MinSize(int(n)).MaxSize(int(n)))
 	index := hegel.Draw(ht, hegel.Integers(0, n-1))
 
 	if index < 0 || index >= int64(len(lst)) {
@@ -166,8 +165,7 @@ t.Run("flatmap_example", hegel.Case(func(ht *hegel.T) {
 		func(n int64) hegel.Generator[[]int64] {
 			return hegel.Lists(
 				hegel.Integers(math.MinInt, math.MaxInt),
-				hegel.ListMinSize(int(n)), hegel.ListMaxSize(int(n)),
-			)
+			).MinSize(int(n)).MaxSize(int(n))
 		},
 	))
 
@@ -185,7 +183,7 @@ t.Run("flatmap_example", hegel.Case(func(ht *hegel.T) {
 hegel.Booleans()                             // bool
 hegel.Integers(-1000, 1000)                  // int64 in [min, max]
 hegel.Integers(math.MinInt, math.MaxInt)     // unbounded int
-hegel.Floats(min, max, nan, inf, eMin, eMax) // float64 (use nil to omit bounds)
+hegel.Floats[float64]().Min(0).Max(1)         // float64
 hegel.Text(0, 50)                            // Unicode string (pass maxSize < 0 for unbounded)
 hegel.Binary(0, 64)                          // []byte (pass maxSize < 0 for unbounded)
 ```
@@ -200,8 +198,8 @@ hegel.SampledFrom([]string{"a", "b", "c"})   // uniform random pick from a slice
 ### Collections
 
 ```go
-hegel.Lists(elemGen, hegel.ListMinSize(1), hegel.ListMaxSize(10)) // []any
-hegel.Dicts(keyGen, valGen, hegel.DictMaxSize(5))                 // map[any]any
+hegel.Lists(elemGen).MinSize(1).MaxSize(10) // []any
+hegel.Dicts(keyGen, valGen).MaxSize(5)      // map[any]any
 ```
 
 ### Combinators
@@ -219,10 +217,10 @@ hegel.FlatMap(gen, fn)          // dependent generation
 ```go
 hegel.Emails()                  // email address strings
 hegel.URLs()                    // URL strings
-hegel.Domains(opts)             // domain name strings
+hegel.Domains().MaxLength(63)   // domain name strings
 hegel.Dates()                   // ISO 8601 date strings (YYYY-MM-DD)
 hegel.Datetimes()               // ISO 8601 datetime strings
-hegel.IPAddresses(opts)         // IPv4 or IPv6 address strings
+hegel.IPAddresses().IPv4()      // IPv4 addresses
 hegel.FromRegex(pattern, true)  // strings matching a regular expression
 ```
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -69,7 +69,7 @@ func TestCompositeListGeneratorFilterReturnsfilteredGenerator(t *testing.T) {
 	// compositeListGenerator is produced when elements are non-basic.
 	// Filter produces a filteredGenerator (non-basic), forcing Lists into composite path.
 	nonBasic := Filter(Integers[int](0, 10), func(v int) bool { return true })
-	listGen := Lists(nonBasic, ListMaxSize(5))
+	listGen := Lists(nonBasic).MaxSize(5)
 	filtered := Filter(listGen, func(v []int) bool { return true })
 	if _, ok := filtered.(*filteredGenerator[[]int]); !ok {
 		t.Fatalf("Filter(compositeListGenerator) should return *filteredGenerator, got %T", filtered)

--- a/formats_test.go
+++ b/formats_test.go
@@ -49,14 +49,11 @@ func TestURLsSchema(t *testing.T) {
 func TestDomainsSchemaNoMaxLength(t *testing.T) {
 	t.Parallel()
 	g := Domains()
-	bg, ok := g.(*basicGenerator[string])
-	if !ok {
-		t.Fatalf("Domains() should return *basicGenerator[string], got %T", g)
+	schema := g.buildSchema()
+	if schema["type"] != "domain" {
+		t.Errorf("type: expected domain, got %v", schema["type"])
 	}
-	if bg.schema["type"] != "domain" {
-		t.Errorf("type: expected domain, got %v", bg.schema["type"])
-	}
-	maxLen, hasMax := bg.schema["max_length"]
+	maxLen, hasMax := schema["max_length"]
 	if !hasMax {
 		t.Fatal("max_length should always be present in domain schema")
 	}
@@ -69,15 +66,12 @@ func TestDomainsSchemaNoMaxLength(t *testing.T) {
 // TestDomainsSchemaWithMaxLength verifies that Domains() with MaxLength includes it.
 func TestDomainsSchemaWithMaxLength(t *testing.T) {
 	t.Parallel()
-	g := Domains(DomainMaxLength(63))
-	bg, ok := g.(*basicGenerator[string])
-	if !ok {
-		t.Fatalf("Domains() should return *basicGenerator[string], got %T", g)
+	g := Domains().MaxLength(63)
+	schema := g.buildSchema()
+	if schema["type"] != "domain" {
+		t.Errorf("type: expected domain, got %v", schema["type"])
 	}
-	if bg.schema["type"] != "domain" {
-		t.Errorf("type: expected domain, got %v", bg.schema["type"])
-	}
-	maxLen, ok := bg.schema["max_length"]
+	maxLen, ok := schema["max_length"]
 	if !ok {
 		t.Fatal("max_length should be present when MaxLength > 0")
 	}
@@ -178,7 +172,7 @@ func TestDomainsMaxLengthE2E(t *testing.T) {
 	hegelBinPath(t)
 	const maxLen = 20
 	if _err := runHegel(func(s *TestCase) {
-		v := Draw(s, Domains(DomainMaxLength(maxLen)))
+		v := Draw(s, Domains().MaxLength(maxLen))
 		if len(v) > maxLen {
 			panic("domain exceeds max_length constraint: " + v)
 		}

--- a/generators.go
+++ b/generators.go
@@ -54,6 +54,11 @@ type Generator[T any] interface {
 	draw(s *TestCase) T
 }
 
+type builderGenerator[T any] interface {
+	Generator[T]
+	buildGenerator() Generator[T]
+}
+
 // testCase is the test context for a Hegel property test.
 type testCase interface {
 	// Assume rejects the current test case if condition is false.
@@ -72,6 +77,13 @@ type testCase interface {
 // Draw produces a value from a Generator using the given State context.
 func Draw[T any](tc testCase, g Generator[T]) T {
 	return g.draw(tc.internal())
+}
+
+func unwrapGenerator[T any](g Generator[T]) Generator[T] {
+	if builder, ok := g.(builderGenerator[T]); ok {
+		return builder.buildGenerator()
+	}
+	return g
 }
 
 // --- basicGenerator ---
@@ -169,6 +181,7 @@ func (g *flatMappedGenerator[T, U]) draw(s *TestCase) U {
 
 // Map returns a new Generator that applies fn to each value from g.
 func Map[T, U any](g Generator[T], fn func(T) U) Generator[U] {
+	g = unwrapGenerator(g)
 	if bg, ok := g.(*basicGenerator[T]); ok {
 		if bg.transform != nil {
 			prev := bg.transform

--- a/generators_test.go
+++ b/generators_test.go
@@ -781,31 +781,24 @@ func TestBinarySchemaNoMax(t *testing.T) {
 // TestFloatsSchemaWithBounds verifies that Floats with explicit bounds sets all schema fields.
 func TestFloatsSchemaWithBounds(t *testing.T) {
 	t.Parallel()
-	minV := 0.0
-	maxV := 1.0
-	falseV := false
-	g := Floats(&minV, &maxV, &falseV, &falseV, false, false)
-	bg, ok := g.(*basicGenerator[float64])
-	if !ok {
-		t.Fatalf("Floats should return *basicGenerator[float64], got %T", g)
+	schema := Floats[float64]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false).buildSchema()
+	if schema["type"] != "float" {
+		t.Errorf("type: expected 'float', got %v", schema["type"])
 	}
-	if bg.schema["type"] != "float" {
-		t.Errorf("type: expected 'float', got %v", bg.schema["type"])
+	if schema["allow_nan"] != false {
+		t.Errorf("allow_nan: expected false, got %v", schema["allow_nan"])
 	}
-	if bg.schema["allow_nan"] != false {
-		t.Errorf("allow_nan: expected false, got %v", bg.schema["allow_nan"])
+	if schema["allow_infinity"] != false {
+		t.Errorf("allow_infinity: expected false, got %v", schema["allow_infinity"])
 	}
-	if bg.schema["allow_infinity"] != false {
-		t.Errorf("allow_infinity: expected false, got %v", bg.schema["allow_infinity"])
+	if schema["exclude_min"] != false {
+		t.Errorf("exclude_min: expected false, got %v", schema["exclude_min"])
 	}
-	if bg.schema["exclude_min"] != false {
-		t.Errorf("exclude_min: expected false, got %v", bg.schema["exclude_min"])
+	if schema["exclude_max"] != false {
+		t.Errorf("exclude_max: expected false, got %v", schema["exclude_max"])
 	}
-	if bg.schema["exclude_max"] != false {
-		t.Errorf("exclude_max: expected false, got %v", bg.schema["exclude_max"])
-	}
-	minVal, _ := bg.schema["min_value"].(float64)
-	maxVal, _ := bg.schema["max_value"].(float64)
+	minVal, _ := schema["min_value"].(float64)
+	maxVal, _ := schema["max_value"].(float64)
 	if minVal != 0.0 {
 		t.Errorf("min_value: expected 0.0, got %v", minVal)
 	}
@@ -817,18 +810,17 @@ func TestFloatsSchemaWithBounds(t *testing.T) {
 // TestFloatsSchemaUnbounded verifies that Floats with no bounds defaults allow_nan=true, allow_infinity=true.
 func TestFloatsSchemaUnbounded(t *testing.T) {
 	t.Parallel()
-	g := Floats(nil, nil, nil, nil, false, false)
-	bg := g.(*basicGenerator[float64])
-	if bg.schema["allow_nan"] != true {
-		t.Errorf("allow_nan: expected true (no bounds), got %v", bg.schema["allow_nan"])
+	schema := Floats[float64]().buildSchema()
+	if schema["allow_nan"] != true {
+		t.Errorf("allow_nan: expected true (no bounds), got %v", schema["allow_nan"])
 	}
-	if bg.schema["allow_infinity"] != true {
-		t.Errorf("allow_infinity: expected true (no bounds), got %v", bg.schema["allow_infinity"])
+	if schema["allow_infinity"] != true {
+		t.Errorf("allow_infinity: expected true (no bounds), got %v", schema["allow_infinity"])
 	}
-	if _, hasMin := bg.schema["min_value"]; hasMin {
+	if _, hasMin := schema["min_value"]; hasMin {
 		t.Error("min_value should not be present when minVal is nil")
 	}
-	if _, hasMax := bg.schema["max_value"]; hasMax {
+	if _, hasMax := schema["max_value"]; hasMax {
 		t.Error("max_value should not be present when maxVal is nil")
 	}
 }
@@ -836,46 +828,38 @@ func TestFloatsSchemaUnbounded(t *testing.T) {
 // TestFloatsSchemaOnlyMin verifies Floats with only min bound: allow_nan=false, allow_infinity=true.
 func TestFloatsSchemaOnlyMin(t *testing.T) {
 	t.Parallel()
-	minV := 0.0
-	g := Floats(&minV, nil, nil, nil, false, false)
-	bg := g.(*basicGenerator[float64])
+	schema := Floats[float64]().Min(0.0).buildSchema()
 	// has_min=true, has_max=false -> allow_nan=false, allow_infinity=true
-	if bg.schema["allow_nan"] != false {
-		t.Errorf("allow_nan: expected false when min set, got %v", bg.schema["allow_nan"])
+	if schema["allow_nan"] != false {
+		t.Errorf("allow_nan: expected false when min set, got %v", schema["allow_nan"])
 	}
-	if bg.schema["allow_infinity"] != true {
-		t.Errorf("allow_infinity: expected true when only min set, got %v", bg.schema["allow_infinity"])
+	if schema["allow_infinity"] != true {
+		t.Errorf("allow_infinity: expected true when only min set, got %v", schema["allow_infinity"])
 	}
 }
 
 // TestFloatsSchemaOnlyMax verifies Floats with only max bound: allow_nan=false, allow_infinity=true.
 func TestFloatsSchemaOnlyMax(t *testing.T) {
 	t.Parallel()
-	maxV := 1.0
-	g := Floats(nil, &maxV, nil, nil, false, false)
-	bg := g.(*basicGenerator[float64])
+	schema := Floats[float64]().Max(1.0).buildSchema()
 	// has_min=false, has_max=true -> allow_nan=false, allow_infinity=true
-	if bg.schema["allow_nan"] != false {
-		t.Errorf("allow_nan: expected false when max set, got %v", bg.schema["allow_nan"])
+	if schema["allow_nan"] != false {
+		t.Errorf("allow_nan: expected false when max set, got %v", schema["allow_nan"])
 	}
-	if bg.schema["allow_infinity"] != true {
-		t.Errorf("allow_infinity: expected true when only max set, got %v", bg.schema["allow_infinity"])
+	if schema["allow_infinity"] != true {
+		t.Errorf("allow_infinity: expected true when only max set, got %v", schema["allow_infinity"])
 	}
 }
 
 // TestFloatsSchemaExcludeBounds verifies that excludeMin/excludeMax are stored correctly.
 func TestFloatsSchemaExcludeBounds(t *testing.T) {
 	t.Parallel()
-	minV := 0.0
-	maxV := 1.0
-	falseV := false
-	g := Floats(&minV, &maxV, &falseV, &falseV, true, true)
-	bg := g.(*basicGenerator[float64])
-	if bg.schema["exclude_min"] != true {
-		t.Errorf("exclude_min: expected true, got %v", bg.schema["exclude_min"])
+	schema := Floats[float64]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false).ExcludeMin().ExcludeMax().buildSchema()
+	if schema["exclude_min"] != true {
+		t.Errorf("exclude_min: expected true, got %v", schema["exclude_min"])
 	}
-	if bg.schema["exclude_max"] != true {
-		t.Errorf("exclude_max: expected true, got %v", bg.schema["exclude_max"])
+	if schema["exclude_max"] != true {
+		t.Errorf("exclude_max: expected true, got %v", schema["exclude_max"])
 	}
 }
 
@@ -938,7 +922,7 @@ func TestFlatMappedGeneratorDependency(t *testing.T) {
 	hegelBinPath(t)
 	gen := FlatMap[int64, []int64](Integers[int64](2, 4), func(v int64) Generator[[]int64] {
 		sz := int(v)
-		return Lists[int64](Integers[int64](0, 100), ListMinSize(sz), ListMaxSize(sz))
+		return Lists[int64](Integers[int64](0, 100)).MinSize(sz).MaxSize(sz)
 	})
 	if _err := runHegel(func(s *TestCase) {
 		slice := Draw[[]int64](s, gen)
@@ -1063,14 +1047,12 @@ func TestExtractIntPanicsOnInvalidType(t *testing.T) {
 
 func TestFloatsSchemaExplicitNaNNilInf(t *testing.T) {
 	t.Parallel()
-	nan := true
-	g := Floats(nil, nil, &nan, nil, false, false)
-	bg := g.(*basicGenerator[float64])
-	if bg.schema["allow_nan"] != true {
-		t.Errorf("allow_nan: expected true, got %v", bg.schema["allow_nan"])
+	schema := Floats[float64]().AllowNaN(true).buildSchema()
+	if schema["allow_nan"] != true {
+		t.Errorf("allow_nan: expected true, got %v", schema["allow_nan"])
 	}
-	if bg.schema["allow_infinity"] != true {
-		t.Errorf("allow_infinity: expected true (default with no bounds), got %v", bg.schema["allow_infinity"])
+	if schema["allow_infinity"] != true {
+		t.Errorf("allow_infinity: expected true (default with no bounds), got %v", schema["allow_infinity"])
 	}
 }
 
@@ -1080,14 +1062,40 @@ func TestFloatsSchemaExplicitNaNNilInf(t *testing.T) {
 
 func TestFloatsSchemaExplicitInfNilNaN(t *testing.T) {
 	t.Parallel()
-	inf := true
-	g := Floats(nil, nil, nil, &inf, false, false)
-	bg := g.(*basicGenerator[float64])
-	if bg.schema["allow_nan"] != true {
-		t.Errorf("allow_nan: expected true (default with no bounds), got %v", bg.schema["allow_nan"])
+	schema := Floats[float64]().AllowInfinity(true).buildSchema()
+	if schema["allow_nan"] != true {
+		t.Errorf("allow_nan: expected true (default with no bounds), got %v", schema["allow_nan"])
 	}
-	if bg.schema["allow_infinity"] != true {
-		t.Errorf("allow_infinity: expected true, got %v", bg.schema["allow_infinity"])
+	if schema["allow_infinity"] != true {
+		t.Errorf("allow_infinity: expected true, got %v", schema["allow_infinity"])
+	}
+}
+
+// TestFloatsFloat32SchemaWidth verifies that Floats[float32]() has "width": int64(32).
+func TestFloatsFloat32SchemaWidth(t *testing.T) {
+	t.Parallel()
+	schema := Floats[float32]().buildSchema()
+	w := schema["width"].(int64)
+	if w != 32 {
+		t.Errorf("width: expected 32, got %d", w)
+	}
+}
+
+// TestExtractFloatAsFloat32 verifies extractFloatAs[float32].
+func TestExtractFloatAsFloat32(t *testing.T) {
+	t.Parallel()
+	v := extractFloatAs[float32](float64(1.5))
+	if v != float32(1.5) {
+		t.Errorf("extractFloatAs[float32]: expected 1.5, got %v", v)
+	}
+}
+
+// TestExtractFloatAsFloat64 verifies extractFloatAs[float64].
+func TestExtractFloatAsFloat64(t *testing.T) {
+	t.Parallel()
+	v := extractFloatAs[float64](float64(2.5))
+	if v != 2.5 {
+		t.Errorf("extractFloatAs[float64]: expected 2.5, got %v", v)
 	}
 }
 
@@ -1146,13 +1154,7 @@ func TestRejectE2E(t *testing.T) {
 
 func TestListsNegativeMinSizeSchema(t *testing.T) {
 	t.Parallel()
-	gen := Lists(Integers[int64](0, 10), ListMinSize(-5), ListMaxSize(10))
-	bg, ok := gen.(*basicGenerator[[]int64])
-	if !ok {
-		t.Fatalf("expected *basicGenerator[[]int64], got %T", gen)
-	}
-	minV, _ := extractCBORInt(bg.schema["min_size"])
-	if minV != 0 {
-		t.Errorf("negative MinSize should be clamped to 0, got %d", minV)
-	}
+	assertPanicsWithMessage(t, "min_size", func() {
+		Lists(Integers[int64](0, 10)).MinSize(-5).MaxSize(10).buildGenerator()
+	})
 }

--- a/lists_test.go
+++ b/lists_test.go
@@ -11,16 +11,13 @@ import (
 // Lists generator unit tests
 // =============================================================================
 
-// TestListsBasicElementSchema verifies that Lists on a basicGenerator[int64] (no transform)
-// produces a basicGenerator[[]int64] with the correct list schema.
+// TestListsBasicElementSchema verifies that Lists on a basic generator produces
+// a list schema with the expected fields.
 func TestListsBasicElementSchema(t *testing.T) {
 	t.Parallel()
 	elem := Integers[int64](0, 100)
-	gen := Lists(elem, ListMinSize(2), ListMaxSize(10))
-	bg, ok := gen.(*basicGenerator[[]int64])
-	if !ok {
-		t.Fatalf("Lists(basic) should return *basicGenerator[[]int64], got %T", gen)
-	}
+	gen := Lists(elem).MinSize(2).MaxSize(10)
+	bg := gen.buildGenerator().(*basicGenerator[[]int64])
 	if bg.schema["type"] != "list" {
 		t.Errorf("schema type: expected 'list', got %v", bg.schema["type"])
 	}
@@ -45,11 +42,8 @@ func TestListsBasicElementSchema(t *testing.T) {
 func TestListsBasicElementNoMaxSchema(t *testing.T) {
 	t.Parallel()
 	elem := Integers[int64](0, 100)
-	gen := Lists(elem, ListMaxSize(-1))
-	bg, ok := gen.(*basicGenerator[[]int64])
-	if !ok {
-		t.Fatalf("Lists(basic, no max) should return *basicGenerator[[]int64], got %T", gen)
-	}
+	gen := Lists(elem)
+	bg := gen.buildGenerator().(*basicGenerator[[]int64])
 	if _, hasMax := bg.schema["max_size"]; hasMax {
 		t.Error("max_size should not be present when MaxSize < 0")
 	}
@@ -63,11 +57,8 @@ func TestListsBasicElementWithTransformSchema(t *testing.T) {
 	elem := Map(Integers[int64](0, 100), func(n int64) int64 {
 		return n * 2
 	})
-	gen := Lists(elem, ListMaxSize(5))
-	bg, ok := gen.(*basicGenerator[[]int64])
-	if !ok {
-		t.Fatalf("Lists(basic with transform) should return *basicGenerator[[]int64], got %T", gen)
-	}
+	gen := Lists(elem).MaxSize(5)
+	bg := gen.buildGenerator().(*basicGenerator[[]int64])
 	if bg.schema["type"] != "list" {
 		t.Errorf("schema type: expected 'list', got %v", bg.schema["type"])
 	}
@@ -92,11 +83,8 @@ func TestListsBasicElementWithTransformSchema(t *testing.T) {
 func TestListsBasicElementWithTransformNonSlicePassthrough(t *testing.T) {
 	t.Parallel()
 	elem := Map(Integers[int64](0, 10), func(n int64) int64 { return n })
-	gen := Lists(elem, ListMaxSize(5))
-	bg, ok := gen.(*basicGenerator[[]int64])
-	if !ok {
-		t.Fatalf("expected *basicGenerator[[]int64], got %T", gen)
-	}
+	gen := Lists(elem).MaxSize(5)
+	bg := gen.buildGenerator().(*basicGenerator[[]int64])
 	// Pass a non-slice value to the transform -- should return nil.
 	result := bg.transform("not-a-slice")
 	if result != nil {
@@ -109,11 +97,8 @@ func TestListsBasicElementWithTransformNonSlicePassthrough(t *testing.T) {
 func TestListsBasicElementNoTransformNonSlicePassthrough(t *testing.T) {
 	t.Parallel()
 	elem := Booleans()
-	gen := Lists(elem, ListMaxSize(5))
-	bg, ok := gen.(*basicGenerator[[]bool])
-	if !ok {
-		t.Fatalf("expected *basicGenerator[[]bool], got %T", gen)
-	}
+	gen := Lists(elem).MaxSize(5)
+	bg := gen.buildGenerator().(*basicGenerator[[]bool])
 	// Pass a non-slice value to the transform -- should return nil.
 	result := bg.transform("not-a-slice")
 	if result != nil {
@@ -122,31 +107,24 @@ func TestListsBasicElementNoTransformNonSlicePassthrough(t *testing.T) {
 }
 
 // TestListsNonBasicElementReturnsComposite verifies that Lists on a non-basic generator
-// returns a compositeListGenerator (not a basicGenerator).
+// builds a compositeListGenerator.
 func TestListsNonBasicElementReturnsComposite(t *testing.T) {
 	t.Parallel()
 	// mappedGenerator is non-basic.
 	inner := Integers[int64](0, 10)
 	nonBasic := &mappedGenerator[int64, int64]{inner: inner, fn: func(v int64) int64 { return v }}
-	gen := Lists(nonBasic, ListMinSize(1), ListMaxSize(3))
-	if _, ok := gen.(*compositeListGenerator[int64]); !ok {
-		t.Fatalf("Lists(non-basic) should return *compositeListGenerator[int64], got %T", gen)
+	gen := Lists(nonBasic).MinSize(1).MaxSize(3)
+	if _, ok := gen.buildGenerator().(*compositeListGenerator[int64]); !ok {
+		t.Fatalf("Lists(non-basic) should build *compositeListGenerator[int64], got %T", gen.buildGenerator())
 	}
 }
 
-// TestListsNegativeMinSizeClampedToZero verifies that a negative MinSize is clamped to 0.
-func TestListsNegativeMinSizeClampedToZero(t *testing.T) {
+// TestListsNegativeMinSizePanics verifies that a negative MinSize is rejected.
+func TestListsNegativeMinSizePanics(t *testing.T) {
 	t.Parallel()
-	elem := Integers[int64](0, 100)
-	gen := Lists(elem, ListMinSize(-5), ListMaxSize(10))
-	bg, ok := gen.(*basicGenerator[[]int64])
-	if !ok {
-		t.Fatalf("expected *basicGenerator[[]int64], got %T", gen)
-	}
-	minV, _ := extractCBORInt(bg.schema["min_size"])
-	if minV != 0 {
-		t.Errorf("negative MinSize should be clamped to 0, got %d", minV)
-	}
+	assertPanicsWithMessage(t, "min_size", func() {
+		Lists(Integers[int64](0, 100)).MinSize(-5).MaxSize(10).buildGenerator()
+	})
 }
 
 // =============================================================================
@@ -159,7 +137,7 @@ func TestListsBasicIntegersE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
-		xs := Lists(Integers[int](0, 100), ListMaxSize(10)).draw(s)
+		xs := Lists(Integers[int](0, 100)).MaxSize(10).draw(s)
 		for _, x := range xs {
 			if x < 0 || x > 100 {
 				panic(fmt.Sprintf("Lists: element %d out of range [0, 100]", x))
@@ -176,7 +154,7 @@ func TestListsWithSizeBoundsE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
-		xs := Lists(Booleans(), ListMinSize(3), ListMaxSize(5)).draw(s)
+		xs := Lists(Booleans()).MinSize(3).MaxSize(5).draw(s)
 		if len(xs) < 3 || len(xs) > 5 {
 			panic(fmt.Sprintf("Lists: length %d out of [3, 5]", len(xs)))
 		}
@@ -197,7 +175,7 @@ func TestListsNonBasicElementE2E(t *testing.T) {
 	nonBasic := &mappedGenerator[int, int]{inner: mapped, fn: func(v int) int { return v }}
 
 	if _err := runHegel(func(s *TestCase) {
-		xs := Lists(nonBasic, ListMaxSize(5)).draw(s)
+		xs := Lists(nonBasic).MaxSize(5).draw(s)
 		for _, x := range xs {
 			if x%2 != 0 {
 				panic(fmt.Sprintf("Lists(non-basic): expected even element, got %d", x))
@@ -214,7 +192,7 @@ func TestListsNestedE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
-		outer := Lists(Lists(Booleans(), ListMaxSize(3)), ListMaxSize(3)).draw(s)
+		outer := Lists(Lists(Booleans()).MaxSize(3)).MaxSize(3).draw(s)
 		for i, inner := range outer {
 			for j, b := range inner {
 				// b is already bool due to typed generators; verify it is true or false.
@@ -238,7 +216,7 @@ func TestListsBasicWithTransformE2E(t *testing.T) {
 		return n * 2
 	})
 	if _err := runHegel(func(s *TestCase) {
-		xs := Lists(doubled, ListMaxSize(5)).draw(s)
+		xs := Lists(doubled).MaxSize(5).draw(s)
 		for _, x := range xs {
 			if x%2 != 0 || x < 0 || x > 20 {
 				panic(fmt.Sprintf("Lists(basic+transform): element %d should be even in [0,20]", x))

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -380,11 +380,8 @@ func TestOptionalNonBasicE2E(t *testing.T) {
 // TestIPAddressesV4Schema verifies that IPAddresses(v4) produces {"type":"ipv4"}.
 func TestIPAddressesV4Schema(t *testing.T) {
 	t.Parallel()
-	g := IPAddresses(IPv4())
-	bg, ok := g.(*basicGenerator[netip.Addr])
-	if !ok {
-		t.Fatalf("IPAddresses(v4) should return *basicGenerator[netip.Addr], got %T", g)
-	}
+	g := IPAddresses().IPv4()
+	bg := g.buildGenerator().(*basicGenerator[netip.Addr])
 	if bg.schema["type"] != "ipv4" {
 		t.Errorf("IPAddresses(v4) type: expected ipv4, got %v", bg.schema["type"])
 	}
@@ -393,11 +390,8 @@ func TestIPAddressesV4Schema(t *testing.T) {
 // TestIPAddressesV6Schema verifies that IPAddresses(v6) produces {"type":"ipv6"}.
 func TestIPAddressesV6Schema(t *testing.T) {
 	t.Parallel()
-	g := IPAddresses(IPv6())
-	bg, ok := g.(*basicGenerator[netip.Addr])
-	if !ok {
-		t.Fatalf("IPAddresses(v6) should return *basicGenerator[netip.Addr], got %T", g)
-	}
+	g := IPAddresses().IPv6()
+	bg := g.buildGenerator().(*basicGenerator[netip.Addr])
 	if bg.schema["type"] != "ipv6" {
 		t.Errorf("IPAddresses(v6) type: expected ipv6, got %v", bg.schema["type"])
 	}
@@ -407,10 +401,7 @@ func TestIPAddressesV6Schema(t *testing.T) {
 func TestIPAddressesDefaultIsOneOf(t *testing.T) {
 	t.Parallel()
 	g := IPAddresses()
-	bg, ok := g.(*basicGenerator[netip.Addr])
-	if !ok {
-		t.Fatalf("IPAddresses(default) should return *basicGenerator[netip.Addr], got %T", g)
-	}
+	bg := g.buildGenerator().(*basicGenerator[netip.Addr])
 	// Should be a one_of of ipv4 and ipv6
 	oneOf, hasOneOf := bg.schema["one_of"]
 	if !hasOneOf {
@@ -426,7 +417,7 @@ func TestIPAddressesDefaultIsOneOf(t *testing.T) {
 func TestIPAddressesV4E2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	g := IPAddresses(IPv4())
+	g := IPAddresses().IPv4()
 	if _err := runHegel(func(s *TestCase) {
 		v := g.draw(s)
 		if !v.Is4() {
@@ -441,7 +432,7 @@ func TestIPAddressesV4E2E(t *testing.T) {
 func TestIPAddressesV6E2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	g := IPAddresses(IPv6())
+	g := IPAddresses().IPv6()
 	if _err := runHegel(func(s *TestCase) {
 		v := g.draw(s)
 		if !v.Is6() {

--- a/primitives.go
+++ b/primitives.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"time"
+	"unsafe"
 
 	"golang.org/x/exp/constraints"
 )
@@ -48,6 +49,11 @@ func extractIntAs[T constraints.Integer](v any) T {
 	return T(extractInt(v))
 }
 
+// extractFloatAs extracts a float from a CBOR-decoded value and converts it to T.
+func extractFloatAs[T constraints.Float](v any) T {
+	return T(extractFloat(v))
+}
+
 // Integers returns a Generator that produces integer values in [minVal, maxVal].
 // For unbounded generation, use the full range of the type:
 //
@@ -66,48 +72,121 @@ func Integers[T constraints.Integer](minVal, maxVal T) Generator[T] {
 	}
 }
 
-// Floats returns a Generator that produces float64 values.
-func Floats(minVal, maxVal *float64, allowNaN, allowInfinity *bool, excludeMin, excludeMax bool) Generator[float64] {
-	hasMin := minVal != nil
-	hasMax := maxVal != nil
+// FloatGenerator configures and generates floating-point values of type T.
+// Use [Floats] to create one, then chain builder methods to configure bounds
+// and behavior. Invalid configurations panic on the first [Draw] call.
+type FloatGenerator[T constraints.Float] struct {
+	minVal     *float64
+	maxVal     *float64
+	allowNaN   *bool
+	allowInf   *bool
+	excludeMin bool
+	excludeMax bool
+}
+
+// Floats returns a FloatGenerator that produces floating-point values of type T.
+// Configure bounds and behavior by chaining builder methods.
+//
+//	hegel.Floats[float64]()                         // any float64 including NaN and Inf
+//	hegel.Floats[float64]().Min(0).Max(1)           // bounded [0, 1]
+//	hegel.Floats[float32]().Min(0).ExcludeMin()     // (0, +Inf)
+func Floats[T constraints.Float]() FloatGenerator[T] {
+	return FloatGenerator[T]{}
+}
+
+// Min sets the minimum value for the float generator.
+func (g FloatGenerator[T]) Min(v T) FloatGenerator[T] {
+	f := float64(v)
+	g.minVal = &f
+	return g
+}
+
+// Max sets the maximum value for the float generator.
+func (g FloatGenerator[T]) Max(v T) FloatGenerator[T] {
+	f := float64(v)
+	g.maxVal = &f
+	return g
+}
+
+// AllowNaN sets whether the generator may produce NaN values.
+// Default: true when no bounds are set, false otherwise.
+func (g FloatGenerator[T]) AllowNaN(v bool) FloatGenerator[T] {
+	g.allowNaN = &v
+	return g
+}
+
+// AllowInfinity sets whether the generator may produce infinite values.
+// Default: true unless both bounds are set.
+func (g FloatGenerator[T]) AllowInfinity(v bool) FloatGenerator[T] {
+	g.allowInf = &v
+	return g
+}
+
+// ExcludeMin excludes the lower bound from the generated range.
+func (g FloatGenerator[T]) ExcludeMin() FloatGenerator[T] {
+	g.excludeMin = true
+	return g
+}
+
+// ExcludeMax excludes the upper bound from the generated range.
+func (g FloatGenerator[T]) ExcludeMax() FloatGenerator[T] {
+	g.excludeMax = true
+	return g
+}
+
+// buildSchema validates the configuration and returns the wire schema.
+// Panics on invalid combinations of settings.
+func (g FloatGenerator[T]) buildSchema() map[string]any {
+	hasMin := g.minVal != nil
+	hasMax := g.maxVal != nil
 
 	nan := !hasMin && !hasMax
-	if allowNaN != nil {
-		nan = *allowNaN
+	if g.allowNaN != nil {
+		nan = *g.allowNaN
 	}
 	inf := !hasMin || !hasMax
-	if allowInfinity != nil {
-		inf = *allowInfinity
+	if g.allowInf != nil {
+		inf = *g.allowInf
 	}
 
 	if nan && (hasMin || hasMax) {
 		panic("hegel: Cannot have allow_nan=true with min_value or max_value")
 	}
-	if hasMin && hasMax && *minVal > *maxVal {
-		panic(fmt.Sprintf("hegel: Cannot have max_value=%v < min_value=%v", *maxVal, *minVal))
+	if hasMin && hasMax && *g.minVal > *g.maxVal {
+		panic(fmt.Sprintf("hegel: Cannot have max_value=%v < min_value=%v", *g.maxVal, *g.minVal))
 	}
 	if inf && hasMin && hasMax {
 		panic("hegel: Cannot have allow_infinity=true with both min_value and max_value")
 	}
 
+	width := int64(unsafe.Sizeof(T(1.0)) * 8)
 	schema := map[string]any{
 		"type":           "float",
 		"allow_nan":      nan,
 		"allow_infinity": inf,
-		"exclude_min":    excludeMin,
-		"exclude_max":    excludeMax,
-		"width":          int64(64),
+		"exclude_min":    g.excludeMin,
+		"exclude_max":    g.excludeMax,
+		"width":          width,
 	}
 	if hasMin {
-		schema["min_value"] = *minVal
+		schema["min_value"] = *g.minVal
 	}
 	if hasMax {
-		schema["max_value"] = *maxVal
+		schema["max_value"] = *g.maxVal
 	}
-	return &basicGenerator[float64]{
-		schema:    schema,
-		transform: func(v any) float64 { return extractFloat(v) },
+	return schema
+}
+
+func (g FloatGenerator[T]) buildGenerator() Generator[T] {
+	return &basicGenerator[T]{
+		schema:    g.buildSchema(),
+		transform: extractFloatAs[T],
 	}
+}
+
+// draw produces a floating-point value from the Hegel server.
+func (g FloatGenerator[T]) draw(s *TestCase) T {
+	return g.buildGenerator().draw(s)
 }
 
 // Booleans returns a Generator that produces boolean values.
@@ -175,40 +254,50 @@ func URLs() Generator[string] {
 	}
 }
 
-// DomainOption configures optional behavior for the [Domains] generator.
-type DomainOption func(*domainConfig)
-
-type domainConfig struct {
-	maxLength int
-}
-
-// DomainMaxLength sets the maximum length of the domain name.
-// Defaults to 255 (matching RFC 1035).
-func DomainMaxLength(n int) DomainOption {
-	return func(cfg *domainConfig) { cfg.maxLength = n }
-}
-
 const defaultDomainMaxLength = 255
 
+// DomainGenerator configures and generates domain name strings.
+// Use [Domains] to create one, then chain builder methods to configure it.
+// Invalid configurations panic on the first [Draw] call.
+type DomainGenerator struct {
+	maxLength int
+	hasMax    bool
+}
+
 // Domains returns a Generator that produces domain name strings.
-func Domains(opts ...DomainOption) Generator[string] {
-	var cfg domainConfig
-	for _, o := range opts {
-		o(&cfg)
-	}
-	maxLen := cfg.maxLength
-	if maxLen <= 0 {
-		maxLen = defaultDomainMaxLength
+func Domains() DomainGenerator {
+	return DomainGenerator{}
+}
+
+// MaxLength sets the maximum domain length.
+func (g DomainGenerator) MaxLength(n int) DomainGenerator {
+	g.maxLength = n
+	g.hasMax = true
+	return g
+}
+
+func (g DomainGenerator) buildSchema() map[string]any {
+	maxLen := defaultDomainMaxLength
+	if g.hasMax {
+		maxLen = g.maxLength
 	}
 	if maxLen < 4 || maxLen > 255 {
 		panic(fmt.Sprintf("hegel: max_length=%d must be between 4 and 255", maxLen))
 	}
-	return &basicGenerator[string]{
-		schema: map[string]any{
-			"type":       "domain",
-			"max_length": int64(maxLen),
-		},
+	return map[string]any{
+		"type":       "domain",
+		"max_length": int64(maxLen),
 	}
+}
+
+func (g DomainGenerator) buildGenerator() Generator[string] {
+	return &basicGenerator[string]{
+		schema: g.buildSchema(),
+	}
+}
+
+func (g DomainGenerator) draw(s *TestCase) string {
+	return g.buildGenerator().draw(s)
 }
 
 // Dates returns a Generator that produces time.Time values from ISO 8601 date strings (YYYY-MM-DD).

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -10,9 +10,6 @@ import (
 	"unicode/utf8"
 )
 
-// floatPtr returns a pointer to f, for use with Floats().
-func floatPtr(f float64) *float64 { return &f }
-
 // =============================================================================
 // Integration / e2e tests (run against real hegel binary, 50 test cases each)
 // =============================================================================
@@ -30,9 +27,8 @@ func TestIntegersFullRangeE2E(t *testing.T) {
 func TestFloatsE2E_WithBounds(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	falseBool := false
 	if _err := runHegel(func(s *TestCase) {
-		fv := Draw[float64](s, Floats(floatPtr(0.0), floatPtr(1.0), &falseBool, &falseBool, false, false))
+		fv := Draw[float64](s, Floats[float64]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
 		if math.IsNaN(fv) {
 			panic("floats: NaN not allowed when allow_nan=false")
 		}
@@ -52,7 +48,7 @@ func TestFloatsE2E_Unbounded(t *testing.T) {
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
 		// Unbounded floats may produce NaN or Inf -- any float64 is valid.
-		_ = Draw[float64](s, Floats(nil, nil, nil, nil, false, false))
+		_ = Draw(s, Floats[float64]())
 	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
 		panic(_err)
 	}
@@ -62,7 +58,7 @@ func TestFloatsE2E_OnlyMin(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	if _err := runHegel(func(s *TestCase) {
-		fv := Draw[float64](s, Floats(floatPtr(0.0), nil, nil, nil, false, false))
+		fv := Draw(s, Floats[float64]().Min(0.0))
 		// allow_nan is false (has min), allow_infinity is true (no max)
 		// Value should be >= 0.0 or Inf; NaN not allowed.
 		if math.IsNaN(fv) {
@@ -71,6 +67,28 @@ func TestFloatsE2E_OnlyMin(t *testing.T) {
 	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
 		panic(_err)
 	}
+}
+
+func TestFloatsE2E_Float32(t *testing.T) {
+	t.Parallel()
+	hegelBinPath(t)
+	if _err := runHegel(func(s *TestCase) {
+		fv := Draw(s, Floats[float32]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
+		if fv < 0.0 || fv > 1.0 {
+			panic("float32: out of range [0.0, 1.0]")
+		}
+	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+		panic(_err)
+	}
+}
+
+func TestFloatsGenerateErrorResponse(t *testing.T) {
+	hegelBinPath(t)
+	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "error_response")
+	err := runHegel(func(s *TestCase) {
+		_ = Floats[float64]().draw(s)
+	}, stderrNoteFn, nil)
+	_ = err
 }
 
 func TestBooleansE2E(t *testing.T) {
@@ -134,5 +152,39 @@ func TestBinaryE2E_Unbounded(t *testing.T) {
 		_ = Draw[[]byte](s, Binary(0, -1))
 	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
 		panic(_err)
+	}
+}
+
+func TestFloatGeneratorBuildsBasicGenerator(t *testing.T) {
+	t.Parallel()
+	gen := Floats[float64]().Min(0).Max(1).AllowNaN(false).AllowInfinity(false)
+
+	bg, ok := gen.buildGenerator().(*basicGenerator[float64])
+	if !ok {
+		t.Fatalf("Floats should build *basicGenerator[float64], got %T", gen.buildGenerator())
+	}
+	if bg.transform == nil {
+		t.Fatal("Floats basic generator should set a transform")
+	}
+	if bg.schema["type"] != "float" {
+		t.Fatalf("schema type: expected 'float', got %v", bg.schema["type"])
+	}
+}
+
+func TestListsFloatBuilderUsesBasicPath(t *testing.T) {
+	t.Parallel()
+	gen := Lists(Floats[float64]().Min(0).Max(1).AllowNaN(false).AllowInfinity(false)).MaxSize(3)
+
+	bg, ok := gen.buildGenerator().(*basicGenerator[[]float64])
+	if !ok {
+		t.Fatalf("Lists(Floats(...)) should build *basicGenerator[[]float64], got %T", gen.buildGenerator())
+	}
+
+	elemSchema, ok := bg.schema["elements"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema elements: expected map[string]any, got %T", bg.schema["elements"])
+	}
+	if elemSchema["type"] != "float" {
+		t.Fatalf("elements type: expected 'float', got %v", elemSchema["type"])
 	}
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 func assertPanicsWithMessage(t *testing.T, substr string, f func()) {
 	t.Helper()
 	defer func() {
@@ -36,19 +34,19 @@ func TestIntegersFromMinGreaterThanMax(t *testing.T) {
 }
 
 func TestFloatsAllowNaNWithMin(t *testing.T) {
-	assertPanicsWithMessage(t, "allow_nan", func() { Floats(ptr(0.0), nil, ptr(true), nil, false, false) })
+	assertPanicsWithMessage(t, "allow_nan", func() { Floats[float64]().Min(0.0).AllowNaN(true).buildSchema() })
 }
 
 func TestFloatsAllowNaNWithMax(t *testing.T) {
-	assertPanicsWithMessage(t, "allow_nan", func() { Floats(nil, ptr(10.0), ptr(true), nil, false, false) })
+	assertPanicsWithMessage(t, "allow_nan", func() { Floats[float64]().Max(10.0).AllowNaN(true).buildSchema() })
 }
 
 func TestFloatsMinGreaterThanMax(t *testing.T) {
-	assertPanicsWithMessage(t, "max_value", func() { Floats(ptr(10.0), ptr(5.0), nil, nil, false, false) })
+	assertPanicsWithMessage(t, "max_value", func() { Floats[float64]().Min(10.0).Max(5.0).buildSchema() })
 }
 
 func TestFloatsAllowInfinityWithBothBounds(t *testing.T) {
-	assertPanicsWithMessage(t, "allow_infinity", func() { Floats(ptr(0.0), ptr(10.0), nil, ptr(true), false, false) })
+	assertPanicsWithMessage(t, "allow_infinity", func() { Floats[float64]().Min(0.0).Max(10.0).AllowInfinity(true).buildSchema() })
 }
 
 func TestTextMinSizeNegative(t *testing.T) {
@@ -68,26 +66,45 @@ func TestBinaryMinGreaterThanMax(t *testing.T) {
 }
 
 func TestListsMinGreaterThanMax(t *testing.T) {
-	assertPanicsWithMessage(t, "max_size", func() { Lists(Booleans(), ListMinSize(10), ListMaxSize(5)) })
+	assertPanicsWithMessage(t, "max_size", func() { Lists(Booleans()).MinSize(10).MaxSize(5).buildGenerator() })
+}
+
+func TestListsMinSizeNegative(t *testing.T) {
+	assertPanicsWithMessage(t, "min_size", func() { Lists(Booleans()).MinSize(-1).buildGenerator() })
+}
+
+func TestListsMaxSizeNegative(t *testing.T) {
+	assertPanicsWithMessage(t, "max_size", func() { Lists(Booleans()).MaxSize(-1).buildGenerator() })
 }
 
 func TestDictsMinSizeNegative(t *testing.T) {
-	assertPanicsWithMessage(t, "min_size", func() { Dicts(Integers(0, 100), Integers(0, 100), DictMinSize(-1)) })
+	assertPanicsWithMessage(t, "min_size", func() {
+		Dicts(Integers(0, 100), Integers(0, 100)).MinSize(-1).buildGenerator()
+	})
+}
+
+func TestDictsMaxSizeNegative(t *testing.T) {
+	assertPanicsWithMessage(t, "max_size", func() {
+		Dicts(Integers(0, 100), Integers(0, 100)).MaxSize(-1).buildGenerator()
+	})
 }
 
 func TestDictsMinGreaterThanMax(t *testing.T) {
 	assertPanicsWithMessage(t, "max_size", func() {
-		Dicts(Integers(0, 100), Integers(0, 100), DictMinSize(10), DictMaxSize(5))
+		Dicts(Integers(0, 100), Integers(0, 100)).MinSize(10).MaxSize(5).buildGenerator()
 	})
 }
 
 func TestDomainsTooSmallMaxLength(t *testing.T) {
-	// MaxLength <= 0 uses the default (255), so we need a value in [1, 3] to trigger the panic
-	assertPanicsWithMessage(t, "max_length", func() { Domains(DomainMaxLength(3)) })
+	assertPanicsWithMessage(t, "max_length", func() { Domains().MaxLength(3).buildSchema() })
+}
+
+func TestDomainsNonPositiveMaxLength(t *testing.T) {
+	assertPanicsWithMessage(t, "max_length", func() { Domains().MaxLength(0).buildSchema() })
 }
 
 func TestDomainsTooBigMaxLength(t *testing.T) {
-	assertPanicsWithMessage(t, "max_length", func() { Domains(DomainMaxLength(256)) })
+	assertPanicsWithMessage(t, "max_length", func() { Domains().MaxLength(256).buildSchema() })
 }
 
 func TestIPAddressesDefaultNoPanic(t *testing.T) {
@@ -96,11 +113,11 @@ func TestIPAddressesDefaultNoPanic(t *testing.T) {
 }
 
 func TestIPAddressesVersion4NoPanic(t *testing.T) {
-	IPAddresses(IPv4())
+	IPAddresses().IPv4()
 }
 
 func TestIPAddressesVersion6NoPanic(t *testing.T) {
-	IPAddresses(IPv6())
+	IPAddresses().IPv6()
 }
 
 func TestOneOfZeroGenerators(t *testing.T) {


### PR DESCRIPTION
Floats[T]() now returns a FloatGenerator[T] with chainable value-receiver methods (Min, Max, AllowNaN, AllowInfinity, ExcludeMin, ExcludeMax). Validation is deferred to draw time. Removes FloatOption, FloatsBounded, and all FloatXxx option functions.

Fixes: https://github.com/hegeldev/hegel-go/issues/13