### PR TITLE
Use Run in tests

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -16,7 +16,7 @@ def git(*args: str, cwd: Path | None = None) -> str:
 
 
 def is_source_file(path: str) -> bool:
-    return path.endswith(".go") and not path.startswith("tests/")
+    return path.endswith(".go") and not path.startswith("tests/") and not path.startswith("internal/conformance/") and not path.endswith("_test.go")
 
 
 def parse_release_file(path: Path) -> tuple[str, str]:

--- a/dicts_test.go
+++ b/dicts_test.go
@@ -220,14 +220,14 @@ func TestPairsToMapNonSlicePair(t *testing.T) {
 func TestDictsStopTestOnNewCollection(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 10),
 			fn:    func(v int64) int64 { return v },
 		}
 		gen := Dicts(nonBasicKeys, Integers[int64](0, 100)).MaxSize(3)
 		_ = gen.draw(s)
-	}, stderrNoteFn, nil)
+	})
 	// StopTest causes test to be skipped or aborted, not fail
 	_ = err
 }
@@ -237,14 +237,14 @@ func TestDictsStopTestOnNewCollection(t *testing.T) {
 func TestDictsStopTestOnCollectionMore(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 10),
 			fn:    func(v int64) int64 { return v },
 		}
 		gen := Dicts(nonBasicKeys, Integers[int64](0, 100)).MaxSize(3)
 		_ = gen.draw(s)
-	}, stderrNoteFn, nil)
+	})
 	_ = err
 }
 
@@ -257,7 +257,7 @@ func TestDictsStopTestOnCollectionMore(t *testing.T) {
 func TestDictsBasicE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		gen := Dicts(Text(0, 5), Integers[int](0, 100)).MaxSize(3)
 		m := gen.draw(s)
 		if len(m) > 3 {
@@ -271,7 +271,7 @@ func TestDictsBasicE2E(t *testing.T) {
 				panic(fmt.Sprintf("Dicts: value %d out of [0,100]", val))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -281,7 +281,7 @@ func TestDictsBasicE2E(t *testing.T) {
 func TestDictsBasicWithBoundsE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		gen := Dicts(Integers[int](0, 10), Booleans()).MinSize(1).MaxSize(3)
 		m := gen.draw(s)
 		if len(m) < 1 || len(m) > 3 {
@@ -292,7 +292,7 @@ func TestDictsBasicWithBoundsE2E(t *testing.T) {
 				panic(fmt.Sprintf("Dicts bounded: key %d out of [0,10]", k))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -301,7 +301,7 @@ func TestDictsBasicWithBoundsE2E(t *testing.T) {
 // uses the default (min_size + 10).
 func TestDictsCompositeNoMaxE2E(t *testing.T) {
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 100),
 			fn:    func(n int64) int64 { return n },
@@ -310,7 +310,7 @@ func TestDictsCompositeNoMaxE2E(t *testing.T) {
 		gen := Dicts(nonBasicKeys, Just("v"))
 		m := gen.draw(s)
 		_ = m // just verify it doesn't panic
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -320,7 +320,7 @@ func TestDictsCompositeNoMaxE2E(t *testing.T) {
 func TestDictsCompositeE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		// mappedGenerator makes this non-basic -> composite path
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 10),
@@ -339,7 +339,7 @@ func TestDictsCompositeE2E(t *testing.T) {
 				panic(fmt.Sprintf("Dicts composite: expected value 'val', got %v for key %v", val, k))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -128,12 +128,12 @@ func TestFilteredGeneratorGeneratePredicatePassesFirstTry(t *testing.T) {
 	hegelBinPath(t)
 	// Filter that always passes: every value is accepted on first try.
 	gen := Filter(Integers[int](0, 100), func(v int) bool { return true })
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		n := gen.draw(s)
 		if n < 0 || n > 100 {
 			panic(fmt.Sprintf("Filter: expected [0,100], got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -147,7 +147,7 @@ func TestFilteredGeneratorGenerateWithRealPredicate(t *testing.T) {
 	gen := Filter(Integers[int](0, 50), func(v int) bool {
 		return v%2 == 0
 	})
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		n := gen.draw(s)
 		if n%2 != 0 {
 			panic(fmt.Sprintf("Filter even: expected even number, got %d", n))
@@ -155,7 +155,7 @@ func TestFilteredGeneratorGenerateWithRealPredicate(t *testing.T) {
 		if n < 0 || n > 50 {
 			panic(fmt.Sprintf("Filter even: expected [0,50], got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -171,12 +171,12 @@ func TestFilteredGeneratorGenerateChainedFilters(t *testing.T) {
 		Filter(Integers[int](0, 100), func(v int) bool { return v%2 == 0 }),
 		func(v int) bool { return v%4 == 0 },
 	)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		n := gen.draw(s)
 		if n%4 != 0 {
 			panic(fmt.Sprintf("chained filter: expected multiple of 4, got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -194,7 +194,7 @@ func TestFilteredGeneratorGenerateThenMap(t *testing.T) {
 	if _, ok := gen.(*mappedGenerator[int, int]); !ok {
 		t.Fatalf("Map(Filter(...)) should return *mappedGenerator, got %T", gen)
 	}
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		n := gen.draw(s)
 		// result must be odd*10, so divisible by 10 but result/10 must be odd
 		quotient := n / 10
@@ -204,7 +204,7 @@ func TestFilteredGeneratorGenerateThenMap(t *testing.T) {
 		if quotient%2 == 0 {
 			panic(fmt.Sprintf("filter+map: expected odd*10, got %d (quotient=%d is even)", n, quotient))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }

--- a/formats_test.go
+++ b/formats_test.go
@@ -121,12 +121,12 @@ func TestDatetimesSchema(t *testing.T) {
 func TestEmailsE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw(s, Emails())
 		if !strings.Contains(v, "@") {
 			panic("email does not contain '@': " + v)
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -135,12 +135,12 @@ func TestEmailsE2E(t *testing.T) {
 func TestURLsE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw(s, URLs())
 		if !strings.HasPrefix(v, "http://") && !strings.HasPrefix(v, "https://") {
 			panic("url does not start with http:// or https://: " + v)
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -154,14 +154,14 @@ func isValidDomainChar(r rune) bool {
 func TestDomainsE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw(s, Domains())
 		for _, r := range v {
 			if !isValidDomainChar(r) {
 				panic("domain contains invalid character '" + string(r) + "': " + v)
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -171,12 +171,12 @@ func TestDomainsMaxLengthE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	const maxLen = 20
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw(s, Domains().MaxLength(maxLen))
 		if len(v) > maxLen {
 			panic("domain exceeds max_length constraint: " + v)
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -185,12 +185,12 @@ func TestDomainsMaxLengthE2E(t *testing.T) {
 func TestDatesE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw(s, Dates())
 		if v.IsZero() {
 			panic("date is zero value")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }
@@ -199,12 +199,12 @@ func TestDatesE2E(t *testing.T) {
 func TestDatetimesE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw(s, Datetimes())
 		if v.IsZero() {
 			panic("datetime is zero value")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
+	}, WithTestCases(30)); _err != nil {
 		panic(_err)
 	}
 }

--- a/generators_test.go
+++ b/generators_test.go
@@ -81,10 +81,10 @@ func TestMappedGeneratorMapOnBasicInner(t *testing.T) {
 func TestCollectionStopTestOnNewCollection(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		coll := newCollection(s, 0, 5)
 		_ = coll.More(s)
-	}, stderrNoteFn, nil)
+	})
 	// Should not error -- the test was stopped, not failed.
 	_ = err
 }
@@ -94,10 +94,10 @@ func TestCollectionStopTestOnNewCollection(t *testing.T) {
 func TestCollectionStopTestOnCollectionMore(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		coll := newCollection(s, 0, 5)
 		_ = coll.More(s)
-	}, stderrNoteFn, nil)
+	})
 	_ = err
 }
 
@@ -145,13 +145,13 @@ func TestIntegersGeneratorHappyPath(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	var vals []int64
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[int64](s, Integers[int64](0, 100))
 		vals = append(vals, v)
 		if v < 0 || v > 100 {
 			panic(fmt.Sprintf("out of range: %d", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(10)}); _err != nil {
+	}, WithTestCases(10)); _err != nil {
 		panic(_err)
 	}
 	if len(vals) == 0 {
@@ -219,12 +219,12 @@ func TestJustTransformIgnoresInput(t *testing.T) {
 func TestJustE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[int](s, Just(42))
 		if v != 42 {
 			panic(fmt.Sprintf("Just: expected 42, got %v", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(20)}); _err != nil {
+	}, WithTestCases(20)); _err != nil {
 		panic(_err)
 	}
 }
@@ -235,12 +235,12 @@ func TestJustNonPrimitive(t *testing.T) {
 	hegelBinPath(t)
 	type myStruct struct{ x int }
 	val := &myStruct{x: 99}
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[*myStruct](s, Just(val))
 		if v != val {
 			panic("Just: pointer identity not preserved")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(10)}); _err != nil {
+	}, WithTestCases(10)); _err != nil {
 		panic(_err)
 	}
 }
@@ -298,12 +298,12 @@ func TestSampledFromTransformMapsIndices(t *testing.T) {
 func TestSampledFromSingleElement(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[string](s, SampledFrom([]string{"only"}))
 		if v != "only" {
 			panic(fmt.Sprintf("SampledFrom single: expected 'only', got %v", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(20)}); _err != nil {
+	}, WithTestCases(20)); _err != nil {
 		panic(_err)
 	}
 }
@@ -315,7 +315,7 @@ func TestSampledFromE2E(t *testing.T) {
 	hegelBinPath(t)
 	choices := []string{"apple", "banana", "cherry"}
 	seen := map[string]bool{}
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[string](s, SampledFrom(choices))
 		found := false
 		for _, c := range choices {
@@ -328,7 +328,7 @@ func TestSampledFromE2E(t *testing.T) {
 			panic(fmt.Sprintf("SampledFrom: value %q not in choices", v))
 		}
 		seen[v] = true
-	}, stderrNoteFn, []Option{WithTestCases(100)}); _err != nil {
+	}, WithTestCases(100)); _err != nil {
 		panic(_err)
 	}
 	// After 100 cases we expect all 3 values to have appeared.
@@ -347,12 +347,12 @@ func TestSampledFromNonPrimitive(t *testing.T) {
 	type myStruct struct{ x int }
 	obj1 := &myStruct{x: 1}
 	obj2 := &myStruct{x: 2}
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[*myStruct](s, SampledFrom([]*myStruct{obj1, obj2}))
 		if v != obj1 && v != obj2 {
 			panic("SampledFrom: value is not one of the original pointers")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(10)}); _err != nil {
+	}, WithTestCases(10)); _err != nil {
 		panic(_err)
 	}
 }
@@ -392,7 +392,7 @@ func TestFromRegexE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	// Only digits, 1-5 chars
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[string](s, FromRegex(`[0-9]{1,5}`, true))
 		if len(v) == 0 || len(v) > 5 {
 			panic(fmt.Sprintf("FromRegex: length out of range: %q", v))
@@ -402,7 +402,7 @@ func TestFromRegexE2E(t *testing.T) {
 				panic(fmt.Sprintf("FromRegex: non-digit character %q in %q", ch, v))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -416,10 +416,10 @@ func TestFromRegexE2E(t *testing.T) {
 func TestBasicGeneratorGenerateErrorResponse(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "error_response")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		g := &basicGenerator[int64]{schema: map[string]any{"type": "integer"}, transform: func(v any) int64 { return extractInt(v) }}
 		_ = g.draw(s) // should panic with requestError -> caught as INTERESTING
-	}, stderrNoteFn, nil)
+	})
 	// error_response causes the test to appear interesting (failing).
 	_ = err
 }
@@ -458,7 +458,7 @@ func TestMapBasicGeneratorE2E(t *testing.T) {
 	if _, ok := gen.(*basicGenerator[int]); !ok {
 		t.Fatalf("Map on basicGenerator should return *basicGenerator[int], got %T", gen)
 	}
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		n := Draw[int](s, gen)
 		if n%2 != 0 {
 			panic(fmt.Sprintf("map(x*2): expected even number, got %d", n))
@@ -466,7 +466,7 @@ func TestMapBasicGeneratorE2E(t *testing.T) {
 		if n < 0 || n > 200 {
 			panic(fmt.Sprintf("map(x*2): expected [0,200], got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -485,7 +485,7 @@ func TestMapChainedBasicGeneratorE2E(t *testing.T) {
 	if _, ok := gen.(*basicGenerator[int]); !ok {
 		t.Fatalf("chained Map on basicGenerator should return *basicGenerator[int], got %T", gen)
 	}
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		n := Draw[int](s, gen)
 		// (x+1)*2 is always even. x in [0,100] -> result in [2, 202].
 		if n%2 != 0 {
@@ -494,7 +494,7 @@ func TestMapChainedBasicGeneratorE2E(t *testing.T) {
 		if n < 2 || n > 202 {
 			panic(fmt.Sprintf("map(x+1).map(x*2): expected [2,202], got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -517,13 +517,13 @@ func TestMapNonBasicGeneratorE2E(t *testing.T) {
 	if _, ok := gen.(*mappedGenerator[int, int]); !ok {
 		t.Fatalf("Map on non-basic Generator should return *mappedGenerator, got %T", gen)
 	}
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		n := Draw[int](s, gen)
 		// inner is Integers[int](1,5)*1, map(*3): result is in {3, 6, 9, 12, 15}
 		if n < 3 || n > 15 || n%3 != 0 {
 			panic(fmt.Sprintf("map(*3) on [1,5]: expected multiple of 3 in [3,15], got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -626,7 +626,7 @@ func TestFilteredGeneratorMapMethod(t *testing.T) {
 func TestFilteredGeneratorE2EAlwaysPasses(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		gen := Filter[int](Integers[int](0, 100), func(v int) bool {
 			return v > 50
 		})
@@ -634,7 +634,7 @@ func TestFilteredGeneratorE2EAlwaysPasses(t *testing.T) {
 		if n <= 50 {
 			panic(fmt.Sprintf("filter(>50): expected n>50, got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -643,7 +643,7 @@ func TestFilteredGeneratorE2EAlwaysPasses(t *testing.T) {
 func TestFilteredGeneratorE2EEvenNumbers(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		gen := Filter[int](Integers[int](0, 10), func(v int) bool {
 			return v%2 == 0
 		})
@@ -651,7 +651,7 @@ func TestFilteredGeneratorE2EEvenNumbers(t *testing.T) {
 		if n%2 != 0 {
 			panic(fmt.Sprintf("filter(even): expected even, got %d", n))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -902,14 +902,14 @@ func TestFlatMappedGeneratorE2E(t *testing.T) {
 	gen := FlatMap[int, string](Integers[int](1, 5), func(v int) Generator[string] {
 		return Text(v, v) // exact length = n
 	})
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := Draw[string](s, gen)
 		count := len([]rune(v))
 		// n is in [1,5], so text length is in [1,5].
 		if count < 1 || count > 5 {
 			panic(fmt.Sprintf("flat_map text length %d out of [1,5]", count))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -924,7 +924,7 @@ func TestFlatMappedGeneratorDependency(t *testing.T) {
 		sz := int(v)
 		return Lists[int64](Integers[int64](0, 100)).MinSize(sz).MaxSize(sz)
 	})
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		slice := Draw[[]int64](s, gen)
 		if len(slice) < 2 || len(slice) > 4 {
 			panic(fmt.Sprintf("flat_map dependency: list length %d not in [2,4]", len(slice)))
@@ -934,7 +934,7 @@ func TestFlatMappedGeneratorDependency(t *testing.T) {
 				panic(fmt.Sprintf("flat_map dependency: element %d not in [0,100]", elem))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -1134,7 +1134,7 @@ func TestRejectFinishedCollection(t *testing.T) {
 // continue iterating — the server should handle this gracefully.
 func TestRejectE2E(t *testing.T) {
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		coll := newCollection(s, 0, 5)
 		if coll.More(s) {
 			// Reject the first element — tells the server it doesn't count.
@@ -1143,7 +1143,7 @@ func TestRejectE2E(t *testing.T) {
 		// Drain remaining elements.
 		for coll.More(s) {
 		}
-	}, stderrNoteFn, []Option{WithTestCases(10)}); _err != nil {
+	}, WithTestCases(10)); _err != nil {
 		panic(_err)
 	}
 }

--- a/lists_test.go
+++ b/lists_test.go
@@ -136,14 +136,14 @@ func TestListsNegativeMinSizePanics(t *testing.T) {
 func TestListsBasicIntegersE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		xs := Lists(Integers[int](0, 100)).MaxSize(10).draw(s)
 		for _, x := range xs {
 			if x < 0 || x > 100 {
 				panic(fmt.Sprintf("Lists: element %d out of range [0, 100]", x))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -153,12 +153,12 @@ func TestListsBasicIntegersE2E(t *testing.T) {
 func TestListsWithSizeBoundsE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		xs := Lists(Booleans()).MinSize(3).MaxSize(5).draw(s)
 		if len(xs) < 3 || len(xs) > 5 {
 			panic(fmt.Sprintf("Lists: length %d out of [3, 5]", len(xs)))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -174,14 +174,14 @@ func TestListsNonBasicElementE2E(t *testing.T) {
 	})
 	nonBasic := &mappedGenerator[int, int]{inner: mapped, fn: func(v int) int { return v }}
 
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		xs := Lists(nonBasic).MaxSize(5).draw(s)
 		for _, x := range xs {
 			if x%2 != 0 {
 				panic(fmt.Sprintf("Lists(non-basic): expected even element, got %d", x))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -191,7 +191,7 @@ func TestListsNonBasicElementE2E(t *testing.T) {
 func TestListsNestedE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		outer := Lists(Lists(Booleans()).MaxSize(3)).MaxSize(3).draw(s)
 		for i, inner := range outer {
 			for j, b := range inner {
@@ -201,7 +201,7 @@ func TestListsNestedE2E(t *testing.T) {
 				}
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -215,14 +215,14 @@ func TestListsBasicWithTransformE2E(t *testing.T) {
 	doubled := Map(Integers[int](0, 10), func(n int) int {
 		return n * 2
 	})
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		xs := Lists(doubled).MaxSize(5).draw(s)
 		for _, x := range xs {
 			if x%2 != 0 || x < 0 || x > 20 {
 				panic(fmt.Sprintf("Lists(basic+transform): element %d should be even in [0,20]", x))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -62,7 +62,7 @@ func TestOneOfPath1E2E(t *testing.T) {
 	sawShort := false
 	sawLong := false
 	combined := OneOf(Text(1, 3), Text(10, 15))
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := combined.draw(s)
 		n := len([]rune(v))
 		if n >= 1 && n <= 3 {
@@ -70,7 +70,7 @@ func TestOneOfPath1E2E(t *testing.T) {
 		} else if n >= 10 && n <= 15 {
 			sawLong = true
 		}
-	}, stderrNoteFn, []Option{WithTestCases(100)}); _err != nil {
+	}, WithTestCases(100)); _err != nil {
 		panic(_err)
 	}
 	if !sawShort {
@@ -216,12 +216,12 @@ func TestOneOfPath2E2E(t *testing.T) {
 	gen2 := Map(Just(int(2)), func(v int) int { return v * 3 })
 	combined := OneOf(gen1, gen2)
 
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := combined.draw(s)
 		if v != 2 && v != 6 {
 			panic(fmt.Sprintf("OneOf Path2: expected 2 or 6, got %d", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -276,7 +276,7 @@ func TestOneOfPath3E2E(t *testing.T) {
 
 	sawInt := false
 	sawStr := false
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := combined.draw(s)
 		switch v.(type) {
 		case int:
@@ -286,7 +286,7 @@ func TestOneOfPath3E2E(t *testing.T) {
 		default:
 			panic(fmt.Sprintf("OneOf Path3: unexpected type %T", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(100)}); _err != nil {
+	}, WithTestCases(100)); _err != nil {
 		panic(_err)
 	}
 	if !sawInt {
@@ -331,7 +331,7 @@ func TestOptionalE2E(t *testing.T) {
 	sawNil := false
 	sawInt := false
 	g := Optional(Integers[int](0, 100))
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := g.draw(s)
 		if v == nil {
 			sawNil = true
@@ -341,7 +341,7 @@ func TestOptionalE2E(t *testing.T) {
 				panic(fmt.Sprintf("Optional: expected [0,100], got %d", *v))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(100)}); _err != nil {
+	}, WithTestCases(100)); _err != nil {
 		panic(_err)
 	}
 	if !sawNil {
@@ -364,14 +364,14 @@ func TestOptionalNonBasicE2E(t *testing.T) {
 	}
 	sawNil := false
 	sawVal := false
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := g.draw(s)
 		if v == nil {
 			sawNil = true
 		} else {
 			sawVal = true
 		}
-	}, stderrNoteFn, []Option{WithTestCases(100)}); _err != nil {
+	}, WithTestCases(100)); _err != nil {
 		panic(_err)
 	}
 	if !sawNil {
@@ -430,12 +430,12 @@ func TestIPAddressesV4E2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	g := IPAddresses().IPv4()
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := g.draw(s)
 		if !v.Is4() {
 			panic(fmt.Sprintf("IPv4 address should be v4: %v", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -445,12 +445,12 @@ func TestIPAddressesV6E2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	g := IPAddresses().IPv6()
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := g.draw(s)
 		if !v.Is6() {
 			panic(fmt.Sprintf("IPv6 address should be v6: %v", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -462,14 +462,14 @@ func TestIPAddressesDefaultE2E(t *testing.T) {
 	sawV4 := false
 	sawV6 := false
 	g := IPAddresses()
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := g.draw(s)
 		if v.Is4() {
 			sawV4 = true
 		} else if v.Is6() {
 			sawV6 = true
 		}
-	}, stderrNoteFn, []Option{WithTestCases(100)}); _err != nil {
+	}, WithTestCases(100)); _err != nil {
 		panic(_err)
 	}
 	if !sawV4 {
@@ -490,7 +490,7 @@ func TestOneOfWithMapMixedTypesE2E(t *testing.T) {
 		Map(Integers[int](0, 10), func(v int) int { return v * 2 }),
 		Just(int(0)),
 	)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := gen.draw(s)
 		if v%2 != 0 {
 			panic(fmt.Sprintf("OneOf map: expected even, got %d", v))
@@ -498,7 +498,7 @@ func TestOneOfWithMapMixedTypesE2E(t *testing.T) {
 		if v < 0 || v > 20 {
 			panic(fmt.Sprintf("OneOf map: expected [0,20], got %d", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(100)}); _err != nil {
+	}, WithTestCases(100)); _err != nil {
 		panic(_err)
 	}
 }
@@ -511,7 +511,7 @@ func TestOneOfAllBranchesAppear(t *testing.T) {
 	sawA := false
 	sawB := false
 	gen := OneOf(Text(1, 3), Text(4, 6))
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		v := gen.draw(s)
 		n := len([]rune(v))
 		if n >= 1 && n <= 3 {
@@ -519,7 +519,7 @@ func TestOneOfAllBranchesAppear(t *testing.T) {
 		} else if n >= 4 && n <= 6 {
 			sawB = true
 		}
-	}, stderrNoteFn, []Option{WithTestCases(200)}); _err != nil {
+	}, WithTestCases(200)); _err != nil {
 		panic(_err)
 	}
 	if !sawA {
@@ -540,9 +540,9 @@ func TestCompositeOneOfGenerateErrorResponse(t *testing.T) {
 	nonBasic1 := &mappedGenerator[int64, int64]{inner: Integers[int64](0, 5), fn: func(v int64) int64 { return v }}
 	nonBasic2 := &mappedGenerator[int64, int64]{inner: Integers[int64](6, 10), fn: func(v int64) int64 { return v }}
 	gen := &compositeOneOfGenerator[int64]{generators: []Generator[int64]{nonBasic1, nonBasic2}}
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		_ = gen.draw(s) // should panic with requestError
-	}, stderrNoteFn, nil)
+	})
 	// error_response makes the test appear interesting (failing).
 	_ = err
 }

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -16,10 +16,10 @@ import (
 
 func TestIntegersFullRangeE2E(t *testing.T) {
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		// Full-range integers: just verify the draw completes without error.
 		_ = Draw[int](s, Integers[int](math.MinInt, math.MaxInt))
-	}, stderrNoteFn, []Option{WithTestCases(20)}); _err != nil {
+	}, WithTestCases(20)); _err != nil {
 		panic(_err)
 	}
 }
@@ -27,7 +27,7 @@ func TestIntegersFullRangeE2E(t *testing.T) {
 func TestFloatsE2E_WithBounds(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		fv := Draw[float64](s, Floats[float64]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
 		if math.IsNaN(fv) {
 			panic("floats: NaN not allowed when allow_nan=false")
@@ -38,7 +38,7 @@ func TestFloatsE2E_WithBounds(t *testing.T) {
 		if fv < 0.0 || fv > 1.0 {
 			panic("floats: out of range [0.0, 1.0]")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -46,10 +46,10 @@ func TestFloatsE2E_WithBounds(t *testing.T) {
 func TestFloatsE2E_Unbounded(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		// Unbounded floats may produce NaN or Inf -- any float64 is valid.
 		_ = Draw(s, Floats[float64]())
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -57,14 +57,14 @@ func TestFloatsE2E_Unbounded(t *testing.T) {
 func TestFloatsE2E_OnlyMin(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		fv := Draw(s, Floats[float64]().Min(0.0))
 		// allow_nan is false (has min), allow_infinity is true (no max)
 		// Value should be >= 0.0 or Inf; NaN not allowed.
 		if math.IsNaN(fv) {
 			panic("floats: NaN not expected when min set")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -72,12 +72,12 @@ func TestFloatsE2E_OnlyMin(t *testing.T) {
 func TestFloatsE2E_Float32(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		fv := Draw(s, Floats[float32]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
 		if fv < 0.0 || fv > 1.0 {
 			panic("float32: out of range [0.0, 1.0]")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -85,22 +85,22 @@ func TestFloatsE2E_Float32(t *testing.T) {
 func TestFloatsGenerateErrorResponse(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "error_response")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		_ = Floats[float64]().draw(s)
-	}, stderrNoteFn, nil)
+	})
 	_ = err
 }
 
 func TestBooleansE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		b := Draw[bool](s, Booleans())
 		// A valid assertion: b is either true or false.
 		if b != true && b != false {
 			panic("booleans: expected bool")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -108,13 +108,13 @@ func TestBooleansE2E(t *testing.T) {
 func TestTextE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		sv := Draw[string](s, Text(2, 8))
 		count := utf8.RuneCountInString(sv)
 		if count < 2 || count > 8 {
 			panic("text: codepoint count out of range [2, 8]")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -122,12 +122,12 @@ func TestTextE2E(t *testing.T) {
 func TestTextE2E_Unbounded(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		sv := Draw[string](s, Text(0, -1))
 		if !utf8.ValidString(sv) {
 			panic("text: invalid UTF-8 string")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -135,12 +135,12 @@ func TestTextE2E_Unbounded(t *testing.T) {
 func TestBinaryE2E(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		bv := Draw[[]byte](s, Binary(1, 10))
 		if len(bv) < 1 || len(bv) > 10 {
 			panic("binary: byte length out of range [1, 10]")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }
@@ -148,9 +148,9 @@ func TestBinaryE2E(t *testing.T) {
 func TestBinaryE2E_Unbounded(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		_ = Draw[[]byte](s, Binary(0, -1))
-	}, stderrNoteFn, []Option{WithTestCases(50)}); _err != nil {
+	}, WithTestCases(50)); _err != nil {
 		panic(_err)
 	}
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -30,14 +30,14 @@ func hegelBinPath(t *testing.T) {
 func TestRunHegelTestPasses(t *testing.T) {
 	hegelBinPath(t)
 	called := false
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		called = true
 		b := Draw[bool](s, Booleans())
 		// A valid assertion: b is either true or false.
 		if b != true && b != false {
 			t.Errorf("expected bool, got %v", b)
 		}
-	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {
+	}, WithTestCases(5)); _err != nil {
 		panic(_err)
 	}
 	if !called {
@@ -49,13 +49,13 @@ func TestRunHegelTestPasses(t *testing.T) {
 
 func TestRunHegelTestFails(t *testing.T) {
 	hegelBinPath(t)
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		x := Draw[int](s, Integers[int](0, 100))
 		// This always fails: no integer < 0 in [0,100]
 		if x >= 0 {
 			panic(fmt.Sprintf("assertion failed: %d >= 0", x))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(10)})
+	}, WithTestCases(10))
 	if err == nil {
 		t.Error("expected RunHegelTestE to return an error for always-failing test")
 	}
@@ -66,9 +66,9 @@ func TestRunHegelTestFails(t *testing.T) {
 func TestRunHegelTestAllInvalid(t *testing.T) {
 	hegelBinPath(t)
 	// A test that always calls Assume(false) should pass (all cases rejected).
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		s.Assume(false)
-	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {
+	}, WithTestCases(5)); _err != nil {
 		panic(_err)
 	}
 }
@@ -78,14 +78,14 @@ func TestRunHegelTestAllInvalid(t *testing.T) {
 func TestAssumeTrue(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		s.Assume(true)
 		b := Draw[bool](s, Booleans())
 		_ = b // use the value
 		if b != true && b != false {
 			panic("expected bool")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {
+	}, WithTestCases(5)); _err != nil {
 		panic(_err)
 	}
 }
@@ -96,10 +96,10 @@ func TestNoteNotFinal(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	// note() should not panic or error when called outside final run
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		s.Note("should not appear")
 		_ = Draw[bool](s, Booleans())
-	}, stderrNoteFn, []Option{WithTestCases(3)}); _err != nil {
+	}, WithTestCases(3)); _err != nil {
 		panic(_err)
 	}
 }
@@ -109,13 +109,13 @@ func TestNoteNotFinal(t *testing.T) {
 func TestTargetSendsCommand(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		x := Draw[int](s, Integers[int](0, 100))
 		s.Target(float64(x), "my_target")
 		if x < 0 || x > 100 {
 			panic("out of range")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {
+	}, WithTestCases(5)); _err != nil {
 		panic(_err)
 	}
 }
@@ -126,9 +126,9 @@ func TestStopTestOnGenerate(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_generate")
 	// Should complete without error: client handles StopTest cleanly.
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		Draw[bool](s, Booleans())
-	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {
+	}, WithTestCases(5)); _err != nil {
 		panic(_err)
 	}
 }
@@ -138,9 +138,9 @@ func TestStopTestOnGenerate(t *testing.T) {
 func TestStopTestOnMarkComplete(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_mark_complete")
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		Draw[bool](s, Booleans())
-	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {
+	}, WithTestCases(5)); _err != nil {
 		panic(_err)
 	}
 }
@@ -150,9 +150,9 @@ func TestStopTestOnMarkComplete(t *testing.T) {
 func TestEmptyTest(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
-	if _err := runHegel(func(_ *TestCase) {
+	if _err := Run(func(_ *TestCase) {
 		panic("should not be called")
-	}, stderrNoteFn, []Option{WithTestCases(5)}); _err != nil {
+	}, WithTestCases(5)); _err != nil {
 		panic(_err)
 	}
 }
@@ -171,9 +171,9 @@ func TestErrorResponse(t *testing.T) {
 				gotErr = fmt.Errorf("%v", r)
 			}
 		}()
-		gotErr = runHegel(func(s *TestCase) {
+		gotErr = Run(func(s *TestCase) {
 			Draw[bool](s, Booleans()) // server sends error_response here
-		}, stderrNoteFn, []Option{WithTestCases(3)})
+		}, WithTestCases(3))
 	}()
 	// The error from the server causes INTERESTING status -> re-raised on final run.
 	// Either a panic or a non-nil error is acceptable.
@@ -307,13 +307,13 @@ func TestHegelSessionConcurrentStart(t *testing.T) {
 func TestRunHegelTestSingleCase(t *testing.T) {
 	hegelBinPath(t)
 	count := 0
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		count++
 		b := Draw[bool](s, Booleans())
 		if b != true && b != false {
 			panic("not a bool")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(1)}); _err != nil {
+	}, WithTestCases(1)); _err != nil {
 		panic(_err)
 	}
 	if count == 0 {
@@ -330,12 +330,12 @@ func TestConcurrentRunHegelTest(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			if _err := runHegel(func(s *TestCase) {
+			if _err := Run(func(s *TestCase) {
 				b := Draw[bool](s, Booleans())
 				if b != true && b != false {
 					panic("not a bool")
 				}
-			}, stderrNoteFn, []Option{WithTestCases(3)}); _err != nil {
+			}, WithTestCases(3)); _err != nil {
 				panic(_err)
 			}
 		}(i)
@@ -347,9 +347,9 @@ func TestConcurrentRunHegelTest(t *testing.T) {
 
 func TestRunHegelTestESuccess(t *testing.T) {
 	hegelBinPath(t)
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		_ = Draw[bool](s, Booleans())
-	}, stderrNoteFn, []Option{WithTestCases(3)})
+	}, WithTestCases(3))
 	if err != nil {
 		t.Errorf("RunHegelTestE: unexpected error: %v", err)
 	}
@@ -361,10 +361,10 @@ func TestWithTestCasesOption(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
 	count := 0
-	if _err := runHegel(func(s *TestCase) {
+	if _err := Run(func(s *TestCase) {
 		count++
 		Draw[bool](s, Booleans())
-	}, stderrNoteFn, []Option{WithTestCases(10)}); _err != nil {
+	}, WithTestCases(10)); _err != nil {
 		panic(_err)
 	}
 	// count should be >= 10 (at least the requested cases)
@@ -378,10 +378,10 @@ func TestWithTestCasesOption(t *testing.T) {
 func TestStopTestOnCollectionMore(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		coll := newCollection(s, 0, 10)
 		_ = coll.More(s)
-	}, stderrNoteFn, nil)
+	})
 	_ = err // StopTest causes abort, not necessarily an error return
 }
 
@@ -390,10 +390,10 @@ func TestStopTestOnCollectionMore(t *testing.T) {
 func TestStopTestOnNewCollection(t *testing.T) {
 	hegelBinPath(t)
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		coll := newCollection(s, 0, 10)
 		_ = coll.More(s)
-	}, stderrNoteFn, nil)
+	})
 	_ = err // StopTest causes abort, not necessarily an error return
 }
 
@@ -414,8 +414,8 @@ func TestNoteOnFinalRun(t *testing.T) {
 		panic("intentional failure for final replay test")
 	}
 	func() {
-		defer func() { recover() }()                                 //nolint:errcheck
-		runHegel(noteFunc, stderrNoteFn, []Option{WithTestCases(3)}) //nolint:errcheck
+		defer func() { recover() }()    //nolint:errcheck
+		Run(noteFunc, WithTestCases(3)) //nolint:errcheck
 	}()
 	if !noted {
 		t.Error("expected isFinal to be true during final replay")
@@ -427,9 +427,9 @@ func TestNoteOnFinalRun(t *testing.T) {
 func TestConnectionErrorInTestFunction(t *testing.T) {
 	t.Parallel()
 	hegelBinPath(t)
-	err := runHegel(func(_ *TestCase) {
+	err := Run(func(_ *TestCase) {
 		panic(&connectionError{msg: "test connection lost"})
-	}, stderrNoteFn, []Option{WithTestCases(1)})
+	}, WithTestCases(1))
 	if err == nil {
 		t.Fatal("expected error to be raised for connection error")
 	}
@@ -659,7 +659,7 @@ func TestRunHegelTestESessionError(t *testing.T) {
 	globalSession = newHegelSession()
 	globalSession.hegelCmd = "/nonexistent/hegel"
 
-	err := runHegel(func(_ *TestCase) {}, stderrNoteFn, []Option{WithTestCases(1)})
+	err := Run(func(_ *TestCase) {}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when session cannot start")
 	}
@@ -685,7 +685,7 @@ func TestRunHegelTestPanicsOnFailure(t *testing.T) {
 	fake.hegelCmd = "/nonexistent/hegel"
 	globalSession = fake
 
-	if _err := runHegel(func(_ *TestCase) {}, stderrNoteFn, []Option{WithTestCases(1)}); _err != nil {
+	if _err := Run(func(_ *TestCase) {}, WithTestCases(1)); _err != nil {
 		panic(_err)
 	}
 }
@@ -695,10 +695,10 @@ func TestRunHegelTestPanicsOnFailure(t *testing.T) {
 func TestRunHegelTestECallsRunTest(t *testing.T) {
 	hegelBinPath(t)
 	called := false
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		called = true
 		Draw[bool](s, Booleans())
-	}, stderrNoteFn, []Option{WithTestCases(1)})
+	}, WithTestCases(1))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -825,7 +825,7 @@ func TestRunHegelTestEProtocolModeStartError(t *testing.T) {
 	t.Setenv("HOME", "/nonexistent")
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
 
-	err := runHegel(func(_ *TestCase) {}, stderrNoteFn, []Option{WithTestCases(1)})
+	err := Run(func(_ *TestCase) {}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when session cannot start in protocol test mode")
 	}
@@ -958,10 +958,10 @@ func TestCaseSuccess(t *testing.T) {
 
 func TestStateFailedPath(t *testing.T) {
 	hegelBinPath(t)
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		_ = Draw[bool](s, Booleans())
 		s.failed = true // simulates T.Error/T.Fail
-	}, stderrNoteFn, []Option{WithTestCases(1)})
+	}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when state.failed is true")
 	}
@@ -973,10 +973,10 @@ func TestStateFailedPath(t *testing.T) {
 
 func TestFatalSentinelPath(t *testing.T) {
 	hegelBinPath(t)
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		_ = Draw[bool](s, Booleans())
 		panic(fatalSentinel{msg: "test fatal"})
-	}, stderrNoteFn, []Option{WithTestCases(1)})
+	}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when fatalSentinel is raised")
 	}
@@ -1076,10 +1076,10 @@ func TestSuppressHealthCheckOption(t *testing.T) {
 func TestSuppressHealthCheckIntegration(t *testing.T) {
 	hegelBinPath(t)
 	// Exercise the suppress_health_check protocol path.
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		n := Draw[int](s, Integers[int](0, 100))
 		s.Assume(n < 90)
-	}, stderrNoteFn, []Option{SuppressHealthCheck(FilterTooMuch, TooSlow), WithTestCases(5)})
+	}, SuppressHealthCheck(FilterTooMuch, TooSlow), WithTestCases(5))
 	if err != nil {
 		t.Errorf("expected test to pass with suppressed health check: %v", err)
 	}
@@ -1087,10 +1087,10 @@ func TestSuppressHealthCheckIntegration(t *testing.T) {
 
 func TestSuppressAllHealthChecksIntegration(t *testing.T) {
 	hegelBinPath(t)
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		n := Draw[int](s, Integers[int](0, 100))
 		s.Assume(n < 90)
-	}, stderrNoteFn, []Option{SuppressHealthCheck(AllHealthChecks()...), WithTestCases(5)})
+	}, SuppressHealthCheck(AllHealthChecks()...), WithTestCases(5))
 	if err != nil {
 		t.Errorf("expected test to pass with all health checks suppressed: %v", err)
 	}
@@ -1153,10 +1153,10 @@ func TestHealthCheckFailureFilterTooMuch(t *testing.T) {
 	hegelBinPath(t)
 	// Filtering based on a tiny range triggers FilterTooMuch: the server sees
 	// almost all test cases rejected and raises a health check failure.
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		n := Draw[int](s, Integers[int](0, 1000))
 		s.Assume(n == 0) // reject ~99.9% of test cases
-	}, stderrNoteFn, []Option{WithTestCases(200)})
+	}, WithTestCases(200))
 	if err == nil {
 		t.Fatal("expected health check failure")
 	}
@@ -1172,11 +1172,11 @@ var flakyCounter atomic.Int64
 func TestFlakyGlobalState(t *testing.T) {
 	hegelBinPath(t)
 	flakyCounter.Store(0)
-	err := runHegel(func(s *TestCase) {
+	err := Run(func(s *TestCase) {
 		min := int(flakyCounter.Load())
 		_ = Draw[int](s, Integers[int](min, min+100))
 		flakyCounter.Add(1)
-	}, stderrNoteFn, []Option{WithTestCases(100)})
+	}, WithTestCases(100))
 	if err == nil {
 		t.Fatal("expected error for flaky test")
 	}


### PR DESCRIPTION
A lot of the unit tests use the internal runHegel function for no good reason. Change them to use Run instead.