### PR TITLE
claude: whitelist .claude in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,19 @@ __pycache__/
 *.pyc
 
 # Claude Code transient files
-.claude/plan.md
-.claude/settings.local.json
 CLAUDE.local.md
-.claude/local/
+
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/changelog/
+!.claude/skills/coverage/
+!.claude/skills/go-concurrency/
+!.claude/skills/self-review/
 
 # Hegelator metadata
 .hegelator/
@@ -43,6 +52,4 @@ vendor/
 *.iml
 .DS_Store
 
-.claude/claude-reliability.yml
-.claude/reliability-config.yaml
 .claude-reliability/


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Switch the `.claude/` section of `.gitignore` from a blacklist (`.claude/plan.md`, `.claude/settings.local.json`, `.claude/local/`, `.claude/claude-reliability.yml`, `.claude/reliability-config.yaml`) to a whitelist. Local files (skills, agents, settings, plans) inside `.claude/` are now untracked by default; only explicitly-allowed files are committed. Top-level `CLAUDE.local.md` continues to be gitignored at the top level.

Whitelisted entries for hegel-go:
- `.claude/CLAUDE.md`
- `.claude/skills/changelog/`
- `.claude/skills/coverage/` (including `references/`)
- `.claude/skills/go-concurrency/` (including `references/`)
- `.claude/skills/self-review/`

The two-tier pattern (`!.claude/skills/` then `.claude/skills/*` then per-skill `!`s) is intentional: `!.claude/skills/` un-ignores the directory so git descends into it, then `.claude/skills/*` re-blacklists its direct children, and the per-skill `!` lines re-include the four tracked skills. New local skill dirs (e.g. `.claude/skills/scratch/`) get ignored automatically. Local notes inside a tracked skill (e.g. `.claude/skills/coverage/notes.md`) will still be tracked — accepted granularity.

Verified via `git ls-files .claude/`: all 10 originally-tracked files remain tracked. `git status --short` shows only `.gitignore` modified; the locally-injected `.claude/agents/` and `.claude/skills/code-review/` are now ignored.

The CI `check-release` gate only fires on `.go` source changes, so no `RELEASE.md` is required for this PR.

</details>
