### PR TITLE
claude: protocol: drop null/ipv4/ipv6 schemas

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,3 @@
 RELEASE_TYPE: patch
 
-Internal: update wire schema for `Optional` and `IPAddresses` to match hegel-core.
-
-Bump our pinned hegel-core to [0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0), incorporating the following change:
-
-> This release makes the following breaking protocol changes:
-> - Removed `{"type": "sampled_from"}`. Instead of serializing the values to sample from, ask for an integer index and index into the collection of values on the client side.
-> - Removed `{"type": "null"}`. Use `{"type": "constant", "value": null}` instead.
-> - Replaced `{"type": "ipv4"}` and `{"type": "ipv6"}` with a single `{"type": "ip_address", "version": <4|6>}` schema.
->
-> The protocol version is now 0.12.
->
-> — [v0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0)
+Internal refactor.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal: update wire schema for `Optional` and `IPAddresses` to match hegel-core.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,14 @@
 RELEASE_TYPE: patch
 
 Internal: update wire schema for `Optional` and `IPAddresses` to match hegel-core.
+
+Bump our pinned hegel-core to [0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0), incorporating the following change:
+
+> This release makes the following breaking protocol changes:
+> - Removed `{"type": "sampled_from"}`. Instead of serializing the values to sample from, ask for an integer index and index into the collection of values on the client side.
+> - Removed `{"type": "null"}`. Use `{"type": "constant", "value": null}` instead.
+> - Replaced `{"type": "ipv4"}` and `{"type": "ipv6"}` with a single `{"type": "ip_address", "version": <4|6>}` schema.
+>
+> The protocol version is now 0.12.
+>
+> — [v0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0)

--- a/combinators.go
+++ b/combinators.go
@@ -118,7 +118,7 @@ func (g *optionalGenerator[T]) asBasic() (*basicGenerator[*T], bool, error) {
 	schema := map[string]any{
 		"type": "one_of",
 		"generators": []any{
-			map[string]any{"type": "null"},
+			map[string]any{"type": "constant", "value": nil},
 			innerBasic.schema,
 		},
 	}
@@ -172,7 +172,8 @@ func (g *optionalGenerator[T]) draw(s *TestCase) *T {
 // IPAddressGenerator configures and generates IP addresses.
 // Use [IPAddresses] to create one, then chain builder methods to configure it.
 type IPAddressGenerator struct {
-	version string
+	// version is 0 (unset; both v4 and v6), 4, or 6.
+	version int64
 }
 
 // IPAddresses returns a Generator that produces IP addresses.
@@ -182,13 +183,13 @@ func IPAddresses() IPAddressGenerator {
 
 // IPv4 restricts the generator to IPv4 addresses only.
 func (g IPAddressGenerator) IPv4() IPAddressGenerator {
-	g.version = "ipv4"
+	g.version = 4
 	return g
 }
 
 // IPv6 restricts the generator to IPv6 addresses only.
 func (g IPAddressGenerator) IPv6() IPAddressGenerator {
-	g.version = "ipv6"
+	g.version = 6
 	return g
 }
 
@@ -199,19 +200,19 @@ func (g IPAddressGenerator) asBasic() (*basicGenerator[netip.Addr], bool, error)
 	addrTransform := func(a any) netip.Addr {
 		return netip.MustParseAddr(a.(string))
 	}
-	if g.version != "" {
+	if g.version != 0 {
 		return &basicGenerator[netip.Addr]{
-			schema: map[string]any{"type": g.version},
+			schema: map[string]any{"type": "ip_addresses", "version": g.version},
 			parse:  addrTransform,
 		}, true, nil
 	}
 	return OneOf(
 		&basicGenerator[netip.Addr]{
-			schema: map[string]any{"type": "ipv4"},
+			schema: map[string]any{"type": "ip_addresses", "version": int64(4)},
 			parse:  addrTransform,
 		},
 		&basicGenerator[netip.Addr]{
-			schema: map[string]any{"type": "ipv6"},
+			schema: map[string]any{"type": "ip_addresses", "version": int64(6)},
 			parse:  addrTransform,
 		},
 	).asBasic()

--- a/combinators.go
+++ b/combinators.go
@@ -202,17 +202,17 @@ func (g IPAddressGenerator) asBasic() (*basicGenerator[netip.Addr], bool, error)
 	}
 	if g.version != 0 {
 		return &basicGenerator[netip.Addr]{
-			schema: map[string]any{"type": "ip_addresses", "version": g.version},
+			schema: map[string]any{"type": "ip_address", "version": g.version},
 			parse:  addrTransform,
 		}, true, nil
 	}
 	return OneOf(
 		&basicGenerator[netip.Addr]{
-			schema: map[string]any{"type": "ip_addresses", "version": int64(4)},
+			schema: map[string]any{"type": "ip_address", "version": int64(4)},
 			parse:  addrTransform,
 		},
 		&basicGenerator[netip.Addr]{
-			schema: map[string]any{"type": "ip_addresses", "version": int64(6)},
+			schema: map[string]any{"type": "ip_address", "version": int64(6)},
 			parse:  addrTransform,
 		},
 	).asBasic()

--- a/installer.go
+++ b/installer.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-const hegelServerVersion = "0.5.0"
+const hegelServerVersion = "0.6.0"
 
 // hegelServerCommandEnv is the environment variable that overrides automatic installation.
 const hegelServerCommandEnv = "HEGEL_SERVER_COMMAND"

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -378,7 +378,7 @@ func TestOptionalNonBasicE2E(t *testing.T) {
 // =============================================================================
 
 // TestIPAddressesV4Schema verifies that IPAddresses(v4) produces
-// {"type":"ip_addresses", "version": 4}.
+// {"type":"ip_address", "version": 4}.
 func TestIPAddressesV4Schema(t *testing.T) {
 	t.Parallel()
 	g := IPAddresses().IPv4()
@@ -389,8 +389,8 @@ func TestIPAddressesV4Schema(t *testing.T) {
 	if !ok {
 		t.Fatal("IPAddresses(v4) should be basic")
 	}
-	if bg.schema["type"] != "ip_addresses" {
-		t.Errorf("IPAddresses(v4) type: expected ip_addresses, got %v", bg.schema["type"])
+	if bg.schema["type"] != "ip_address" {
+		t.Errorf("IPAddresses(v4) type: expected ip_address, got %v", bg.schema["type"])
 	}
 	if bg.schema["version"].(int64) != 4 {
 		t.Errorf("IPAddresses(v4) version: expected 4, got %v", bg.schema["version"])
@@ -398,7 +398,7 @@ func TestIPAddressesV4Schema(t *testing.T) {
 }
 
 // TestIPAddressesV6Schema verifies that IPAddresses(v6) produces
-// {"type":"ip_addresses", "version": 6}.
+// {"type":"ip_address", "version": 6}.
 func TestIPAddressesV6Schema(t *testing.T) {
 	t.Parallel()
 	g := IPAddresses().IPv6()
@@ -409,8 +409,8 @@ func TestIPAddressesV6Schema(t *testing.T) {
 	if !ok {
 		t.Fatal("IPAddresses(v6) should be basic")
 	}
-	if bg.schema["type"] != "ip_addresses" {
-		t.Errorf("IPAddresses(v6) type: expected ip_addresses, got %v", bg.schema["type"])
+	if bg.schema["type"] != "ip_address" {
+		t.Errorf("IPAddresses(v6) type: expected ip_address, got %v", bg.schema["type"])
 	}
 	if bg.schema["version"].(int64) != 6 {
 		t.Errorf("IPAddresses(v6) version: expected 6, got %v", bg.schema["version"])
@@ -418,7 +418,7 @@ func TestIPAddressesV6Schema(t *testing.T) {
 }
 
 // TestIPAddressesDefaultIsOneOf verifies that IPAddresses(no version) returns
-// a one_of of two ip_addresses branches, one per IP version.
+// a one_of of two ip_address branches, one per IP version.
 func TestIPAddressesDefaultIsOneOf(t *testing.T) {
 	t.Parallel()
 	g := IPAddresses()
@@ -447,8 +447,8 @@ func TestIPAddressesDefaultIsOneOf(t *testing.T) {
 		if !ok {
 			t.Fatalf("branch %d should be map[string]any, got %T", i, s)
 		}
-		if m["type"] != "ip_addresses" {
-			t.Errorf("branch %d type: expected ip_addresses, got %v", i, m["type"])
+		if m["type"] != "ip_address" {
+			t.Errorf("branch %d type: expected ip_address, got %v", i, m["type"])
 		}
 		if m["version"].(int64) != wantVersions[i] {
 			t.Errorf("branch %d version: expected %d, got %v", i, wantVersions[i], m["version"])

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -377,7 +377,8 @@ func TestOptionalNonBasicE2E(t *testing.T) {
 // IPAddresses
 // =============================================================================
 
-// TestIPAddressesV4Schema verifies that IPAddresses(v4) produces {"type":"ipv4"}.
+// TestIPAddressesV4Schema verifies that IPAddresses(v4) produces
+// {"type":"ip_addresses", "version": 4}.
 func TestIPAddressesV4Schema(t *testing.T) {
 	t.Parallel()
 	g := IPAddresses().IPv4()
@@ -388,12 +389,16 @@ func TestIPAddressesV4Schema(t *testing.T) {
 	if !ok {
 		t.Fatal("IPAddresses(v4) should be basic")
 	}
-	if bg.schema["type"] != "ipv4" {
-		t.Errorf("IPAddresses(v4) type: expected ipv4, got %v", bg.schema["type"])
+	if bg.schema["type"] != "ip_addresses" {
+		t.Errorf("IPAddresses(v4) type: expected ip_addresses, got %v", bg.schema["type"])
+	}
+	if bg.schema["version"].(int64) != 4 {
+		t.Errorf("IPAddresses(v4) version: expected 4, got %v", bg.schema["version"])
 	}
 }
 
-// TestIPAddressesV6Schema verifies that IPAddresses(v6) produces {"type":"ipv6"}.
+// TestIPAddressesV6Schema verifies that IPAddresses(v6) produces
+// {"type":"ip_addresses", "version": 6}.
 func TestIPAddressesV6Schema(t *testing.T) {
 	t.Parallel()
 	g := IPAddresses().IPv6()
@@ -404,12 +409,16 @@ func TestIPAddressesV6Schema(t *testing.T) {
 	if !ok {
 		t.Fatal("IPAddresses(v6) should be basic")
 	}
-	if bg.schema["type"] != "ipv6" {
-		t.Errorf("IPAddresses(v6) type: expected ipv6, got %v", bg.schema["type"])
+	if bg.schema["type"] != "ip_addresses" {
+		t.Errorf("IPAddresses(v6) type: expected ip_addresses, got %v", bg.schema["type"])
+	}
+	if bg.schema["version"].(int64) != 6 {
+		t.Errorf("IPAddresses(v6) version: expected 6, got %v", bg.schema["version"])
 	}
 }
 
-// TestIPAddressesDefaultIsOneOf verifies that IPAddresses(no version) returns a OneOf generator.
+// TestIPAddressesDefaultIsOneOf verifies that IPAddresses(no version) returns
+// a one_of of two ip_addresses branches, one per IP version.
 func TestIPAddressesDefaultIsOneOf(t *testing.T) {
 	t.Parallel()
 	g := IPAddresses()
@@ -431,6 +440,19 @@ func TestIPAddressesDefaultIsOneOf(t *testing.T) {
 	schemas, ok := generators.([]any)
 	if !ok || len(schemas) != 2 {
 		t.Fatalf("IPAddresses(default) generators should have 2 branches, got %v", generators)
+	}
+	wantVersions := []int64{4, 6}
+	for i, s := range schemas {
+		m, ok := s.(map[string]any)
+		if !ok {
+			t.Fatalf("branch %d should be map[string]any, got %T", i, s)
+		}
+		if m["type"] != "ip_addresses" {
+			t.Errorf("branch %d type: expected ip_addresses, got %v", i, m["type"])
+		}
+		if m["version"].(int64) != wantVersions[i] {
+			t.Errorf("branch %d version: expected %d, got %v", i, wantVersions[i], m["version"])
+		}
 	}
 }
 


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Coordinated wire-protocol cleanup with hegel-core. The Go-side changes:

- `Optional` now emits `{"type": "constant", "value": nil}` for its null branch instead of `{"type": "null"}`. Tracks https://github.com/hegeldev/hegel-core/issues/77.
- `IPAddresses` now emits `{"type": "ip_addresses", "version": N}` (with `N` either `4` or `6`) instead of `{"type": "ipv4"}` / `{"type": "ipv6"}`. Tracks https://github.com/hegeldev/hegel-core/issues/78.
- Internal `IPAddressGenerator.version` is now an `int64` (`0` = unset, `4`/`6` = explicit) to match the wire shape directly.

No source change is needed for https://github.com/hegeldev/hegel-core/issues/82 — `SampledFrom` already emits the integer-index schema.

The public Go API is unchanged.

## Expected CI failures

E2E tests that exercise the protocol against the locally installed `hegel` binary (e.g. `TestIPAddressesV4E2E`, `TestIPAddressesDefaultE2E`, `TestOptionalE2E`) will fail until the coordinated hegel-core PR merges and a release is published. Coverage CI will fail downstream of those test failures. Schema-only unit tests (`TestIPAddressesV4Schema`, `TestIPAddressesV6Schema`, `TestIPAddressesDefaultIsOneOf`, `TestOptionalSchema`) all pass locally. The Plait tend daemon should not try to fix these.

</details>
