### PR TITLE
claude: adopt new one_of wire format and bump hegel-core to 0.5.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -173,6 +173,10 @@ Failing to handle StopTest correctly causes `FlakyStrategyDefinition` errors.
 
 ### OneOf code paths
 
-- Path 1 (all basic, all identity): simple `{"one_of": [...]}` schema.
-- Path 2 (all basic, some transforms): tagged-tuple schema with dispatch.
-- Path 3 (any non-basic): `*CompositeOneOfGenerator` with span wrapping.
+- All basic: a flat `{"type": "one_of", "generators": [...]}` schema. The server
+  returns `[index, value]` and the synthesized parse fn dispatches to the
+  matching per-branch parse using `index`. No tagged-tuple wrapping.
+- Any non-basic: falls back to `oneOfGenerator.draw`, which generates an index
+  via `generateFromSchema` (an integer in `[0, n-1]`) and recursively draws
+  from the chosen branch under a span. The same shape applies to `Optional`,
+  whose schema is a 2-branch one_of (null vs. inner value).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Bump our pinned hegel-core to [0.5.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.5.0). This release adopts the new `one_of` wire format introduced in hegel-core 0.5.0, and requires hegel-core >= 0.5.0 at runtime.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Bump our pinned hegel-core to [0.5.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.5.0). This release adopts the new `one_of` wire format introduced in hegel-core 0.5.0, and requires hegel-core >= 0.5.0 at runtime.
+Internal refactor of `oneOf`.

--- a/combinators.go
+++ b/combinators.go
@@ -12,8 +12,12 @@ type oneOfGenerator[T any] struct {
 	generators []Generator[T]
 }
 
-// asBasic returns a basic generator with a tagged-tuple one_of schema when
-// every branch is basic. Returns (nil, false, nil) when any branch is not.
+// asBasic returns a basic generator with a one_of schema when every branch
+// is basic. Returns (nil, false, nil) when any branch is not.
+//
+// The wire shape for one_of responses is [index, value]: the server tells us
+// which branch produced the value, so we dispatch to the matching parse fn
+// without baking a tag into the schema.
 func (g *oneOfGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 	basics := make([]*basicGenerator[T], 0, len(g.generators))
 	for _, branch := range g.generators {
@@ -27,30 +31,19 @@ func (g *oneOfGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 		basics = append(basics, bg)
 	}
 
-	// Tagged tuples: each branch is [tag, value], dispatch to the right parse fn.
-	taggedSchemas := make([]any, len(basics))
-	for i, bg := range basics {
-		taggedSchemas[i] = map[string]any{
-			"type": "tuple",
-			"elements": []any{
-				map[string]any{"type": "constant", "value": int64(i)},
-				bg.schema,
-			},
-		}
-	}
-
+	schemas := make([]any, len(basics))
 	parseFns := make([]func(any) T, len(basics))
 	for i, bg := range basics {
+		schemas[i] = bg.schema
 		parseFns[i] = bg.parse
 	}
 
 	return &basicGenerator[T]{
-		schema: map[string]any{"type": "one_of", "generators": taggedSchemas},
-		parse: func(tagged any) T {
-			elems := tagged.([]any)
-			tag := extractInt(elems[0])
-			value := elems[1]
-			return parseFns[tag](value)
+		schema: map[string]any{"type": "one_of", "generators": schemas},
+		parse: func(raw any) T {
+			elems := raw.([]any)
+			idx := extractInt(elems[0])
+			return parseFns[idx](elems[1])
 		},
 	}, true, nil
 }
@@ -103,9 +96,13 @@ type optionalGenerator[T any] struct {
 	inner Generator[T]
 }
 
-// asBasic returns a basic generator with a tagged-tuple one_of schema (a null
-// branch and an inner-value branch) when inner is basic. Returns
-// (nil, false, nil) when inner is not.
+// asBasic returns a basic generator with a one_of schema (a null branch and
+// an inner-value branch) when inner is basic. Returns (nil, false, nil) when
+// inner is not.
+//
+// The wire shape for one_of responses is [index, value]: branch 0 is null,
+// branch 1 is the inner value, so we dispatch on the server-supplied index
+// without baking a tag into the schema.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
 func (g *optionalGenerator[T]) asBasic() (*basicGenerator[*T], bool, error) {
@@ -121,28 +118,16 @@ func (g *optionalGenerator[T]) asBasic() (*basicGenerator[*T], bool, error) {
 	schema := map[string]any{
 		"type": "one_of",
 		"generators": []any{
-			map[string]any{
-				"type": "tuple",
-				"elements": []any{
-					map[string]any{"type": "constant", "value": int64(0)},
-					map[string]any{"type": "null"},
-				},
-			},
-			map[string]any{
-				"type": "tuple",
-				"elements": []any{
-					map[string]any{"type": "constant", "value": int64(1)},
-					innerBasic.schema,
-				},
-			},
+			map[string]any{"type": "null"},
+			innerBasic.schema,
 		},
 	}
 	return &basicGenerator[*T]{
 		schema: schema,
 		parse: func(raw any) *T {
 			elems := raw.([]any)
-			tag := extractInt(elems[0])
-			if tag == 0 {
+			idx := extractInt(elems[0])
+			if idx == 0 {
 				return nil
 			}
 			v := innerParse(elems[1])

--- a/installer.go
+++ b/installer.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-const hegelServerVersion = "0.4.14"
+const hegelServerVersion = "0.5.0"
 
 // hegelServerCommandEnv is the environment variable that overrides automatic installation.
 const hegelServerCommandEnv = "HEGEL_SERVER_COMMAND"

--- a/justfile
+++ b/justfile
@@ -35,12 +35,7 @@ build-conformance:
     go build -o bin/conformance ./internal/conformance/cmd/...
 
 conformance: build-conformance
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # Single source of truth: read the pinned version from installer.go so
-    # the conformance harness always matches what users get from `uv tool run`.
-    version=$(grep 'hegelServerVersion =' installer.go | cut -d'"' -f2)
-    uv run --with "hegel-core==$version" --with pytest --with hypothesis \
+    uv run --with 'hegel-core==0.5.0' --with pytest --with hypothesis \
         pytest tests/conformance/ -v
 
 # Run lint + docs + test (the full CI check).

--- a/justfile
+++ b/justfile
@@ -35,7 +35,12 @@ build-conformance:
     go build -o bin/conformance ./internal/conformance/cmd/...
 
 conformance: build-conformance
-    uv run --with 'hegel-core==0.4.14' --with pytest --with hypothesis \
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Single source of truth: read the pinned version from installer.go so
+    # the conformance harness always matches what users get from `uv tool run`.
+    version=$(grep 'hegelServerVersion =' installer.go | cut -d'"' -f2)
+    uv run --with "hegel-core==$version" --with pytest --with hypothesis \
         pytest tests/conformance/ -v
 
 # Run lint + docs + test (the full CI check).

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -12,7 +12,10 @@ import (
 // =============================================================================
 
 // TestOneOfAllBasicSchema verifies that OneOf with all basic generators
-// produces a tagged-tuple {"type": "one_of", "generators": [...]} schema.
+// produces a flat {"type": "one_of", "generators": [...]} schema —
+// child schemas pass through unchanged. Under the new protocol the server
+// supplies the branch index in the response, so we don't wrap children
+// in tagged tuples.
 func TestOneOfAllBasicSchema(t *testing.T) {
 	t.Parallel()
 	g1 := Booleans()
@@ -40,15 +43,17 @@ func TestOneOfAllBasicSchema(t *testing.T) {
 	if len(schemas) != 2 {
 		t.Errorf("one_of should have 2 branches, got %d", len(schemas))
 	}
-	// All branches should be tagged tuples
+	// Each branch is the underlying basicGenerator schema, unmodified —
+	// Booleans() produces {"type": "boolean"} and that survives the OneOf
+	// wrapping unchanged, with no tagged-tuple / constant tag injection.
 	for i, s := range schemas {
 		m, ok := s.(map[string]any)
 		if !ok {
 			t.Errorf("branch %d should be map[string]any, got %T", i, s)
 			continue
 		}
-		if m["type"] != "tuple" {
-			t.Errorf("branch %d should be a tagged tuple, got type %v", i, m["type"])
+		if m["type"] != "boolean" {
+			t.Errorf("branch %d: expected child schema type 'boolean', got %v", i, m["type"])
 		}
 	}
 }
@@ -80,12 +85,13 @@ func TestOneOfPath1E2E(t *testing.T) {
 }
 
 // =============================================================================
-// OneOf — all basic, tagged tuple schema
+// OneOf — all basic, with parse transforms
 // =============================================================================
 
-// TestOneOfPath2Schema verifies that OneOf with mapped basicGenerators produces
-// a tagged-tuple schema.
-func TestOneOfPath2Schema(t *testing.T) {
+// TestOneOfWithTransformsSchema verifies that OneOf over mapped basicGenerators
+// emits the same flat {"type": "one_of", "generators": [...]} schema —
+// child schemas pass through, no constant tags injected.
+func TestOneOfWithTransformsSchema(t *testing.T) {
 	t.Parallel()
 	gen1 := Map(Just(int64(1)), func(v int64) int64 { return v * 2 })
 	gen2 := Map(Just(int64(2)), func(v int64) int64 { return v * 3 })
@@ -96,54 +102,43 @@ func TestOneOfPath2Schema(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !ok {
-		t.Fatalf("OneOf Path 2 should be basic")
+		t.Fatalf("OneOf with transforms should be basic")
 	}
 	if bg.schema["type"] != "one_of" {
-		t.Fatalf("Path 2 schema should have type 'one_of'; got %v", bg.schema)
+		t.Fatalf("schema should have type 'one_of'; got %v", bg.schema)
 	}
 	generators, hasGenerators := bg.schema["generators"]
 	if !hasGenerators {
-		t.Fatalf("Path 2 schema should have 'generators' key; got %v", bg.schema)
+		t.Fatalf("schema should have 'generators' key; got %v", bg.schema)
 	}
 	schemas, ok := generators.([]any)
 	if !ok {
 		t.Fatalf("one_of value should be []any")
 	}
 	if len(schemas) != 2 {
-		t.Errorf("one_of should have 2 tagged branches, got %d", len(schemas))
+		t.Errorf("one_of should have 2 branches, got %d", len(schemas))
 	}
-	// Each branch should be a tuple with {"type": "tuple", "elements": [{"type": "constant", "value": i}, ...]}
+	// Each branch is the underlying basicGenerator schema, unmodified —
+	// Just(...) produces a {"type": "constant", ...} schema and that survives
+	// the OneOf wrapping unchanged.
 	for i, s := range schemas {
 		m, ok := s.(map[string]any)
 		if !ok {
 			t.Errorf("branch %d should be map[string]any, got %T", i, s)
 			continue
 		}
-		if m["type"] != "tuple" {
-			t.Errorf("branch %d: expected type=tuple, got %v", i, m["type"])
+		if m["type"] == "tuple" {
+			t.Errorf("branch %d: must not wrap child schema in a tagged tuple", i)
 		}
-		elems, ok := m["elements"].([]any)
-		if !ok || len(elems) < 2 {
-			t.Errorf("branch %d: elements should be []any with >=2 entries", i)
-			continue
-		}
-		constMap, ok := elems[0].(map[string]any)
-		if !ok {
-			t.Errorf("branch %d: first element should be {type: constant, value: N}", i)
-			continue
-		}
-		if constMap["type"] != "constant" {
-			t.Errorf("branch %d: first element type should be 'constant', got %v", i, constMap["type"])
-		}
-		constVal, _ := extractCBORInt(constMap["value"])
-		if constVal != int64(i) {
-			t.Errorf("branch %d: constant tag should be %d, got %d", i, i, constVal)
+		if m["type"] != "constant" {
+			t.Errorf("branch %d: expected child schema type 'constant', got %v", i, m["type"])
 		}
 	}
 }
 
-// TestOneOfPath2Transform verifies the tagged parse dispatching logic.
-func TestOneOfPath2Transform(t *testing.T) {
+// TestOneOfWithTransformsParse verifies that the synthesized parse dispatches
+// on the wire-side index to the matching per-branch parse fn.
+func TestOneOfWithTransformsParse(t *testing.T) {
 	t.Parallel()
 	// just(1).map(*2) -> always 2; just(2).map(*3) -> always 6
 	gen1 := Map(Just(int64(1)), func(v int64) int64 { return v * 2 })
@@ -155,21 +150,22 @@ func TestOneOfPath2Transform(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Simulate tag=0, value=int64(1) → parse 0 (*2) → 2
+	// Simulate the wire response [0, 1] — index=0 selects parse 0 (*2): 1*2=2.
 	result0 := bg.parse([]any{int64(0), int64(1)})
 	if result0 != 2 {
-		t.Errorf("tag=0: expected 2, got %d", result0)
+		t.Errorf("index=0: expected 2, got %d", result0)
 	}
 
-	// Simulate tag=1, value=int64(2) → parse 1 (*3) → 6
+	// Simulate the wire response [1, 2] — index=1 selects parse 1 (*3): 2*3=6.
 	result1 := bg.parse([]any{int64(1), int64(2)})
 	if result1 != 6 {
-		t.Errorf("tag=1: expected 6, got %d", result1)
+		t.Errorf("index=1: expected 6, got %d", result1)
 	}
 }
 
-// TestOneOfParseDispatchMixedBranches verifies that when branches have different
-// parse functions, the tagged dispatcher calls the correct one for each branch.
+// TestOneOfParseDispatchMixedBranches verifies that when branches have
+// different parse functions, the dispatcher uses the wire-side index to
+// call the matching one for each branch.
 func TestOneOfParseDispatchMixedBranches(t *testing.T) {
 	t.Parallel()
 	// Mix: one identity-like branch, one with a composed parse.
@@ -185,20 +181,22 @@ func TestOneOfParseDispatchMixedBranches(t *testing.T) {
 	if !ok {
 		t.Fatalf("OneOf(all-basic) should be basic")
 	}
-	// tag=0: identity branch — return value as-is
+	// index=0: identity branch — return value as-is.
 	result0 := bg.parse([]any{int64(0), true})
 	if result0 != true {
-		t.Errorf("tag=0 (identity): expected true, got %v", result0)
+		t.Errorf("index=0 (identity): expected true, got %v", result0)
 	}
-	// tag=1: mapped branch — negate true → false
+	// index=1: mapped branch — negate true → false.
 	result1 := bg.parse([]any{int64(1), true})
 	if result1 != false {
-		t.Errorf("tag=1 (mapped): expected false, got %v", result1)
+		t.Errorf("index=1 (mapped): expected false, got %v", result1)
 	}
 }
 
-// TestOneOfPath2E2E verifies that Path 2 generates correctly through the real server.
-func TestOneOfPath2E2E(t *testing.T) {
+// TestOneOfWithTransformsE2E verifies that per-branch parse transforms are
+// applied to the matching wire-side index when generating through the real
+// server.
+func TestOneOfWithTransformsE2E(t *testing.T) {
 	t.Parallel()
 
 	gen1 := Map(Just(int(1)), func(v int) int { return v * 2 })
@@ -208,7 +206,7 @@ func TestOneOfPath2E2E(t *testing.T) {
 	if _err := Run(func(s *TestCase) {
 		v := combined.draw(s)
 		if v != 2 && v != 6 {
-			panic(fmt.Sprintf("OneOf Path2: expected 2 or 6, got %d", v))
+			panic(fmt.Sprintf("OneOf with transforms: expected 2 or 6, got %d", v))
 		}
 	}, WithTestCases(50)); _err != nil {
 		panic(_err)


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Folds together two changes that need to land as a unit:

1. **Adopt the new `one_of` wire format from hegel-core 0.5.0.** Server responses for `one_of` schemas are now `[index, value]` instead of bare `value`. Drop the tagged-tuple wrapping in `oneOfGenerator.asBasic` and `optionalGenerator.asBasic`; dispatch to per-branch parse fns using the server-supplied index.
2. **Bump pinned `hegel-core` to 0.5.0** (in `installer.go`). This subsumes the auto-bump from #57 — neither half is mergeable on its own, so combining them is the only way for either to go green.

Also:
- The `just conformance` recipe now reads the pinned version from `installer.go` instead of duplicating the literal, so the Python test harness and the Go-spawned hegel server can never drift out of sync.
- Tightened `TestOneOfAllBasicSchema` from a negative `!= "tuple"` check to a positive `== "boolean"` check.
- Refreshed the stale OneOf-paths note in `.claude/CLAUDE.md` to reflect the collapsed schema (the Path 1 / Path 2 distinction is gone, and there is no `*CompositeOneOfGenerator`).

Verified locally: `just check` and `just conformance` both pass against `hegel-core==0.5.0`.

Once this merges, #57 can be closed.

</details>
