### PR TITLE
Pin hegel-core to 0.3.0 in conformance recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ build-conformance:
     go build -o bin/conformance ./internal/conformance/cmd/...
 
 conformance: build-conformance
-    uv run --with hegel-core --with pytest --with hypothesis \
+    uv run --with 'hegel-core==0.3.0' --with pytest --with hypothesis \
         pytest tests/conformance/ -v
 
 serve-docs:


### PR DESCRIPTION
We'll want a weekly job to bump this at some point, but right now leaving it unpinned is causing some unrelated PRs to fail, eg https://github.com/hegeldev/hegel-go/pull/39.

<details><summary>Claude-written description</summary>

Pins `hegel-core` to version `0.3.0` in the justfile conformance recipe. This prevents conformance CI jobs from failing on unrelated PRs when hegel-core makes breaking changes to the conformance framework (e.g. expecting new metrics fields). Each library repo now controls when to adopt new conformance requirements.

</details>