### PR TITLE
Fix unsigned int bounds

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix an error when using `Integers` with the full unsigned bounds.

--- a/generators_test.go
+++ b/generators_test.go
@@ -181,6 +181,39 @@ func TestIntegersSchema(t *testing.T) {
 	}
 }
 
+func TestIntegersInBounds(t *testing.T) {
+	runIntegersBoundsCheck[int8](t, "int8", math.MinInt8, math.MaxInt8)
+	runIntegersBoundsCheck[int16](t, "int16", math.MinInt16, math.MaxInt16)
+	runIntegersBoundsCheck[int32](t, "int32", math.MinInt32, math.MaxInt32)
+	runIntegersBoundsCheck[int64](t, "int64", math.MinInt64, math.MaxInt64)
+	runIntegersBoundsCheck[int](t, "int", math.MinInt, math.MaxInt)
+	runIntegersBoundsCheck[uint8](t, "uint8", 0, math.MaxUint8)
+	runIntegersBoundsCheck[uint16](t, "uint16", 0, math.MaxUint16)
+	runIntegersBoundsCheck[uint32](t, "uint32", 0, math.MaxUint32)
+	runIntegersBoundsCheck[uint64](t, "uint64", 0, math.MaxUint64)
+	runIntegersBoundsCheck[uint](t, "uint", 0, math.MaxUint)
+}
+
+func runIntegersBoundsCheck[T integer](t *testing.T, name string, lo, hi T) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+		var drew bool
+		if _err := Run(func(s *TestCase) {
+			v := Draw[T](s, Integers[T](lo, hi))
+			drew = true
+			if v < lo || v > hi {
+				panic(fmt.Sprintf("out of range: lo=%d hi=%d v=%d", lo, hi, v))
+			}
+		}, WithTestCases(20)); _err != nil {
+			t.Fatalf("run failed: %v", _err)
+		}
+		if !drew {
+			t.Error("test function was never called")
+		}
+	})
+}
+
 // =============================================================================
 // Just generator tests
 // =============================================================================

--- a/primitives.go
+++ b/primitives.go
@@ -65,15 +65,26 @@ func extractFloatAs[T float](v any) T {
 // For unbounded generation, use the full range of the type:
 //
 //	hegel.Integers[int](math.MinInt, math.MaxInt)
+//	hegel.Integers[uint](0, math.MaxUint)
 func Integers[T integer](minVal, maxVal T) Generator[T] {
 	if minVal > maxVal {
 		panic(fmt.Sprintf("hegel: Cannot have max_value=%d < min_value=%d", maxVal, minVal))
 	}
+	// Encode bounds in the widest type that preserves T's range.
+	var minSchema, maxSchema any
+	var zero T
+	if ^zero > zero {
+		minSchema = uint64(minVal)
+		maxSchema = uint64(maxVal)
+	} else {
+		minSchema = int64(minVal)
+		maxSchema = int64(maxVal)
+	}
 	return &basicGenerator[T]{
 		schema: map[string]any{
 			"type":      "integer",
-			"min_value": int64(minVal),
-			"max_value": int64(maxVal),
+			"min_value": minSchema,
+			"max_value": maxSchema,
 		},
 		transform: extractIntAs[T],
 	}


### PR DESCRIPTION
Closes https://github.com/hegeldev/hegel-go/issues/51.

@DRMacIver I think this is too language specific to have a conformance test for, but maybe our claude skill should require the agent write tests for all primitive generators of the form "assert that drawing from a `generator[T](...bounds)` is within `bounds`"