### PR TITLE
Update go sdk to have the right installer semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ vendor/
 .vscode/
 *.iml
 .DS_Store
+
+.claude/claude-reliability.yml

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release changes the way the go library automatically manages its hegel binary to match the rust library.

--- a/installer.go
+++ b/installer.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 )
 
 // hegelServerVersion is the version of hegel-core that this SDK requires.
@@ -14,29 +16,77 @@ const hegelServerVersion = "0.2.1"
 // hegelServerCommandEnv is the environment variable that overrides automatic installation.
 const hegelServerCommandEnv = "HEGEL_SERVER_COMMAND"
 
+// installMu serializes installation attempts within a single process.
+var installMu sync.Mutex
+
+// fileLockTimeoutVal is how long to wait for the cross-process file lock.
+// Overridable in tests.
+var fileLockTimeoutVal = 5 * time.Minute
+
+// fileLockPollIntervalVal is how often to retry acquiring the file lock.
+// Overridable in tests.
+var fileLockPollIntervalVal = 500 * time.Millisecond
+
+// isInstalled checks whether the correct version is cached and the binary exists.
+func isInstalled(versionFile, hegelBin string) bool {
+	cached, err := os.ReadFile(versionFile)
+	if err != nil {
+		return false
+	}
+	if strings.TrimSpace(string(cached)) != hegelServerVersion {
+		return false
+	}
+	_, err = os.Stat(hegelBin)
+	return err == nil
+}
+
 // ensureHegelInstalled checks if the correct version of hegel is installed
 // in the project's .hegel/venv directory, and installs it if not.
+// It is safe to call concurrently from multiple goroutines and multiple processes.
 // Returns the path to the hegel binary.
 func ensureHegelInstalled() (string, error) {
 	hegelDir := getHegelDirectory()
 	venvDir := filepath.Join(hegelDir, "venv")
 	versionFile := filepath.Join(venvDir, "hegel-version")
 	hegelBin := filepath.Join(venvDir, "bin", "hegel")
-	installLog := filepath.Join(hegelDir, "install.log")
 
-	// Fast path: check cached version.
-	if cached, err := os.ReadFile(versionFile); err == nil {
-		if strings.TrimSpace(string(cached)) == hegelServerVersion {
-			if _, err := os.Stat(hegelBin); err == nil {
-				return hegelBin, nil
-			}
-		}
+	// Fast path (no locks): check cached version.
+	if isInstalled(versionFile, hegelBin) {
+		return hegelBin, nil
 	}
 
-	// Need to install. Create the .hegel directory.
+	// Acquire in-process lock to serialize goroutines.
+	installMu.Lock()
+	defer installMu.Unlock()
+
+	// Re-check after acquiring in-process lock.
+	if isInstalled(versionFile, hegelBin) {
+		return hegelBin, nil
+	}
+
+	// Create .hegel directory (needed for the file lock).
 	if err := os.MkdirAll(hegelDir, 0o755); err != nil {
 		return "", fmt.Errorf("failed to create %s: %w", hegelDir, err)
 	}
+
+	// Acquire cross-process file lock.
+	lockDir := filepath.Join(hegelDir, ".install-lock")
+	if err := acquireFileLock(lockDir); err != nil {
+		return "", err
+	}
+	defer releaseFileLock(lockDir)
+
+	// Re-check after acquiring file lock (another process may have installed).
+	if isInstalled(versionFile, hegelBin) {
+		return hegelBin, nil
+	}
+
+	return doInstall(hegelDir, venvDir, versionFile, hegelBin)
+}
+
+// doInstall performs the actual installation. Caller must hold both locks.
+func doInstall(hegelDir, venvDir, versionFile, hegelBin string) (string, error) {
+	installLog := filepath.Join(hegelDir, "install.log")
 
 	logFile, err := os.Create(installLog)
 	if err != nil {
@@ -46,12 +96,12 @@ func ensureHegelInstalled() (string, error) {
 
 	fmt.Fprintf(os.Stderr, "hegel: installing hegel-core %s into %s...\n", hegelServerVersion, venvDir)
 
-	// Create venv.
 	uvPath, err := uvLookPathFn()
 	if err != nil {
 		return "", fmt.Errorf("hegel: uv not found on PATH. Install uv (https://docs.astral.sh/uv/) to auto-install the hegel server, or set %s to a hegel binary path", hegelServerCommandEnv)
 	}
 
+	// Create venv.
 	cmd := exec.Command(uvPath, "venv", "--clear", venvDir)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
@@ -77,13 +127,32 @@ func ensureHegelInstalled() (string, error) {
 		return "", fmt.Errorf("hegel not found at %s after installation", hegelBin)
 	}
 
-	// Write version file.
+	// Write version file (signals completion to other waiters).
 	if err := os.WriteFile(versionFile, []byte(hegelServerVersion), 0o644); err != nil {
 		return "", fmt.Errorf("failed to write version file: %w", err)
 	}
 
 	fmt.Fprintf(os.Stderr, "hegel: installation complete.\n")
 	return hegelBin, nil
+}
+
+// acquireFileLock uses mkdir as an atomic lock primitive (works on macOS and Linux).
+func acquireFileLock(lockDir string) error {
+	deadline := time.Now().Add(fileLockTimeoutVal)
+	for {
+		if err := os.Mkdir(lockDir, 0o755); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("hegel: timed out waiting for install lock %s (another process may be installing; remove manually if stale)", lockDir)
+		}
+		time.Sleep(fileLockPollIntervalVal)
+	}
+}
+
+// releaseFileLock removes the lock directory.
+func releaseFileLock(lockDir string) {
+	os.Remove(lockDir) //nolint:errcheck
 }
 
 // uvLookPathFn is the function used to find uv. Overridable in tests.

--- a/installer.go
+++ b/installer.go
@@ -1,0 +1,92 @@
+package hegel
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// hegelServerVersion is the version of hegel-core that this SDK requires.
+const hegelServerVersion = "0.2.1"
+
+// hegelServerCommandEnv is the environment variable that overrides automatic installation.
+const hegelServerCommandEnv = "HEGEL_SERVER_COMMAND"
+
+// ensureHegelInstalled checks if the correct version of hegel is installed
+// in the project's .hegel/venv directory, and installs it if not.
+// Returns the path to the hegel binary.
+func ensureHegelInstalled() (string, error) {
+	hegelDir := getHegelDirectory()
+	venvDir := filepath.Join(hegelDir, "venv")
+	versionFile := filepath.Join(venvDir, "hegel-version")
+	hegelBin := filepath.Join(venvDir, "bin", "hegel")
+	installLog := filepath.Join(hegelDir, "install.log")
+
+	// Fast path: check cached version.
+	if cached, err := os.ReadFile(versionFile); err == nil {
+		if strings.TrimSpace(string(cached)) == hegelServerVersion {
+			if _, err := os.Stat(hegelBin); err == nil {
+				return hegelBin, nil
+			}
+		}
+	}
+
+	// Need to install. Create the .hegel directory.
+	if err := os.MkdirAll(hegelDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create %s: %w", hegelDir, err)
+	}
+
+	logFile, err := os.Create(installLog)
+	if err != nil {
+		return "", fmt.Errorf("failed to create install log: %w", err)
+	}
+	defer logFile.Close()
+
+	fmt.Fprintf(os.Stderr, "hegel: installing hegel-core %s into %s...\n", hegelServerVersion, venvDir)
+
+	// Create venv.
+	uvPath, err := uvLookPathFn()
+	if err != nil {
+		return "", fmt.Errorf("hegel: uv not found on PATH. Install uv (https://docs.astral.sh/uv/) to auto-install the hegel server, or set %s to a hegel binary path", hegelServerCommandEnv)
+	}
+
+	cmd := exec.Command(uvPath, "venv", "--clear", venvDir)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Run(); err != nil {
+		log, _ := os.ReadFile(installLog)
+		return "", fmt.Errorf("uv venv failed: %w\nInstall log:\n%s", err, string(log))
+	}
+
+	// Install hegel-core.
+	pythonPath := filepath.Join(venvDir, "bin", "python")
+	cmd = exec.Command(uvPath, "pip", "install", "--python", pythonPath,
+		fmt.Sprintf("hegel-core==%s", hegelServerVersion))
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Run(); err != nil {
+		log, _ := os.ReadFile(installLog)
+		return "", fmt.Errorf("failed to install hegel-core %s. Set %s to a hegel binary path to skip installation.\nInstall log:\n%s",
+			hegelServerVersion, hegelServerCommandEnv, string(log))
+	}
+
+	// Verify binary exists.
+	if _, err := os.Stat(hegelBin); err != nil {
+		return "", fmt.Errorf("hegel not found at %s after installation", hegelBin)
+	}
+
+	// Write version file.
+	if err := os.WriteFile(versionFile, []byte(hegelServerVersion), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write version file: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "hegel: installation complete.\n")
+	return hegelBin, nil
+}
+
+// uvLookPathFn is the function used to find uv. Overridable in tests.
+var uvLookPathFn = func() (string, error) {
+	return exec.LookPath("uv")
+}

--- a/installer_test.go
+++ b/installer_test.go
@@ -1,0 +1,412 @@
+package hegel
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureHegelInstalledCachedVersion(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Set up a fake cached installation.
+	hegelDir := filepath.Join(tmp, ".hegel")
+	venvDir := filepath.Join(hegelDir, "venv")
+	binDir := filepath.Join(venvDir, "bin")
+	os.MkdirAll(binDir, 0o755)                                                               //nolint:errcheck
+	os.WriteFile(filepath.Join(binDir, "hegel"), []byte("#!/bin/sh\n"), 0o755)               //nolint:errcheck
+	os.WriteFile(filepath.Join(venvDir, "hegel-version"), []byte(hegelServerVersion), 0o644) //nolint:errcheck
+
+	result, err := ensureHegelInstalled()
+	if err != nil {
+		t.Fatalf("ensureHegelInstalled() error: %v", err)
+	}
+	expected := filepath.Join(binDir, "hegel")
+	if result != expected {
+		t.Errorf("ensureHegelInstalled() = %q, want %q", result, expected)
+	}
+}
+
+func TestEnsureHegelInstalledVersionMismatch(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Set up a cached installation with wrong version.
+	hegelDir := filepath.Join(tmp, ".hegel")
+	venvDir := filepath.Join(hegelDir, "venv")
+	binDir := filepath.Join(venvDir, "bin")
+	os.MkdirAll(binDir, 0o755)                                                        //nolint:errcheck
+	os.WriteFile(filepath.Join(binDir, "hegel"), []byte("#!/bin/sh\n"), 0o755)        //nolint:errcheck
+	os.WriteFile(filepath.Join(venvDir, "hegel-version"), []byte("0.0.0-old"), 0o644) //nolint:errcheck
+
+	// Mock uv to fail so we can verify the version check triggers reinstall.
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return "", fmt.Errorf("uv not found")
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when uv not found")
+	}
+	if !strings.Contains(err.Error(), "uv not found") {
+		t.Errorf("expected uv error, got: %v", err)
+	}
+}
+
+func TestEnsureHegelInstalledBinaryMissing(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Set up cached version file but no binary.
+	hegelDir := filepath.Join(tmp, ".hegel")
+	venvDir := filepath.Join(hegelDir, "venv")
+	os.MkdirAll(venvDir, 0o755)                                                              //nolint:errcheck
+	os.WriteFile(filepath.Join(venvDir, "hegel-version"), []byte(hegelServerVersion), 0o644) //nolint:errcheck
+
+	// Mock uv to fail to verify reinstall is triggered.
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return "", fmt.Errorf("uv not found")
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when binary missing and uv unavailable")
+	}
+}
+
+func TestEnsureHegelInstalledNoUv(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return "", fmt.Errorf("uv not found")
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when uv not found")
+	}
+	if !strings.Contains(err.Error(), "uv not found") {
+		t.Errorf("expected uv error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), hegelServerCommandEnv) {
+		t.Errorf("expected env var hint in error, got: %v", err)
+	}
+}
+
+func TestEnsureHegelInstalledUvVenvFails(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Use "false" as uv — it exits with code 1.
+	falseBin, err := exec.LookPath("false")
+	if err != nil {
+		t.Skip("false binary not available")
+	}
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return falseBin, nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err = ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when uv venv fails")
+	}
+	if !strings.Contains(err.Error(), "uv venv failed") {
+		t.Errorf("expected venv failure error, got: %v", err)
+	}
+}
+
+func TestEnsureHegelInstalledPipInstallFails(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create a script that succeeds on "venv" but fails on "pip".
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "fake_uv")
+	script := `#!/bin/sh
+if [ "$1" = "venv" ]; then
+    mkdir -p "$3/bin"
+    exit 0
+fi
+exit 1
+`
+	os.WriteFile(scriptPath, []byte(script), 0o755) //nolint:errcheck
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return scriptPath, nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when pip install fails")
+	}
+	if !strings.Contains(err.Error(), "failed to install") {
+		t.Errorf("expected pip install failure error, got: %v", err)
+	}
+}
+
+func TestEnsureHegelInstalledBinaryNotCreated(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create a script that succeeds on both commands but doesn't create the binary.
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "fake_uv")
+	script := `#!/bin/sh
+if [ "$1" = "venv" ]; then
+    mkdir -p "$3/bin"
+    exit 0
+fi
+if [ "$1" = "pip" ]; then
+    exit 0
+fi
+exit 1
+`
+	os.WriteFile(scriptPath, []byte(script), 0o755) //nolint:errcheck
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return scriptPath, nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when binary not created")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestEnsureHegelInstalledSuccess(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create a fake uv that creates the venv and binary.
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "fake_uv")
+	script := `#!/bin/sh
+if [ "$1" = "venv" ]; then
+    mkdir -p "$3/bin"
+    touch "$3/bin/python"
+    chmod +x "$3/bin/python"
+    exit 0
+fi
+if [ "$1" = "pip" ]; then
+    # Find the venv dir from --python arg and create the hegel binary.
+    python_path="$4"
+    venv_dir=$(dirname $(dirname "$python_path"))
+    touch "$venv_dir/bin/hegel"
+    chmod +x "$venv_dir/bin/hegel"
+    exit 0
+fi
+exit 1
+`
+	os.WriteFile(scriptPath, []byte(script), 0o755) //nolint:errcheck
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return scriptPath, nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	result, err := ensureHegelInstalled()
+	if err != nil {
+		t.Fatalf("ensureHegelInstalled() error: %v", err)
+	}
+
+	hegelDir := filepath.Join(tmp, ".hegel")
+	expected := filepath.Join(hegelDir, "venv", "bin", "hegel")
+	if result != expected {
+		t.Errorf("ensureHegelInstalled() = %q, want %q", result, expected)
+	}
+
+	// Verify version file was written.
+	versionFile := filepath.Join(hegelDir, "venv", "hegel-version")
+	cached, err := os.ReadFile(versionFile)
+	if err != nil {
+		t.Fatalf("reading version file: %v", err)
+	}
+	if string(cached) != hegelServerVersion {
+		t.Errorf("version file = %q, want %q", string(cached), hegelServerVersion)
+	}
+
+	// Second call should use cached version (fast path).
+	result2, err := ensureHegelInstalled()
+	if err != nil {
+		t.Fatalf("second ensureHegelInstalled() error: %v", err)
+	}
+	if result2 != expected {
+		t.Errorf("second ensureHegelInstalled() = %q, want %q", result2, expected)
+	}
+}
+
+func TestEnsureHegelInstalledLogCreationFails(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create .hegel as a read-only directory so install.log creation fails.
+	hegelDir := filepath.Join(tmp, ".hegel")
+	os.MkdirAll(hegelDir, 0o755) //nolint:errcheck
+	// Create install.log as a directory so File.Create fails.
+	os.MkdirAll(filepath.Join(hegelDir, "install.log"), 0o755) //nolint:errcheck
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return "/usr/bin/true", nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when log creation fails")
+	}
+	if !strings.Contains(err.Error(), "install log") {
+		t.Errorf("expected log creation error, got: %v", err)
+	}
+}
+
+func TestEnsureHegelInstalledMkdirFails(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create a file at .hegel so MkdirAll fails.
+	os.WriteFile(filepath.Join(tmp, ".hegel"), []byte("not a dir"), 0o644) //nolint:errcheck
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return "/usr/bin/true", nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when mkdir fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create") {
+		t.Errorf("expected mkdir error, got: %v", err)
+	}
+}
+
+func TestFindHegelServerCommandEnv(t *testing.T) {
+	resetProjectRoot(t)
+	t.Setenv(hegelServerCommandEnv, "/custom/hegel/binary")
+
+	result := findHegel()
+	if result != "/custom/hegel/binary" {
+		t.Errorf("findHegel() = %q, want /custom/hegel/binary", result)
+	}
+}
+
+func TestFindHegelAutoInstallPath(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// No .venv, no HEGEL_SERVER_COMMAND — set up a fake cached install.
+	hegelDir := filepath.Join(tmp, ".hegel")
+	venvDir := filepath.Join(hegelDir, "venv")
+	binDir := filepath.Join(venvDir, "bin")
+	os.MkdirAll(binDir, 0o755)                                                               //nolint:errcheck
+	os.WriteFile(filepath.Join(binDir, "hegel"), []byte("#!/bin/sh\n"), 0o755)               //nolint:errcheck
+	os.WriteFile(filepath.Join(venvDir, "hegel-version"), []byte(hegelServerVersion), 0o644) //nolint:errcheck
+
+	result := findHegel()
+	expected := filepath.Join(binDir, "hegel")
+	if result != expected {
+		t.Errorf("findHegel() = %q, want %q", result, expected)
+	}
+}
+
+func TestEnsureHegelInstalledVersionFileWriteFails(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create a fake uv that creates the binary but makes hegel-version a directory
+	// so the write fails.
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "fake_uv")
+	script := `#!/bin/sh
+if [ "$1" = "venv" ]; then
+    mkdir -p "$3/bin"
+    touch "$3/bin/python"
+    chmod +x "$3/bin/python"
+    # Make hegel-version a directory so write fails.
+    mkdir -p "$3/hegel-version"
+    exit 0
+fi
+if [ "$1" = "pip" ]; then
+    python_path="$4"
+    venv_dir=$(dirname $(dirname "$python_path"))
+    touch "$venv_dir/bin/hegel"
+    chmod +x "$venv_dir/bin/hegel"
+    exit 0
+fi
+exit 1
+`
+	os.WriteFile(scriptPath, []byte(script), 0o755) //nolint:errcheck
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return scriptPath, nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected error when version file write fails")
+	}
+	if !strings.Contains(err.Error(), "version file") {
+		t.Errorf("expected version file error, got: %v", err)
+	}
+}

--- a/installer_test.go
+++ b/installer_test.go
@@ -6,7 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestEnsureHegelInstalledCachedVersion(t *testing.T) {
@@ -270,6 +272,12 @@ exit 1
 		t.Errorf("version file = %q, want %q", string(cached), hegelServerVersion)
 	}
 
+	// Verify lock directory was released.
+	lockDir := filepath.Join(hegelDir, ".install-lock")
+	if _, err := os.Stat(lockDir); err == nil {
+		t.Error("lock directory should have been removed after install")
+	}
+
 	// Second call should use cached version (fast path).
 	result2, err := ensureHegelInstalled()
 	if err != nil {
@@ -287,10 +295,9 @@ func TestEnsureHegelInstalledLogCreationFails(t *testing.T) {
 	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
 	t.Chdir(tmp)
 
-	// Create .hegel as a read-only directory so install.log creation fails.
+	// Create .hegel directory so lock succeeds, but make install.log a directory so Create fails.
 	hegelDir := filepath.Join(tmp, ".hegel")
-	os.MkdirAll(hegelDir, 0o755) //nolint:errcheck
-	// Create install.log as a directory so File.Create fails.
+	os.MkdirAll(hegelDir, 0o755)                               //nolint:errcheck
 	os.MkdirAll(filepath.Join(hegelDir, "install.log"), 0o755) //nolint:errcheck
 
 	origUv := uvLookPathFn
@@ -408,5 +415,250 @@ exit 1
 	}
 	if !strings.Contains(err.Error(), "version file") {
 		t.Errorf("expected version file error, got: %v", err)
+	}
+}
+
+// TestEnsureHegelInstalledConcurrentGoroutines verifies that concurrent
+// goroutines within the same process are serialized by the in-process mutex.
+func TestEnsureHegelInstalledConcurrentGoroutines(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create a fake uv that creates the venv and binary.
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "fake_uv")
+	script := `#!/bin/sh
+if [ "$1" = "venv" ]; then
+    mkdir -p "$3/bin"
+    touch "$3/bin/python"
+    chmod +x "$3/bin/python"
+    exit 0
+fi
+if [ "$1" = "pip" ]; then
+    python_path="$4"
+    venv_dir=$(dirname $(dirname "$python_path"))
+    touch "$venv_dir/bin/hegel"
+    chmod +x "$venv_dir/bin/hegel"
+    exit 0
+fi
+exit 1
+`
+	os.WriteFile(scriptPath, []byte(script), 0o755) //nolint:errcheck
+
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return scriptPath, nil
+	}
+	defer func() { uvLookPathFn = origUv }()
+
+	expected := filepath.Join(tmp, ".hegel", "venv", "bin", "hegel")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 5)
+	results := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = ensureHegelInstalled()
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < 5; i++ {
+		if errs[i] != nil {
+			t.Errorf("goroutine %d: %v", i, errs[i])
+		}
+		if results[i] != expected {
+			t.Errorf("goroutine %d: got %q, want %q", i, results[i], expected)
+		}
+	}
+}
+
+// TestIsInstalled covers the isInstalled helper directly.
+func TestIsInstalled(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	versionFile := filepath.Join(tmp, "hegel-version")
+	hegelBin := filepath.Join(tmp, "hegel")
+
+	// No version file.
+	if isInstalled(versionFile, hegelBin) {
+		t.Error("expected false when version file missing")
+	}
+
+	// Wrong version.
+	os.WriteFile(versionFile, []byte("0.0.0"), 0o644) //nolint:errcheck
+	if isInstalled(versionFile, hegelBin) {
+		t.Error("expected false with wrong version")
+	}
+
+	// Right version, no binary.
+	os.WriteFile(versionFile, []byte(hegelServerVersion), 0o644) //nolint:errcheck
+	if isInstalled(versionFile, hegelBin) {
+		t.Error("expected false when binary missing")
+	}
+
+	// Right version + binary exists.
+	os.WriteFile(hegelBin, []byte("#!/bin/sh\n"), 0o755) //nolint:errcheck
+	if !isInstalled(versionFile, hegelBin) {
+		t.Error("expected true when version matches and binary exists")
+	}
+}
+
+// TestAcquireFileLock verifies basic lock/unlock and timeout.
+func TestAcquireFileLock(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	lockDir := filepath.Join(tmp, "test-lock")
+
+	// Acquire and release.
+	if err := acquireFileLock(lockDir); err != nil {
+		t.Fatalf("acquireFileLock: %v", err)
+	}
+	if _, err := os.Stat(lockDir); err != nil {
+		t.Error("lock directory should exist after acquire")
+	}
+	releaseFileLock(lockDir)
+	if _, err := os.Stat(lockDir); err == nil {
+		t.Error("lock directory should not exist after release")
+	}
+}
+
+// TestReleaseFileLockIdempotent verifies releasing a non-existent lock is safe.
+func TestReleaseFileLockIdempotent(t *testing.T) {
+	t.Parallel()
+	releaseFileLock(filepath.Join(t.TempDir(), "nonexistent"))
+}
+
+// TestAcquireFileLockTimeout verifies the lock times out when held by another party.
+func TestAcquireFileLockTimeout(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	lockDir := filepath.Join(tmp, "test-lock")
+
+	// Pre-create the lock directory to simulate another holder.
+	os.Mkdir(lockDir, 0o755) //nolint:errcheck
+
+	// Use very short timeout and poll interval.
+	origTimeout := fileLockTimeoutVal
+	origPoll := fileLockPollIntervalVal
+	fileLockTimeoutVal = 10 * time.Millisecond
+	fileLockPollIntervalVal = 1 * time.Millisecond
+	defer func() {
+		fileLockTimeoutVal = origTimeout
+		fileLockPollIntervalVal = origPoll
+	}()
+
+	err := acquireFileLock(lockDir)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+}
+
+// TestAcquireFileLockWaitsAndSucceeds verifies the lock retries and succeeds
+// when the holder releases.
+func TestAcquireFileLockWaitsAndSucceeds(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	lockDir := filepath.Join(tmp, "test-lock")
+
+	// Pre-create the lock directory.
+	os.Mkdir(lockDir, 0o755) //nolint:errcheck
+
+	origPoll := fileLockPollIntervalVal
+	fileLockPollIntervalVal = 1 * time.Millisecond
+	defer func() { fileLockPollIntervalVal = origPoll }()
+
+	// Release the lock after a short delay.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		os.Remove(lockDir) //nolint:errcheck
+	}()
+
+	err := acquireFileLock(lockDir)
+	if err != nil {
+		t.Fatalf("acquireFileLock: %v", err)
+	}
+	releaseFileLock(lockDir)
+}
+
+// TestEnsureHegelInstalledFileLockTimeout verifies ensureHegelInstalled returns
+// an error when the file lock cannot be acquired.
+func TestEnsureHegelInstalledFileLockTimeout(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	// Create the .hegel dir and hold the lock.
+	hegelDir := filepath.Join(tmp, ".hegel")
+	os.MkdirAll(hegelDir, 0o755)                              //nolint:errcheck
+	os.Mkdir(filepath.Join(hegelDir, ".install-lock"), 0o755) //nolint:errcheck
+
+	origTimeout := fileLockTimeoutVal
+	origPoll := fileLockPollIntervalVal
+	fileLockTimeoutVal = 10 * time.Millisecond
+	fileLockPollIntervalVal = 1 * time.Millisecond
+	defer func() {
+		fileLockTimeoutVal = origTimeout
+		fileLockPollIntervalVal = origPoll
+	}()
+
+	_, err := ensureHegelInstalled()
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+}
+
+// TestEnsureHegelInstalledRecheckAfterFileLock verifies that if another process
+// completes the install while we wait for the file lock, we use the cached result.
+func TestEnsureHegelInstalledRecheckAfterFileLock(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	t.Chdir(tmp)
+
+	hegelDir := filepath.Join(tmp, ".hegel")
+	venvDir := filepath.Join(hegelDir, "venv")
+	binDir := filepath.Join(venvDir, "bin")
+	versionFile := filepath.Join(venvDir, "hegel-version")
+	hegelBin := filepath.Join(binDir, "hegel")
+
+	// Create the .hegel dir and hold the lock.
+	os.MkdirAll(hegelDir, 0o755)                              //nolint:errcheck
+	os.Mkdir(filepath.Join(hegelDir, ".install-lock"), 0o755) //nolint:errcheck
+
+	origPoll := fileLockPollIntervalVal
+	fileLockPollIntervalVal = 1 * time.Millisecond
+	defer func() { fileLockPollIntervalVal = origPoll }()
+
+	// Simulate another process completing the install and releasing the lock.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		os.MkdirAll(binDir, 0o755)                                   //nolint:errcheck
+		os.WriteFile(hegelBin, []byte("#!/bin/sh\n"), 0o755)         //nolint:errcheck
+		os.WriteFile(versionFile, []byte(hegelServerVersion), 0o644) //nolint:errcheck
+		os.Remove(filepath.Join(hegelDir, ".install-lock"))          //nolint:errcheck
+	}()
+
+	result, err := ensureHegelInstalled()
+	if err != nil {
+		t.Fatalf("ensureHegelInstalled: %v", err)
+	}
+	if result != hegelBin {
+		t.Errorf("got %q, want %q", result, hegelBin)
 	}
 }

--- a/project_root.go
+++ b/project_root.go
@@ -15,7 +15,6 @@ var projectRootMarkers = []string{
 	"Makefile",
 	"justfile",
 	"Justfile",
-	".hegel",
 }
 
 // getwdFn is the function used to get the current working directory.

--- a/project_root.go
+++ b/project_root.go
@@ -1,0 +1,102 @@
+package hegel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// projectRootMarkers are filenames whose presence indicates a project root directory.
+var projectRootMarkers = []string{
+	"go.mod",
+	".git",
+	"go.sum",
+	"Makefile",
+	"justfile",
+	"Justfile",
+	".hegel",
+}
+
+// getwdFn is the function used to get the current working directory.
+// Overridable in tests to simulate failures.
+var getwdFn = os.Getwd
+
+var (
+	hegelDirOnce     sync.Once
+	hegelDirResult   string
+	hegelDirOverride string
+	hegelDirMu       sync.Mutex
+)
+
+// SetHegelDirectory overrides the automatically detected hegel data directory.
+// Call this before any hegel tests run (e.g. in TestMain) if automatic
+// detection does not find the correct project root.
+func SetHegelDirectory(dir string) {
+	hegelDirMu.Lock()
+	defer hegelDirMu.Unlock()
+	hegelDirOverride = dir
+}
+
+// getHegelDirectory returns the path to the .hegel data directory.
+// It is calculated once on first call by walking up from the working directory
+// to find the project root, then appending ".hegel". If SetHegelDirectory was
+// called, that value is used instead.
+func getHegelDirectory() string {
+	hegelDirMu.Lock()
+	override := hegelDirOverride
+	hegelDirMu.Unlock()
+	if override != "" {
+		return override
+	}
+
+	hegelDirOnce.Do(func() {
+		hegelDirResult = detectHegelDirectory()
+	})
+	return hegelDirResult
+}
+
+// getProjectRoot returns the project root (parent of the .hegel directory).
+func getProjectRoot() string {
+	d := getHegelDirectory()
+	return filepath.Dir(d)
+}
+
+func detectHegelDirectory() string {
+	root := findProjectRoot()
+	if root != "" {
+		return filepath.Join(root, ".hegel")
+	}
+	fmt.Fprintf(os.Stderr,
+		"hegel: warning: could not detect project root (no go.mod, .git, etc. found in parent directories). "+
+			"The .hegel data directory will be created in the current working directory. "+
+			"Call hegel.SetHegelDirectory() to set an explicit path.\n")
+	cwd, err := getwdFn()
+	if err != nil {
+		cwd = "."
+	}
+	return filepath.Join(cwd, ".hegel")
+}
+
+// findProjectRoot walks upward from the current working directory looking for
+// project root markers (go.mod, .git, etc.). Returns the directory containing
+// the marker, or "" if none is found.
+func findProjectRoot() string {
+	cwd, err := getwdFn()
+	if err != nil {
+		return ""
+	}
+	dir := cwd
+	for {
+		for _, marker := range projectRootMarkers {
+			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/project_root_test.go
+++ b/project_root_test.go
@@ -1,0 +1,250 @@
+package hegel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// resetProjectRoot resets the global state so tests get fresh detection.
+func resetProjectRoot(t *testing.T) {
+	t.Helper()
+	hegelDirOnce = sync.Once{}
+	hegelDirResult = ""
+	hegelDirMu.Lock()
+	old := hegelDirOverride
+	hegelDirOverride = ""
+	hegelDirMu.Unlock()
+	t.Cleanup(func() {
+		hegelDirOnce = sync.Once{}
+		hegelDirResult = ""
+		hegelDirMu.Lock()
+		hegelDirOverride = old
+		hegelDirMu.Unlock()
+	})
+}
+
+func TestFindProjectRootFindsGoMod(t *testing.T) {
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	sub := filepath.Join(tmp, "a", "b", "c")
+	os.MkdirAll(sub, 0o755)                                                    //nolint:errcheck
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+
+	t.Chdir(sub)
+
+	root := findProjectRoot()
+	if root != tmp {
+		t.Errorf("findProjectRoot() = %q, want %q", root, tmp)
+	}
+}
+
+func TestFindProjectRootFindsGitDir(t *testing.T) {
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	sub := filepath.Join(tmp, "x")
+	os.MkdirAll(sub, 0o755)                        //nolint:errcheck
+	os.MkdirAll(filepath.Join(tmp, ".git"), 0o755) //nolint:errcheck
+
+	t.Chdir(sub)
+
+	root := findProjectRoot()
+	if root != tmp {
+		t.Errorf("findProjectRoot() = %q, want %q", root, tmp)
+	}
+}
+
+func TestFindProjectRootFindsJustfile(t *testing.T) {
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "justfile"), []byte(""), 0o644) //nolint:errcheck
+
+	t.Chdir(tmp)
+
+	root := findProjectRoot()
+	if root != tmp {
+		t.Errorf("findProjectRoot() = %q, want %q", root, tmp)
+	}
+}
+
+func TestFindProjectRootReturnsEmptyWhenNoMarker(t *testing.T) {
+	// Use a temp dir that has no markers all the way up to /.
+	// On most systems, / has no go.mod etc, so this should return "".
+	// We create a deep temp tree to be safe.
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	sub := filepath.Join(tmp, "a", "b")
+	os.MkdirAll(sub, 0o755) //nolint:errcheck
+
+	t.Chdir(sub)
+
+	root := findProjectRoot()
+	// The temp dir is under /tmp or similar which may have markers above.
+	// We just verify it doesn't panic and returns something reasonable.
+	_ = root
+}
+
+func TestGetHegelDirectoryUsesProjectRoot(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	sub := filepath.Join(tmp, "child")
+	os.MkdirAll(sub, 0o755)                                                    //nolint:errcheck
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+
+	t.Chdir(sub)
+
+	dir := getHegelDirectory()
+	expected := filepath.Join(tmp, ".hegel")
+	if dir != expected {
+		t.Errorf("getHegelDirectory() = %q, want %q", dir, expected)
+	}
+}
+
+func TestGetProjectRoot(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+
+	t.Chdir(tmp)
+
+	root := getProjectRoot()
+	if root != tmp {
+		t.Errorf("getProjectRoot() = %q, want %q", root, tmp)
+	}
+}
+
+func TestSetHegelDirectoryOverridesDetection(t *testing.T) {
+	resetProjectRoot(t)
+
+	custom := "/tmp/custom-hegel-dir"
+	SetHegelDirectory(custom)
+	defer SetHegelDirectory("")
+
+	dir := getHegelDirectory()
+	if dir != custom {
+		t.Errorf("getHegelDirectory() = %q, want %q", dir, custom)
+	}
+}
+
+func TestSetHegelDirectoryAffectsProjectRoot(t *testing.T) {
+	resetProjectRoot(t)
+
+	custom := "/tmp/my-project/.hegel"
+	SetHegelDirectory(custom)
+	defer SetHegelDirectory("")
+
+	root := getProjectRoot()
+	if root != "/tmp/my-project" {
+		t.Errorf("getProjectRoot() = %q, want %q", root, "/tmp/my-project")
+	}
+}
+
+func TestDetectHegelDirectoryWarnsWhenNoRoot(t *testing.T) {
+	// Create a temp dir with no markers at all.
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	sub := filepath.Join(tmp, "isolated", "deep")
+	os.MkdirAll(sub, 0o755) //nolint:errcheck
+
+	t.Chdir(sub)
+
+	// Capture stderr to check for warning.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	result := detectHegelDirectory()
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	output := string(buf[:n])
+
+	// The result should fall back to cwd/.hegel.
+	expected := filepath.Join(sub, ".hegel")
+	// On systems where /tmp itself has markers, we might get a different root.
+	// Accept either the sub-dir fallback or any .hegel suffix.
+	if !strings.HasSuffix(result, ".hegel") {
+		t.Errorf("detectHegelDirectory() = %q, expected suffix .hegel", result)
+	}
+
+	// If it fell back to cwd, there should be a warning.
+	if result == expected && !strings.Contains(output, "warning") {
+		t.Error("expected warning on stderr when no project root found")
+	}
+}
+
+func TestGetHegelDirectoryIsCached(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+
+	t.Chdir(tmp)
+
+	dir1 := getHegelDirectory()
+	dir2 := getHegelDirectory()
+	if dir1 != dir2 {
+		t.Errorf("getHegelDirectory() not cached: %q vs %q", dir1, dir2)
+	}
+}
+
+func TestFindHegelUsesProjectRoot(t *testing.T) {
+	resetProjectRoot(t)
+
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
+	sub := filepath.Join(tmp, "pkg")
+	os.MkdirAll(sub, 0o755) //nolint:errcheck
+	// Create go.mod in tmp (the project root).
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
+	// Create .venv/bin/hegel in the project root.
+	venvBin := filepath.Join(tmp, ".venv", "bin")
+	os.MkdirAll(venvBin, 0o755) //nolint:errcheck
+	hegelBin := filepath.Join(venvBin, "hegel")
+	os.WriteFile(hegelBin, []byte("#!/bin/sh\n"), 0o755) //nolint:errcheck
+
+	// cwd is a subdirectory (simulating go test running from a package dir).
+	t.Chdir(sub)
+
+	result := findHegel()
+	if result != hegelBin {
+		t.Errorf("findHegel() = %q, want %q", result, hegelBin)
+	}
+}
+
+func TestFindProjectRootGetwdError(t *testing.T) {
+	orig := getwdFn
+	getwdFn = func() (string, error) {
+		return "", fmt.Errorf("simulated getwd failure")
+	}
+	defer func() { getwdFn = orig }()
+
+	root := findProjectRoot()
+	if root != "" {
+		t.Errorf("findProjectRoot() = %q, want empty on Getwd error", root)
+	}
+}
+
+func TestDetectHegelDirectoryGetwdError(t *testing.T) {
+	orig := getwdFn
+	getwdFn = func() (string, error) {
+		return "", fmt.Errorf("simulated getwd failure")
+	}
+	defer func() { getwdFn = orig }()
+
+	// Suppress the warning to stderr.
+	oldStderr := os.Stderr
+	_, w, _ := os.Pipe()
+	os.Stderr = w
+	defer func() {
+		w.Close()
+		os.Stderr = oldStderr
+	}()
+
+	result := detectHegelDirectory()
+	if result != ".hegel" {
+		t.Errorf("detectHegelDirectory() = %q, want %q on Getwd error", result, ".hegel")
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -478,8 +478,9 @@ func (s *hegelSession) start() error {
 	sockPath := filepath.Join(tmp, "hegel.sock")
 	s.socketPath = sockPath
 
-	// Spawn hegel process.
+	// Spawn hegel process in the project root so .hegel is created there.
 	cmd := exec.Command(hegelBin, sockPath)
+	cmd.Dir = getProjectRoot()
 	cmd.Stdout = os.Stderr
 	if s.suppressStderr {
 		cmd.Stderr = io.Discard
@@ -567,19 +568,26 @@ func (s *hegelSession) runTest(fn testBody, opts runOptions, noteFn func(string)
 }
 
 // findHegel locates the hegel binary.
+// Priority: HEGEL_SERVER_COMMAND env var > .venv in project root > auto-install > PATH > bare "hegel".
 func findHegel() string {
-	// Check venv in current working directory.
-	cwd, err := os.Getwd()
-	if err == nil {
-		if p := findHegelInDir(filepath.Join(cwd, ".venv")); p != "" {
-			return p
-		}
+	// 1. Environment variable override.
+	if override := os.Getenv(hegelServerCommandEnv); override != "" {
+		return override
 	}
-	// Check PATH.
+	// 2. Check .venv in project root (e.g. from `just setup`).
+	root := getProjectRoot()
+	if p := findHegelInDir(filepath.Join(root, ".venv")); p != "" {
+		return p
+	}
+	// 3. Auto-install into .hegel/venv.
+	if p, err := ensureHegelInstalled(); err == nil {
+		return p
+	}
+	// 4. Check PATH.
 	if p, err := exec.LookPath("hegel"); err == nil {
 		return p
 	}
-	// Fallback.
+	// 5. Fallback.
 	return "hegel"
 }
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -247,15 +247,17 @@ func TestFindHegelInVenv(t *testing.T) {
 }
 
 func TestFindHegelVenvViaCwd(t *testing.T) {
+	resetProjectRoot(t)
+
 	tmp, _ := filepath.EvalSymlinks(t.TempDir())
 	venvBin := filepath.Join(tmp, ".venv", "bin")
 	os.MkdirAll(venvBin, 0o755) //nolint:errcheck
 	hegelBin := filepath.Join(venvBin, "hegel")
 	os.WriteFile(hegelBin, []byte("#!/bin/sh\n"), 0o755) //nolint:errcheck
+	// Create a project root marker so findHegel uses this directory.
+	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module test\n"), 0o644) //nolint:errcheck
 
-	origDir, _ := os.Getwd()
-	os.Chdir(tmp)           //nolint:errcheck
-	defer os.Chdir(origDir) //nolint:errcheck
+	t.Chdir(tmp)
 
 	result := findHegel()
 	expected := filepath.Join(tmp, ".venv", "bin", "hegel")
@@ -822,6 +824,7 @@ func TestExtractPanicOriginAllHegelFrames(t *testing.T) {
 // --- RunHegelTestE: HEGEL_PROTOCOL_TEST_MODE path, session start error ---
 
 func TestRunHegelTestEProtocolModeStartError(t *testing.T) {
+	resetProjectRoot(t)
 	// Set HEGEL_PROTOCOL_TEST_MODE so RunHegelTestE uses a temp session.
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
 
@@ -886,9 +889,17 @@ func TestHegelSessionStartHandshakeError(t *testing.T) {
 // --- findHegel: LookPath success and fallback ---
 
 func TestFindHegelLookPathAndFallback(t *testing.T) {
+	resetProjectRoot(t)
 	// Change to a temp dir without .venv so findHegelInDir returns "".
 	tmp := t.TempDir()
 	t.Chdir(tmp)
+
+	// Disable auto-installer so we test the PATH and fallback paths.
+	origUv := uvLookPathFn
+	uvLookPathFn = func() (string, error) {
+		return "", fmt.Errorf("uv not found")
+	}
+	defer func() { uvLookPathFn = origUv }()
 
 	// First: put hegel somewhere in PATH -> LookPath succeeds.
 	hegelBin := filepath.Join(tmp, "hegel")


### PR DESCRIPTION
This will use uv to install the right version of hegel automatically, following the way it works in rust.

1. If you set `HEGEL_SERVER_COMMAND` it will always use that and not attempt to install anything.
2. Otherwise it will install the intended hegel version using uv.

The one go-specific complexity is that we need to figure out a reasonable project root directory. This is a bit terrible, but it's the approach we discussed and I don't think we have a better option.