### PR TITLE
feat: Write .gitignore into .hegel directory on creation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The `.hegel` data directory now contains a `.gitignore` file with `*` so users don't need to manually add it to their project's `.gitignore`.

--- a/runner.go
+++ b/runner.go
@@ -541,7 +541,8 @@ type hegelSession struct {
 // Each process gets its own file to avoid interleaved writes from concurrent processes.
 func openServerLog() *os.File {
 	hegelDir := filepath.Join(getProjectRoot(), ".hegel")
-	os.MkdirAll(hegelDir, 0o755) //nolint:errcheck
+	os.MkdirAll(hegelDir, 0o755)                                              //nolint:errcheck
+	os.WriteFile(filepath.Join(hegelDir, ".gitignore"), []byte("*\n"), 0o644) //nolint:errcheck
 	logPath := filepath.Join(hegelDir, fmt.Sprintf("server.%d.log", os.Getpid()))
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil { // coverage-ignore


### PR DESCRIPTION
When hegel creates the `.hegel` data directory, it now also writes a `.gitignore` containing `*` inside it. This means users don't need to add `.hegel/` to their own project's `.gitignore` — it's handled automatically.