### PR TITLE
downgrade go to v1.25

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,6 @@
 ## Build Commands
 
 ```bash
-just setup              # Install dependencies and hegel binary
 just test               # Run tests with coverage (fails if coverage < 100%)
 just format             # Auto-format code
 just lint               # Check formatting + linting
@@ -11,6 +10,7 @@ just docs               # Build API documentation
 just check              # Run lint + docs + test (full CI check)
 just build-conformance  # Compile conformance binaries to bin/conformance/
 just conformance        # Build conformance binaries + run Python conformance test suite
+go test -run TestName ./...  # Run a single test
 ```
 
 Tests must use `PATH="$(pwd)/.venv/bin:$PATH"` (absolute path) so the `hegel` binary is found.
@@ -98,7 +98,7 @@ Failing to handle StopTest correctly causes `FlakyStrategyDefinition` errors.
 
 ## Tooling Choices
 
-- **Go version**: 1.23.x (installed via `actions/setup-go@v5` in CI)
+- **Go version**: the oldest version supported by go.dev (1.N-1); CI tests 1.N and 1.N-1
 - **Test framework**: `testing` (Go stdlib) — run via `go test -race -coverprofile=coverage.out -covermode=atomic ./...`
 - **Linter**: `go vet` (stdlib) + `staticcheck` v0.7.0 (2026.1) — run via `just lint`
 - **Formatter**: `gofmt` (bundled with Go) — check with `gofmt -l .`, apply with `gofmt -w .`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.23'
+          go-version: stable
 
       - name: Install just
         run: sudo apt-get update && sudo apt-get install -y just
@@ -38,11 +38,14 @@ jobs:
         run: zizmor --format plain .github/
 
   test:
-    name: test
+    name: "test (go ${{ matrix.go-version }})"
     runs-on: ubuntu-latest
     permissions:
       contents: write  # needed for ratchet auto-update
       pull-requests: write  # needed for creating PRs on main
+    strategy:
+      matrix:
+        go-version: [oldstable, stable]
     steps:
       # persist-credentials needed for git push in the auto-update step below
       # For fork PRs, head_ref points to a branch that doesn't exist on the base repo,
@@ -66,13 +69,13 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.23'
+          go-version: ${{ matrix.go-version }}
 
       - name: Run tests
         run: just test
 
       - name: Auto-update coverage annotations and ratchet
-        if: success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: success() && matrix.go-version == 'stable' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -117,7 +120,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.23'
+          go-version: stable
 
       - name: Install just
         run: sudo apt-get update && sudo apt-get install -y just
@@ -145,7 +148,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.23'
+          go-version: stable
 
       - run: just conformance
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch lowers the minimum Go version from 1.26 to 1.25.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module hegel.dev/go/hegel
 
-go 1.26
+go 1.25.0
 
 require github.com/fxamacker/cbor/v2 v2.9.0
 
@@ -10,7 +10,8 @@ require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/aws/aws-sdk-go v1.49.4 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
-	github.com/google/go-github/v82 v82.0.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-github/v56 v56.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -18,7 +19,7 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/narqo/go-badge v0.0.0-20230821190521-c9a75c019a59 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
-	github.com/vladopajic/go-test-coverage/v2 v2.18.4 // indirect
+	github.com/vladopajic/go-test-coverage/v2 v2.18.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/image v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v82 v82.0.0 h1:OH09ESON2QwKCUVMYmMcVu1IFKFoaZHwqYaUtr/MVfk=
-github.com/google/go-github/v82 v82.0.0/go.mod h1:hQ6Xo0VKfL8RZ7z1hSfB4fvISg0QqHOqe9BP0qo+WvM=
+github.com/google/go-github/v56 v56.0.0 h1:TysL7dMa/r7wsQi44BjqlwaHvwlFlqkK8CtBWCX3gb4=
+github.com/google/go-github/v56 v56.0.0/go.mod h1:D8cdcX98YWJvi7TLo7zM4/h8ZTx6u6fwGEkCdisopo0=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -56,8 +56,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vladopajic/go-test-coverage/v2 v2.18.4 h1:n4SSFcpHEwiIExCH84ueaa9ADKJC3RC4F57d0p1CJWY=
-github.com/vladopajic/go-test-coverage/v2 v2.18.4/go.mod h1:kg1D8UmMAoIMOXzOpukGbaQUr2fNI95YkpPOFRxGoyI=
+github.com/vladopajic/go-test-coverage/v2 v2.18.3 h1:rqleIDU37ficXnOosls2QfFRFBQ9+2egI7euGGHuvhI=
+github.com/vladopajic/go-test-coverage/v2 v2.18.3/go.mod h1:QJHP3NJg9YTLxsAtZfZGjV2PsXnUHxy/6ZoDhFsbXFA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=


### PR DESCRIPTION
I don't see that we were using any 1.26 features. And add a CI job for lowest + highest go versions we support.