### PR TITLE
Move over to new stdio based implementation of hegel-core

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Switch from Unix socket transport to stdio-based communication with the hegel-core binary.

--- a/connection.go
+++ b/connection.go
@@ -3,7 +3,7 @@ package hegel
 import (
 	"bytes"
 	"fmt"
-	"net"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -29,12 +29,13 @@ const (
 	stateClient
 )
 
-// connection manages a multiplexed socket with a dedicated reader goroutine.
+// connection manages a multiplexed stream with a dedicated reader goroutine.
 // It is safe to call Close from any goroutine; all other methods must be called
 // from a single goroutine per connection.
 type connection struct {
-	name string
-	conn net.Conn
+	name   string
+	reader io.ReadCloser
+	writer io.WriteCloser
 
 	nextChannelID int
 	channels      map[uint32]*channel
@@ -65,11 +66,13 @@ func (c *connection) serverCrashError() *connectionError {
 	return &connectionError{msg: msg}
 }
 
-// newConnection wraps conn in a new connection and registers the control channel (ID 0).
-func newConnection(conn net.Conn, name string) *connection {
+// newConnection creates a new multiplexed connection from separate reader and writer
+// streams and registers the control channel (ID 0).
+func newConnection(reader io.ReadCloser, writer io.WriteCloser, name string) *connection {
 	c := &connection{
 		name:          name,
-		conn:          conn,
+		reader:        reader,
+		writer:        writer,
 		channels:      make(map[uint32]*channel),
 		state:         stateUnresolved,
 		nextChannelID: 1, // first real channel counter (matches Python's __next_channel_id = 1)
@@ -102,28 +105,23 @@ func (c *connection) SendControlRequest(payload []byte) (any, error) {
 func (c *connection) SendPacket(pkt packet) error {
 	c.writerMu.Lock()
 	defer c.writerMu.Unlock()
-	return writePacket(c.conn, pkt)
+	return writePacket(c.writer, pkt)
 }
 
-// Close shuts down the connection. Closing the socket causes readLoop to exit,
+// Close shuts down the connection. Closing the reader causes readLoop to exit,
 // which closes the done channel and wakes all waiters.
 func (c *connection) Close() {
-	// Shut down the socket to unblock any pending reads.
-	if tc, ok := c.conn.(interface{ CloseRead() error }); ok {
-		tc.CloseRead() //nolint:errcheck
-	}
-
-	_ = c.conn.Close()
+	c.reader.Close() //nolint:errcheck
 	<-c.done
+	c.writer.Close() //nolint:errcheck
 }
 
-// readLoop continuously reads packets from the socket and dispatches them.
-// It exits when readPacket returns an error (e.g. the socket was closed).
+// readLoop continuously reads packets from the reader and dispatches them.
+// It exits when readPacket returns an error (e.g. the stream was closed).
 func (c *connection) readLoop() {
-	defer c.conn.Close()
 	defer close(c.done)
 	for {
-		pkt, err := readPacket(c.conn)
+		pkt, err := readPacket(c.reader)
 		if err != nil {
 			return
 		}

--- a/connection_test.go
+++ b/connection_test.go
@@ -15,7 +15,7 @@ import (
 func clientConnPair(t *testing.T) (*connection, net.Conn) {
 	t.Helper()
 	s, c := socketPair(t)
-	clientConn := newConnection(c, "Client")
+	clientConn := newConnection(c, c, "Client")
 	t.Cleanup(func() { clientConn.Close() })
 
 	// Raw handshake responder: read one packet, reply with "Hegel/0.4".
@@ -44,7 +44,7 @@ func clientConnPair(t *testing.T) (*connection, net.Conn) {
 
 func TestConnectionDone(t *testing.T) {
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	select {
 	case <-conn.done:
 		t.Error("new connection should not be done")
@@ -63,7 +63,7 @@ func TestConnectionDone(t *testing.T) {
 func TestConnectionDoubleClose(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	conn.Close()
 	conn.Close() // must not panic or deadlock
 }
@@ -86,7 +86,7 @@ func TestDoubleSendHandshakeRaises(t *testing.T) {
 func TestSendHandshakeBadResponse(t *testing.T) {
 	t.Parallel()
 	s, c := socketPair(t)
-	clientConn := newConnection(c, "Client")
+	clientConn := newConnection(c, c, "Client")
 
 	go func() {
 		// Read the handshake request and send a bad response.
@@ -138,7 +138,7 @@ func TestNewChannelOddIDs(t *testing.T) {
 func TestNewChannelBeforeHandshakeRaises(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	defer func() {
@@ -154,7 +154,7 @@ func TestNewChannelBeforeHandshakeRaises(t *testing.T) {
 func TestConnectChannelBeforeHandshakeRaises(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	_, err := conn.ConnectChannel(1, "test")
@@ -237,7 +237,7 @@ func TestChannelTimeout(t *testing.T) {
 func TestConnectionClosedWhileWaiting(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 
 	ch := conn.ControlChannel()
 	go func() {
@@ -343,30 +343,6 @@ func TestResultOrErrorReturnsResult(t *testing.T) {
 	n, _ := extractCBORInt(v)
 	if n != 42 {
 		t.Errorf("result = %v, want 42", v)
-	}
-}
-
-// --- connection.Close with CloseRead (TCP conn interface) ---
-
-// closeReadConn wraps a net.Conn and records calls to CloseRead.
-type closeReadConn struct {
-	net.Conn
-	closed bool
-}
-
-func (c *closeReadConn) CloseRead() error {
-	c.closed = true
-	return nil
-}
-
-func TestConnectionCloseCallsCloseRead(t *testing.T) {
-	t.Parallel()
-	s, _ := socketPair(t)
-	cr := &closeReadConn{Conn: s}
-	conn := newConnection(cr, "Test")
-	conn.Close()
-	if !cr.closed {
-		t.Error("expected CloseRead to be called")
 	}
 }
 
@@ -520,7 +496,7 @@ func TestDispatchUnknownChannelRequest(t *testing.T) {
 func TestSendHandshakeVersionSendError(t *testing.T) {
 	t.Parallel()
 	s, c := net.Pipe()
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	// Close both ends so SendRequestRaw fails.
 	s.Close()
 	c.Close()
@@ -536,7 +512,7 @@ func TestSendHandshakeVersionSendError(t *testing.T) {
 func TestSendHandshakeVersionRecvError(t *testing.T) {
 	t.Parallel()
 	s, c := net.Pipe()
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	// Close the peer end immediately after accepting the write.
 	go func() {
 		// Drain the handshake request so SendRequestRaw unblocks, then close.
@@ -575,7 +551,7 @@ func TestNewRequestErrorNonStringKey(t *testing.T) {
 func TestChannelPanicsOnDroppedMessage(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
@@ -607,7 +583,7 @@ func TestSendReplyValueEncodeError(t *testing.T) {
 	s, c := socketPair(t)
 	defer s.Close()
 	defer c.Close()
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 
 	// Build a channel manually without handshake for encode error testing.
 	ch := &channel{conn: conn, channelID: 0, inbox: make(chan any, 1), nextMessageID: 1}
@@ -626,7 +602,7 @@ func TestSendReplyErrorSucceeds(t *testing.T) {
 	s, c := socketPair(t)
 	defer s.Close()
 	defer c.Close()
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	ch := &channel{conn: conn, channelID: 0, inbox: make(chan any, 1), nextMessageID: 1}
 	errc := make(chan error, 1)
 	go func() { errc <- ch.SendReplyError(1, "msg", "Type") }()
@@ -643,7 +619,7 @@ func TestSendReplyErrorSucceeds(t *testing.T) {
 func TestRecvRequestDecodeCBORError(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
@@ -661,7 +637,7 @@ func TestRecvRequestDecodeCBORError(t *testing.T) {
 func TestRecvResponseRawProcessError(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 
 	ch := conn.ControlChannel()
 	// Close connection so processOneMessage returns an error.
@@ -681,7 +657,7 @@ func TestRecvResponseRawProcessError(t *testing.T) {
 func TestReceiveResponseDecodeCBORError(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
@@ -699,7 +675,7 @@ func TestReceiveResponseDecodeCBORError(t *testing.T) {
 func TestReceiveResponseExtractCBORDictError(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
@@ -718,7 +694,7 @@ func TestReceiveResponseExtractCBORDictError(t *testing.T) {
 func TestReceiveResponseRecvError(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 
 	ch := conn.ControlChannel()
 	// Close connection so recvResponseRaw returns an error.
@@ -738,7 +714,7 @@ func TestReceiveResponseRecvError(t *testing.T) {
 func TestProcessOneMessageRouteReplyNilResponses(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
@@ -764,7 +740,7 @@ func TestProcessOneMessageRouteReplyNilResponses(t *testing.T) {
 func TestChannelNameUnnamed(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	// Create a channel with an empty name to exercise the unnamed branch.
@@ -778,7 +754,7 @@ func TestChannelNameUnnamed(t *testing.T) {
 func TestRequestSendError(t *testing.T) {
 	t.Parallel()
 	s, c := net.Pipe()
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	// Close both ends so SendRequestRaw fails.
 	s.Close()
 	c.Close()
@@ -794,7 +770,7 @@ func TestRequestSendError(t *testing.T) {
 
 func TestRecvRequestHappyPath(t *testing.T) {
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
@@ -818,7 +794,7 @@ func TestRecvRequestHappyPath(t *testing.T) {
 
 func TestPendingRequestGetCached(t *testing.T) {
 	s, _ := socketPair(t)
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	defer conn.Close()
 
 	ch := conn.ControlChannel()
@@ -846,7 +822,7 @@ func TestPendingRequestGetCached(t *testing.T) {
 func TestSendControlRequestSendError(t *testing.T) {
 	t.Parallel()
 	s, c := net.Pipe()
-	conn := newConnection(s, "Test")
+	conn := newConnection(s, s, "Test")
 	// Close both ends so SendRequestRaw fails.
 	s.Close()
 	c.Close()

--- a/installer.go
+++ b/installer.go
@@ -11,7 +11,7 @@ import (
 )
 
 // hegelServerVersion is the version of hegel-core that this SDK requires.
-const hegelServerVersion = "0.2.1"
+const hegelServerVersion = "0.2.3"
 
 // hegelServerCommandEnv is the environment variable that overrides automatic installation.
 const hegelServerCommandEnv = "HEGEL_SERVER_COMMAND"

--- a/protocol.go
+++ b/protocol.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"net"
 )
 
 // Wire protocol constants.
@@ -64,17 +63,17 @@ func isEOFLike(err error) bool {
 	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.ErrClosedPipe)
 }
 
-// recvExact reads exactly n bytes from conn.
+// recvExact reads exactly n bytes from r.
 // It returns a *partialPacketError if the connection closes before the first byte,
 // and a plain error if it closes partway through.
-func recvExact(conn net.Conn, n int) ([]byte, error) {
+func recvExact(r io.Reader, n int) ([]byte, error) {
 	if n == 0 {
 		return []byte{}, nil
 	}
 	buf := make([]byte, n)
 	read := 0
 	for read < n {
-		nr, err := conn.Read(buf[read:])
+		nr, err := r.Read(buf[read:])
 		read += nr
 		if err != nil {
 			if isEOFLike(err) {
@@ -89,11 +88,11 @@ func recvExact(conn net.Conn, n int) ([]byte, error) {
 	return buf, nil
 }
 
-// readPacket reads and deserializes a single packet from conn.
+// readPacket reads and deserializes a single packet from r.
 // It validates the magic number, checksum, and terminator byte.
-func readPacket(conn net.Conn) (packet, error) {
+func readPacket(r io.Reader) (packet, error) {
 	// Read the fixed 20-byte header.
-	header, err := recvExact(conn, headerSize)
+	header, err := recvExact(r, headerSize)
 	if err != nil {
 		return packet{}, err
 	}
@@ -114,13 +113,13 @@ func readPacket(conn net.Conn) (packet, error) {
 	}
 
 	// Read payload.
-	payload, err := recvExact(conn, int(payloadLen))
+	payload, err := recvExact(r, int(payloadLen))
 	if err != nil {
 		return packet{}, err
 	}
 
 	// Read terminator.
-	term, err := recvExact(conn, 1)
+	term, err := recvExact(r, 1)
 	if err != nil {
 		return packet{}, err
 	}
@@ -145,9 +144,9 @@ func readPacket(conn net.Conn) (packet, error) {
 	}, nil
 }
 
-// writePacket serializes and writes a packet to conn.
+// writePacket serializes and writes a packet to w.
 // It computes the CRC32 checksum and appends the terminator byte.
-func writePacket(conn net.Conn, pkt packet) error {
+func writePacket(w io.Writer, pkt packet) error {
 	messageID := pkt.MessageID
 	if pkt.IsReply {
 		messageID |= replyBit
@@ -170,6 +169,6 @@ func writePacket(conn net.Conn, pkt packet) error {
 	frame = append(frame, pkt.Payload...)
 	frame = append(frame, terminator)
 
-	_, err := conn.Write(frame)
+	_, err := w.Write(frame)
 	return err
 }

--- a/runner.go
+++ b/runner.go
@@ -3,7 +3,6 @@ package hegel
 import (
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -457,7 +456,7 @@ func (c *client) runTestCase(ch *channel, fn testBody, isFinal bool, noteFn func
 					status = "INTERESTING"
 					origin = "test failed (via t.Error/t.Fail)"
 					if isFinal {
-						finalErr = fmt.Errorf("test failed")
+						finalErr = fmt.Errorf("property test failed: test failed")
 					}
 				}
 				return
@@ -475,13 +474,13 @@ func (c *client) runTestCase(ch *channel, fn testBody, isFinal bool, noteFn func
 				status = "INTERESTING"
 				origin = extractPanicOrigin(v)
 				if isFinal {
-					finalErr = fmt.Errorf("%s", v.msg)
+					finalErr = fmt.Errorf("property test failed: %s", v.msg)
 				}
 			default:
 				status = "INTERESTING"
 				origin = extractPanicOrigin(v)
 				if isFinal {
-					finalErr = fmt.Errorf("%v", v)
+					finalErr = fmt.Errorf("property test failed: %v", v)
 				}
 			}
 		}()
@@ -531,8 +530,6 @@ type hegelSession struct {
 	conn           *connection
 	cli            *client
 	process        *exec.Cmd
-	tempDir        string
-	socketPath     string
 	hegelCmd       string // overridable for testing
 	suppressStderr bool   // suppress hegel subprocess stderr (used for test-mode sessions that intentionally crash)
 	logFile        *os.File
@@ -560,15 +557,11 @@ func (s *hegelSession) serverCrashMessage() string {
 	return "The hegel server process exited unexpectedly."
 }
 
-// mkdirTempFn is the function used to create temp directories.
-// Overridable in tests to simulate failures.
-var mkdirTempFn = os.MkdirTemp
-
 func newHegelSession() *hegelSession {
 	return &hegelSession{}
 }
 
-// start starts the hegel subprocess and connects to it (idempotent).
+// start starts the hegel subprocess and connects via stdio (idempotent).
 func (s *hegelSession) start() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -583,28 +576,28 @@ func (s *hegelSession) start() error {
 		hegelBin = findHegel()
 	}
 
-	// Create temp dir for socket.
-	tmp, err := mkdirTempFn("", "hegel-")
-	if err != nil {
-		return fmt.Errorf("hegel: mktemp: %w", err)
-	}
-	s.tempDir = tmp
-	sockPath := filepath.Join(tmp, "hegel.sock")
-	s.socketPath = sockPath
-
-	// Spawn hegel process in the project root so .hegel is created there.
-	cmd := exec.Command(hegelBin, sockPath)
+	// Spawn hegel process with stdio transport.
+	cmd := exec.Command(hegelBin, "--stdio", "--verbosity", "normal")
 	cmd.Dir = getProjectRoot()
+	cmd.Env = append(os.Environ(), "PYTHONUNBUFFERED=1")
 	logFile := openServerLog()
-	cmd.Stdout = logFile
 	if s.suppressStderr {
 		cmd.Stderr = io.Discard
 	} else {
 		cmd.Stderr = logFile
 	}
 	s.logFile = logFile
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil { //nocov
+		panic(fmt.Sprintf("hegel: unreachable: stdin pipe: %v", err)) //nocov
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil { //nocov
+		panic(fmt.Sprintf("hegel: unreachable: stdout pipe: %v", err)) //nocov
+	}
+
 	if err := cmd.Start(); err != nil {
-		os.RemoveAll(tmp) //nolint:errcheck
 		return fmt.Errorf("hegel: spawn: %w", err)
 	}
 	s.process = cmd
@@ -617,32 +610,7 @@ func (s *hegelSession) start() error {
 		close(processExited)
 	}()
 
-	// Wait for socket to appear and connect, checking for early server exit.
-	var sock net.Conn
-	for i := 0; i < 50; i++ {
-		select {
-		case <-processExited:
-			os.RemoveAll(tmp) //nolint:errcheck
-			return fmt.Errorf("hegel: %s", s.serverCrashMessage())
-		default:
-		}
-		if _, statErr := os.Stat(sockPath); statErr == nil {
-			c, connErr := net.Dial("unix", sockPath)
-			if connErr == nil {
-				sock = c
-				break
-			}
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if sock == nil {
-		cmd.Process.Kill() //nolint:errcheck
-		<-processExited
-		os.RemoveAll(tmp) //nolint:errcheck
-		return fmt.Errorf("hegel: timeout waiting for hegel to start")
-	}
-
-	conn := newConnection(sock, "Client")
+	conn := newConnection(stdoutPipe, stdinPipe, "Client")
 	conn.processExited = processExited
 	conn.crashMessage = s.serverCrashMessage()
 	version, err := conn.SendHandshakeVersion()
@@ -650,7 +618,6 @@ func (s *hegelSession) start() error {
 		conn.Close()
 		cmd.Process.Kill() //nolint:errcheck
 		<-processExited
-		os.RemoveAll(tmp) //nolint:errcheck
 		return fmt.Errorf("hegel: handshake: %w", err)
 	}
 	_ = version // we accept any version for now
@@ -685,11 +652,6 @@ func (s *hegelSession) cleanup() {
 	if s.logFile != nil {
 		s.logFile.Close() //nolint:errcheck
 		s.logFile = nil
-	}
-
-	if s.tempDir != "" {
-		os.RemoveAll(s.tempDir) //nolint:errcheck
-		s.tempDir = ""
 	}
 }
 

--- a/runner.go
+++ b/runner.go
@@ -598,6 +598,12 @@ func (s *hegelSession) start() error {
 	}
 
 	if err := cmd.Start(); err != nil {
+		stdinPipe.Close()
+		stdoutPipe.Close()
+		if logFile != nil {
+			logFile.Close()
+		}
+		s.logFile = nil
 		return fmt.Errorf("hegel: spawn: %w", err)
 	}
 	s.process = cmd
@@ -618,6 +624,11 @@ func (s *hegelSession) start() error {
 		conn.Close()
 		cmd.Process.Kill() //nolint:errcheck
 		<-processExited
+		s.process = nil
+		if s.logFile != nil {
+			s.logFile.Close()
+			s.logFile = nil
+		}
 		return fmt.Errorf("hegel: handshake: %w", err)
 	}
 	_ = version // we accept any version for now

--- a/runner_test.go
+++ b/runner_test.go
@@ -305,25 +305,23 @@ func TestHegelSessionCleanupEmpty(t *testing.T) {
 	s.cleanup() // Should not panic when nothing started.
 }
 
-// --- hegelSession: server exits immediately (early crash detection) ---
+// --- hegelSession: start fails when hegel exits immediately ---
 
-func TestHegelSessionStartServerExitsImmediately(t *testing.T) {
+func TestHegelSessionStartExitsImmediately(t *testing.T) {
 	t.Parallel()
-	// Use `false` (exits immediately) so the process exit is detected before
-	// the socket appears. With the server crash monitor, this triggers
-	// the early exit error rather than a timeout.
+	// Use `false` (exits immediately) so stdio pipes close immediately.
 	falseBin, err := exec.LookPath("false")
 	if err != nil {
 		t.Skip("false binary not available")
 	}
 	s := newHegelSession()
-	s.hegelCmd = falseBin // exits immediately without creating socket
+	s.hegelCmd = falseBin // exits immediately, pipes close
 	startErr := s.start()
 	if startErr == nil {
 		s.cleanup()
-		t.Fatal("expected error")
+		t.Fatal("expected handshake error")
 	}
-	mustContainStr(t, startErr.Error(), "server process exited unexpectedly")
+	mustContainStr(t, startErr.Error(), "handshake")
 }
 
 // --- hegelSession: concurrent starts (double-checked locking) ---
@@ -552,7 +550,7 @@ func TestAbortedFlagDirect(t *testing.T) {
 func TestGenerateFromSchemaConnectionError(t *testing.T) {
 	t.Parallel()
 	s, c := socketPair(t)
-	conn := newConnection(s, "C")
+	conn := newConnection(s, s, "C")
 	c.Close()
 	// We need state=client so NewChannel works.
 	conn.state = stateClient
@@ -583,7 +581,7 @@ func TestGenerateFromSchemaConnectionError(t *testing.T) {
 func TestTargetConnectionError(t *testing.T) {
 	t.Parallel()
 	s, _ := socketPair(t)
-	conn := newConnection(s, "C")
+	conn := newConnection(s, s, "C")
 	conn.state = stateClient
 	ch := &channel{conn: conn, channelID: 1, inbox: make(chan any, 1), nextMessageID: 1}
 	conn.channels[1] = ch
@@ -680,7 +678,7 @@ func TestHegelSessionCleanupWithErrors(t *testing.T) {
 	sc, cc := socketPair(t)
 	sc.Close()
 	cc.Close()
-	s.conn = newConnection(sc, "closed")
+	s.conn = newConnection(sc, sc, "closed")
 	s.conn.Close() // pre-close
 
 	// This should not panic.
@@ -796,9 +794,8 @@ func TestHegelSessionStartInnerCheck(t *testing.T) {
 func TestHegelSessionStartHegelCmd(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	path, _ := exec.LookPath("hegel")
 	s := newHegelSession()
-	s.hegelCmd = path
+	s.hegelCmd = findHegel()
 	defer s.cleanup()
 	if err := s.start(); err != nil {
 		t.Fatalf("start with hegelCmd: %v", err)
@@ -814,16 +811,13 @@ func TestHegelSessionCleanupAllPaths(t *testing.T) {
 	if err := s.start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	// Cleanup should close conn, kill process, remove tempdir.
+	// Cleanup should close conn and kill process.
 	s.cleanup()
 	if s.conn != nil {
 		t.Error("conn should be nil after cleanup")
 	}
 	if s.process != nil {
 		t.Error("process should be nil after cleanup")
-	}
-	if s.tempDir != "" {
-		t.Error("tempDir should be empty after cleanup")
 	}
 }
 
@@ -864,37 +858,15 @@ func TestRunHegelTestEProtocolModeStartError(t *testing.T) {
 	mustContainStr(t, err.Error(), "session start")
 }
 
-// --- hegelSession.start: MkdirTemp error ---
-
-func TestHegelSessionStartMkdirTempError(t *testing.T) {
-	orig := mkdirTempFn
-	mkdirTempFn = func(dir, pattern string) (string, error) {
-		return "", fmt.Errorf("simulated mktemp failure")
-	}
-	defer func() { mkdirTempFn = orig }()
-
-	s := newHegelSession()
-	s.hegelCmd = "hegel" // doesn't matter, mktemp fails first
-	err := s.start()
-	if err == nil {
-		s.cleanup()
-		t.Fatal("expected error from start when mkdirTemp fails")
-	}
-	mustContainStr(t, err.Error(), "mktemp")
-}
-
 // --- hegelSession.start: handshake error ---
 
 func TestHegelSessionStartHandshakeError(t *testing.T) {
 	t.Parallel()
-	// Write a fake hegel binary that creates the socket, accepts one connection,
-	// sends bad handshake data, then exits. This causes SendHandshakeVersion to fail.
+	// Write a fake hegel binary that writes garbage to stdout and exits.
+	// This causes SendHandshakeVersion to fail because the data isn't a valid packet.
 	tmp := t.TempDir()
 	scriptPath := filepath.Join(tmp, "fake_hegel.sh")
-	// The Python one-liner: bind, listen, accept, send garbage, close.
-	script := "#!/bin/sh\n" +
-		`python3 -c "import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1]); s.listen(1); c,_=s.accept(); c.send(b'bad_data\n'); c.close()" "$1"` +
-		"\n"
+	script := "#!/bin/sh\nprintf 'bad_data\\n'\n"
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write script: %v", err)
 	}
@@ -1087,26 +1059,6 @@ func TestCaseNoteFnOnFinal(t *testing.T) {
 	if !noted {
 		t.Error("expected noteFn to be called on final replay")
 	}
-}
-
-// =============================================================================
-// hegelSession.start — mkdirTemp failure
-// =============================================================================
-
-func TestHegelSessionStartMkdirFail(t *testing.T) {
-	oldFn := mkdirTempFn
-	defer func() { mkdirTempFn = oldFn }()
-	mkdirTempFn = func(dir, pattern string) (string, error) {
-		return "", fmt.Errorf("simulated mktemp failure")
-	}
-
-	sess := newHegelSession()
-	sess.hegelCmd = "/nonexistent" // Won't actually be called since mkdirTemp fails first
-	err := sess.start()
-	if err == nil {
-		t.Error("expected start to fail with mkdirTemp error")
-	}
-	mustContainStr(t, err.Error(), "mktemp")
 }
 
 // =============================================================================

--- a/runner_test.go
+++ b/runner_test.go
@@ -1172,7 +1172,7 @@ func TestSuppressAllHealthChecksIntegration(t *testing.T) {
 func TestProcessExitedChannel(t *testing.T) {
 	t.Parallel()
 	s, c := socketPair(t)
-	conn := newConnection(s, "C")
+	conn := newConnection(s, s, "C")
 	defer conn.Close()
 	c.Close()
 
@@ -1211,7 +1211,7 @@ func TestHegelSessionStartTimeout(t *testing.T) {
 	if startErr == nil {
 		t.Fatal("expected timeout error")
 	}
-	mustContainStr(t, startErr.Error(), "timeout")
+	mustContainStr(t, startErr.Error(), "timed out")
 }
 
 // =============================================================================
@@ -1259,7 +1259,7 @@ func TestFlakyGlobalState(t *testing.T) {
 func TestGenerateServerCrashOnRequest(t *testing.T) {
 	t.Parallel()
 	s, c := socketPair(t)
-	conn := newConnection(s, "C")
+	conn := newConnection(s, s, "C")
 	c.Close()
 	conn.state = stateClient
 	ch := &channel{conn: conn, channelID: 1, inbox: make(chan any, 1), dropped: make(chan struct{}), nextMessageID: 1}
@@ -1296,7 +1296,7 @@ func TestGenerateServerCrashOnRequest(t *testing.T) {
 func TestGenerateServerCrashOnGet(t *testing.T) {
 	t.Parallel()
 	s, c := socketPair(t)
-	conn := newConnection(s, "C")
+	conn := newConnection(s, s, "C")
 	conn.state = stateClient
 	ch := &channel{conn: conn, channelID: 1, inbox: make(chan any, 1), dropped: make(chan struct{}), nextMessageID: 1}
 	conn.writerMu.Lock()
@@ -1336,7 +1336,7 @@ func TestGenerateServerCrashOnGet(t *testing.T) {
 func TestProcessOneMessageServerCrash(t *testing.T) {
 	t.Parallel()
 	s, c := socketPair(t)
-	conn := newConnection(s, "C")
+	conn := newConnection(s, s, "C")
 	conn.state = stateClient
 	ch := conn.NewChannel("Test")
 


### PR DESCRIPTION
We're now using stdio rather than unix sockets to communicate with the hegel-core binary in hegel-rust. This moves go over to do the same.