### PR TITLE
Drop golang.org/x/exp/constraints dependency

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Drop the `golang.org/x/exp/constraints` dependency in favor of locally defined `Integer` and `Float` type constraints. These interfaces are identical to the ones from `x/exp` but eliminate an external dependency now that Go's type parameter support is mature.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Drop the `golang.org/x/exp/constraints` dependency in favor of locally defined `integer` and `float` type constraints. These interfaces are identical to the ones from `x/exp` but eliminate an external dependency now that Go's type parameter support is mature.
+Internal refactoring to drop `golang.org/x/exp/constraints` as a dependency.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Drop the `golang.org/x/exp/constraints` dependency in favor of locally defined `Integer` and `Float` type constraints. These interfaces are identical to the ones from `x/exp` but eliminate an external dependency now that Go's type parameter support is mature.
+Drop the `golang.org/x/exp/constraints` dependency in favor of locally defined `integer` and `float` type constraints. These interfaces are identical to the ones from `x/exp` but eliminate an external dependency now that Go's type parameter support is mature.

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module hegel.dev/go/hegel
 
 go 1.26
 
-require (
-	github.com/fxamacker/cbor/v2 v2.9.0
-	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa
-)
+require github.com/fxamacker/cbor/v2 v2.9.0
 
 require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/vladopajic/go-test-coverage/v2 v2.18.4 h1:n4SSFcpHEwiIExCH84ueaa9ADKJ
 github.com/vladopajic/go-test-coverage/v2 v2.18.4/go.mod h1:kg1D8UmMAoIMOXzOpukGbaQUr2fNI95YkpPOFRxGoyI=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa h1:Zt3DZoOFFYkKhDT3v7Lm9FDMEV06GpzjG2jrqW+QTE0=
-golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa/go.mod h1:K79w1Vqn7PoiZn+TkNpx3BUWUQksGO3JcVX6qIjytmA=
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=

--- a/primitives.go
+++ b/primitives.go
@@ -7,12 +7,12 @@ import (
 	"unsafe"
 )
 
-type Integer interface {
+type integer interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
 }
 
-type Float interface {
+type float interface {
 	~float32 | ~float64
 }
 
@@ -52,12 +52,12 @@ func extractFloat(v any) float64 {
 }
 
 // extractIntAs extracts an integer from a CBOR-decoded value and converts it to T.
-func extractIntAs[T Integer](v any) T {
+func extractIntAs[T integer](v any) T {
 	return T(extractInt(v))
 }
 
 // extractFloatAs extracts a float from a CBOR-decoded value and converts it to T.
-func extractFloatAs[T Float](v any) T {
+func extractFloatAs[T float](v any) T {
 	return T(extractFloat(v))
 }
 
@@ -65,7 +65,7 @@ func extractFloatAs[T Float](v any) T {
 // For unbounded generation, use the full range of the type:
 //
 //	hegel.Integers[int](math.MinInt, math.MaxInt)
-func Integers[T Integer](minVal, maxVal T) Generator[T] {
+func Integers[T integer](minVal, maxVal T) Generator[T] {
 	if minVal > maxVal {
 		panic(fmt.Sprintf("hegel: Cannot have max_value=%d < min_value=%d", maxVal, minVal))
 	}
@@ -82,7 +82,7 @@ func Integers[T Integer](minVal, maxVal T) Generator[T] {
 // FloatGenerator configures and generates floating-point values of type T.
 // Use [Floats] to create one, then chain builder methods to configure bounds
 // and behavior. Invalid configurations panic on the first [Draw] call.
-type FloatGenerator[T Float] struct {
+type FloatGenerator[T float] struct {
 	minVal     *float64
 	maxVal     *float64
 	allowNaN   *bool
@@ -97,7 +97,7 @@ type FloatGenerator[T Float] struct {
 //	hegel.Floats[float64]()                         // any float64 including NaN and Inf
 //	hegel.Floats[float64]().Min(0).Max(1)           // bounded [0, 1]
 //	hegel.Floats[float32]().Min(0).ExcludeMin()     // (0, +Inf)
-func Floats[T Float]() FloatGenerator[T] {
+func Floats[T float]() FloatGenerator[T] {
 	return FloatGenerator[T]{}
 }
 

--- a/primitives.go
+++ b/primitives.go
@@ -5,9 +5,16 @@ import (
 	"math/big"
 	"time"
 	"unsafe"
-
-	"golang.org/x/exp/constraints"
 )
+
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+type Float interface {
+	~float32 | ~float64
+}
 
 // --- Built-in generators ---
 
@@ -45,12 +52,12 @@ func extractFloat(v any) float64 {
 }
 
 // extractIntAs extracts an integer from a CBOR-decoded value and converts it to T.
-func extractIntAs[T constraints.Integer](v any) T {
+func extractIntAs[T Integer](v any) T {
 	return T(extractInt(v))
 }
 
 // extractFloatAs extracts a float from a CBOR-decoded value and converts it to T.
-func extractFloatAs[T constraints.Float](v any) T {
+func extractFloatAs[T Float](v any) T {
 	return T(extractFloat(v))
 }
 
@@ -58,7 +65,7 @@ func extractFloatAs[T constraints.Float](v any) T {
 // For unbounded generation, use the full range of the type:
 //
 //	hegel.Integers[int](math.MinInt, math.MaxInt)
-func Integers[T constraints.Integer](minVal, maxVal T) Generator[T] {
+func Integers[T Integer](minVal, maxVal T) Generator[T] {
 	if minVal > maxVal {
 		panic(fmt.Sprintf("hegel: Cannot have max_value=%d < min_value=%d", maxVal, minVal))
 	}
@@ -75,7 +82,7 @@ func Integers[T constraints.Integer](minVal, maxVal T) Generator[T] {
 // FloatGenerator configures and generates floating-point values of type T.
 // Use [Floats] to create one, then chain builder methods to configure bounds
 // and behavior. Invalid configurations panic on the first [Draw] call.
-type FloatGenerator[T constraints.Float] struct {
+type FloatGenerator[T Float] struct {
 	minVal     *float64
 	maxVal     *float64
 	allowNaN   *bool
@@ -90,7 +97,7 @@ type FloatGenerator[T constraints.Float] struct {
 //	hegel.Floats[float64]()                         // any float64 including NaN and Inf
 //	hegel.Floats[float64]().Min(0).Max(1)           // bounded [0, 1]
 //	hegel.Floats[float32]().Min(0).ExcludeMin()     // (0, +Inf)
-func Floats[T constraints.Float]() FloatGenerator[T] {
+func Floats[T Float]() FloatGenerator[T] {
 	return FloatGenerator[T]{}
 }
 


### PR DESCRIPTION
My understanding is golang.org/x/exp/constraints is an unstable package and isn't a great thing to rely on. It seemed easy enough to drop our dependency on it. @lmb thoughts? Can you check this and confirm this is the right thing to do here?