### PR TITLE
claude: rename hegel.Case to hegel.Test with new signature

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,19 +49,19 @@ body.
 
 The `hegel` subprocess is managed by a global session that starts lazily on first
 use and shuts down automatically on process exit. Users never construct connections
-or sessions manually — `Case` (and the low-level `RunHegelTestE`) are plain free
+or sessions manually — `Test` (and the low-level `Run`) are plain free
 functions.
 
 ## Public API
 
 The user-facing surface lives in `hegel.go` (canonical package doc). Entry points:
 
-- `hegel.Case(fn, opts...) func(*testing.T)` — wraps a property test for `t.Run`
+- `hegel.Test(t, fn, opts...)` — runs a property test as part of `t`
 - `hegel.Draw(ht, gen)` — draws a value inside a test body
 - `hegel.T` — passed to the test body; methods include `Note`, `Fatal`, `Fatalf`
 - Generators: `Integers`, `Floats`, `Text`, `Booleans`, `Lists`, `Maps`, ...
 - Options: `WithTestCases(n)` and other `Option` funcs configure runs
-- Low-level: `RunHegelTestE` is the runner Case wraps; useful in error-injection tests
+- Low-level: `Run` is the bare runner Test wraps; useful in error-injection tests
 
 ## Testing Philosophy
 
@@ -77,7 +77,7 @@ The user-facing surface lives in `hegel.go` (canonical package doc). Entry point
 
 ### HEGEL_PROTOCOL_TEST_MODE — Error Injection
 
-Set the `HEGEL_PROTOCOL_TEST_MODE` environment variable before calling `RunHegelTestE` to
+Set the `HEGEL_PROTOCOL_TEST_MODE` environment variable before calling `Run` to
 trigger server-side error injection:
 
 | Mode                          | What it does                                      |
@@ -151,7 +151,7 @@ Failing to handle StopTest correctly causes `FlakyStrategyDefinition` errors.
 
 ### Test isolation with HEGEL_PROTOCOL_TEST_MODE
 
-- Test-mode hegel handles exactly ONE `run_test` then exits. `RunHegelTestE` creates a fresh temporary session when this env var is set.
+- Test-mode hegel handles exactly ONE `run_test` then exits. `Run` creates a fresh temporary session when this env var is set.
 - Test-mode sessions suppress stderr to avoid Python tracebacks in test output.
 
 ### Protocol field names

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ func mySort(ls []int) []int {
 }
 
 func TestMatchesBuiltin(t *testing.T) {
-	t.Run("matches builtin", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		slice1 := hegel.Draw(ht, hegel.Lists(hegel.Integers(math.MinInt, math.MaxInt)))
 		slice2 := mySort(slice1)
 		slices.Sort(slice1)
 		if !slices.Equal(slice1, slice2) {
 			ht.Fatalf("slices not equal: %v != %v", slice1, slice2)
 		}
-	}))
+	})
 }
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+RELEASE_TYPE: minor
+
+This release removes `hegel.Case` in favor of a new `hegel.Test`. `hegel.Test` is now the recommended way to write Hegel tests.
+
+```go
+// before
+func TestA(t *testing.T) {
+	t.Run("test_name", hegel.Case(func(ht *hegel.T) {
+		hegel.Draw(ht, hegel.Integers(-1000, 1000))
+	}))
+}
+
+// after
+func TestA(t *testing.T) {
+	hegel.Test(t, func(ht *hegel.T) {
+		hegel.Draw(ht, hegel.Integers(-1000, 1000))
+	})
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -8,25 +8,25 @@ import (
 	"hegel.dev/go/hegel"
 )
 
-func ExampleCase() {
+func ExampleTest() {
 	t := &testing.T{} // in real code, use the *testing.T from your test function
-	t.Run("integers", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		n := hegel.Draw(ht, hegel.Integers(0, 200))
 		if n >= 50 {
 			ht.Fatalf("n=%d is too large", n)
 		}
-	}))
+	})
 }
 
-func ExampleCase_withTestCases() {
+func ExampleTest_withTestCases() {
 	t := &testing.T{}
-	t.Run("many", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		a := hegel.Draw(ht, hegel.Integers(-1000, 1000))
 		b := hegel.Draw(ht, hegel.Integers(-1000, 1000))
 		if a+b != b+a {
 			ht.Fatal("addition is not commutative")
 		}
-	}, hegel.WithTestCases(500)))
+	}, hegel.WithTestCases(500))
 }
 
 func ExampleRun() {
@@ -41,17 +41,17 @@ func ExampleRun() {
 
 func ExampleDraw() {
 	t := &testing.T{}
-	t.Run("multiple_values", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		n := hegel.Draw(ht, hegel.Integers(math.MinInt, math.MaxInt))
 		s := hegel.Draw(ht, hegel.Text().MaxSize(50))
 		_ = n // n is int
 		_ = s // s is string
-	}))
+	})
 }
 
 func ExampleFilter() {
 	t := &testing.T{}
-	t.Run("even_integers", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		evenIntegers := hegel.Filter(hegel.Integers(math.MinInt, math.MaxInt), func(v int) bool {
 			return v%2 == 0
 		})
@@ -59,12 +59,12 @@ func ExampleFilter() {
 		if n%2 != 0 {
 			ht.Fatalf("%d is not even", n)
 		}
-	}))
+	})
 }
 
-func ExampleCase_assume() {
+func ExampleTest_assume() {
 	t := &testing.T{}
-	t.Run("division", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		n1 := hegel.Draw(ht, hegel.Integers(-1000, 1000))
 		n2 := hegel.Draw(ht, hegel.Integers(-1000, 1000))
 		ht.Assume(n2 != 0)
@@ -72,12 +72,12 @@ func ExampleCase_assume() {
 		if n1 != q*n2+r {
 			ht.Fatalf("%d != %d*%d + %d", n1, q, n2, r)
 		}
-	}))
+	})
 }
 
 func ExampleMap() {
 	t := &testing.T{}
-	t.Run("string_of_digits", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		s := hegel.Draw(ht, hegel.Map(hegel.Integers(0, 100), func(n int) string {
 			return fmt.Sprintf("%d", n)
 		}))
@@ -86,12 +86,12 @@ func ExampleMap() {
 				ht.Fatalf("%q contains non-digit %c", s, c)
 			}
 		}
-	}))
+	})
 }
 
 func ExampleDraw_dependentGeneration() {
 	t := &testing.T{}
-	t.Run("list_with_valid_index", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		n := hegel.Draw(ht, hegel.Integers(1, 10))
 		lst := hegel.Draw(ht, hegel.Lists(
 			hegel.Integers(math.MinInt, math.MaxInt),
@@ -100,12 +100,12 @@ func ExampleDraw_dependentGeneration() {
 		if index < 0 || index >= len(lst) {
 			ht.Fatal("index out of range")
 		}
-	}))
+	})
 }
 
 func ExampleFlatMap() {
 	t := &testing.T{}
-	t.Run("flatmap_example", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		result := hegel.Draw(ht, hegel.FlatMap(
 			hegel.Integers(1, 5),
 			func(n int) hegel.Generator[[]int] {
@@ -117,28 +117,28 @@ func ExampleFlatMap() {
 		if len(result) < 1 || len(result) > 5 {
 			ht.Fatalf("unexpected list length: %d", len(result))
 		}
-	}))
+	})
 }
 
-func ExampleCase_note() {
+func ExampleTest_note() {
 	t := &testing.T{}
-	t.Run("commutativity", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		x := hegel.Draw(ht, hegel.Integers(-1000, 1000))
 		y := hegel.Draw(ht, hegel.Integers(-1000, 1000))
 		ht.Note(fmt.Sprintf("trying x=%d, y=%d", x, y))
 		if x+y != y+x {
 			ht.Fatal("addition is not commutative")
 		}
-	}))
+	})
 }
 
-func ExampleCase_target() {
+func ExampleTest_target() {
 	t := &testing.T{}
-	t.Run("seek_large_values", hegel.Case(func(ht *hegel.T) {
+	hegel.Test(t, func(ht *hegel.T) {
 		x := hegel.Draw(ht, hegel.Integers(0, 10000))
 		ht.Target(float64(x), "maximize_x")
 		if x > 9999 {
 			ht.Fatalf("x=%d exceeds limit", x)
 		}
-	}, hegel.WithTestCases(1000)))
+	}, hegel.WithTestCases(1000))
 }

--- a/hegel.go
+++ b/hegel.go
@@ -14,20 +14,20 @@
 // # Write your first test
 //
 // You're now ready to write your first test. Hegel integrates directly with
-// go test via [Case], which returns a func(*testing.T) for use with t.Run:
+// go test via [Test]:
 //
 //	func TestIntegerSelfEquality(t *testing.T) {
-//		t.Run("integer_self_equality", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			n := hegel.Draw(ht, hegel.Integers(math.MinInt, math.MaxInt))
 //			if n != n {
 //				ht.Fatal("integer was not equal to itself")
 //			}
-//		}))
+//		})
 //	}
 //
 // Now run the test using go test. You should see that this test passes.
 //
-// Let's look at what's happening in more detail. [Case] runs your test
+// Let's look at what's happening in more detail. [Test] runs your test
 // many times (100, by default). The test function receives a *[T],
 // which is used with the [Draw] function for drawing different values.
 // This test draws a random integer and checks that it should be equal
@@ -36,12 +36,12 @@
 // Next, try a test that fails:
 //
 //	func TestIntegersAlwaysBelow50(t *testing.T) {
-//		t.Run("integers_always_below_50", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			n := hegel.Draw(ht, hegel.Integers(math.MinInt, math.MaxInt))
 //			if n >= 50 {
 //				ht.Fatalf("n=%d is too large", n)
 //			}
-//		}))
+//		})
 //	}
 //
 // This test asserts that any integer is less than 50, which is obviously
@@ -53,12 +53,12 @@
 // min and max arguments to [Integers]:
 //
 //	func TestBoundedIntegersAlwaysBelow50(t *testing.T) {
-//		t.Run("bounded_integers_always_below_50", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			n := hegel.Draw(ht, hegel.Integers(0, 49))
 //			if n >= 50 {
 //				ht.Fatalf("n=%d is too large", n)
 //			}
-//		}))
+//		})
 //	}
 //
 // Run the test again. It should now pass.
@@ -73,14 +73,14 @@
 // For example, you can use [Lists] to generate a slice of integers:
 //
 //	func TestAppendIncreasesLength(t *testing.T) {
-//		t.Run("append_increases_length", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			slice := hegel.Draw(ht, hegel.Lists(hegel.Integers(math.MinInt, math.MaxInt)))
 //			initialLength := len(slice)
 //			slice = append(slice, hegel.Draw(ht, hegel.Integers(math.MinInt, math.MaxInt)))
 //			if len(slice) <= initialLength {
 //				ht.Fatal("length did not increase")
 //			}
-//		}))
+//		})
 //	}
 //
 // This test checks that appending an element to a random slice of integers
@@ -96,13 +96,13 @@
 //			Age  int
 //			Name string
 //		}
-//		t.Run("person", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			person := Person{
 //				Age:  hegel.Draw(ht, hegel.Integers(0, 120)),
 //				Name: hegel.Draw(ht, hegel.Text().MinSize(1).MaxSize(50)),
 //			}
 //			_ = person // use person in your test
-//		}))
+//		})
 //	}
 //
 // Note that you can feed the results of a [Draw] to subsequent calls.
@@ -115,7 +115,7 @@
 //			Name           string
 //			DrivingLicense bool
 //		}
-//		t.Run("person_with_license", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			age := hegel.Draw(ht, hegel.Integers(0, 120))
 //			name := hegel.Draw(ht, hegel.Text().MinSize(1).MaxSize(50))
 //			drivingLicense := false
@@ -124,7 +124,7 @@
 //			}
 //			person := Person{Age: age, Name: name, DrivingLicense: drivingLicense}
 //			_ = person // use person in your test
-//		}))
+//		})
 //	}
 //
 // # Debug your failing test cases
@@ -132,14 +132,14 @@
 // Use the [TestCase.Note] method to attach debug information:
 //
 //	func TestWithNotes(t *testing.T) {
-//		t.Run("with_notes", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			x := hegel.Draw(ht, hegel.Integers(math.MinInt, math.MaxInt))
 //			y := hegel.Draw(ht, hegel.Integers(math.MinInt, math.MaxInt))
 //			ht.Note(fmt.Sprintf("x + y = %d, y + x = %d", x+y, y+x))
 //			if x+y != y+x {
 //				ht.Fatal("addition is not commutative")
 //			}
-//		}))
+//		})
 //	}
 //
 // Notes only appear when Hegel replays the minimal failing example.
@@ -150,12 +150,12 @@
 // [WithTestCases]:
 //
 //	func TestIntegersMany(t *testing.T) {
-//		t.Run("integers_many", hegel.Case(func(ht *hegel.T) {
+//		hegel.Test(t, func(ht *hegel.T) {
 //			n := hegel.Draw(ht, hegel.Integers(math.MinInt, math.MaxInt))
 //			if n != n {
 //				ht.Fatal("integer was not equal to itself")
 //			}
-//		}, hegel.WithTestCases(500)))
+//		}, hegel.WithTestCases(500))
 //	}
 //
 // # Learning more

--- a/runner.go
+++ b/runner.go
@@ -20,7 +20,7 @@ type TestCase struct {
 	isFinal bool
 	aborted bool
 	failed  bool         // for T.Error/Fail deferred INTERESTING
-	noteFn  func(string) // injected: t.Log for Case, stderr for Run
+	noteFn  func(string) // injected: t.Log for Test, stderr for Run
 }
 
 // --- Sentinel errors ---
@@ -60,7 +60,7 @@ func (s *TestCase) Assume(condition bool) {
 
 // Note prints message, but only during the final (replay) test case.
 //
-// Output is routed to t.Log for [Case], or stderr for [Run].
+// Output is routed to t.Log for [Test], or stderr for [Run].
 func (s *TestCase) Note(message string) {
 	if s.isFinal && s.noteFn != nil {
 		s.noteFn(message)
@@ -182,7 +182,7 @@ type runOptions struct {
 	suppressHealthCheck []HealthCheck
 }
 
-// Option is a functional option for Case and Run.
+// Option is a functional option for Test and Run.
 type Option func(*runOptions)
 
 // WithTestCases sets the number of test cases to run.
@@ -214,21 +214,20 @@ func MustRun(fn func(*TestCase), opts ...Option) {
 	}
 }
 
-// Case returns a test function for use with testing.T.Run.
+// Test runs a property test as part of t.
 //
-// Note output is routed to t.Log.
-func Case(fn func(*T), opts ...Option) func(*testing.T) {
-	return func(t *testing.T) {
-		t.Helper()
+// Note output is routed to t.Log. Use [testing.T.Run] to organize multiple
+// property tests into subtests in the standard Go way.
+func Test(t *testing.T, fn func(*T), opts ...Option) {
+	t.Helper()
 
-		body := func(s *TestCase) {
-			ht := &T{TestCase: s, T: t}
-			fn(ht)
-		}
-		err := runHegel(body, func(msg string) { t.Log(msg) }, opts) // coverage-ignore
-		if err != nil {                                              // coverage-ignore
-			t.Fatal(err)
-		}
+	body := func(s *TestCase) {
+		ht := &T{TestCase: s, T: t}
+		fn(ht)
+	}
+	err := runHegel(body, func(msg string) { t.Log(msg) }, opts) // coverage-ignore
+	if err != nil {                                              // coverage-ignore
+		t.Fatal(err)
 	}
 }
 
@@ -237,7 +236,7 @@ func stderrNoteFn(msg string) {
 	fmt.Fprintln(os.Stderr, msg)
 }
 
-// runHegel is the shared implementation for Run, MustRun, and Case.
+// runHegel is the shared implementation for Run, MustRun, and Test.
 func runHegel(fn testBody, noteFn func(string), opts []Option) error {
 	o := runOptions{testCases: 100}
 	for _, opt := range opts {

--- a/runner_test.go
+++ b/runner_test.go
@@ -913,15 +913,15 @@ func TestMustRunSuccess(t *testing.T) {
 }
 
 // =============================================================================
-// Public API: Case — via real binary
+// Public API: Test — via real binary
 // =============================================================================
 
-func TestCaseSuccess(t *testing.T) {
+func TestTestSuccess(t *testing.T) {
 
-	t.Run("case_test", Case(func(ht *T) {
+	Test(t, func(ht *T) {
 		_ = Draw[bool](ht, Booleans())
-		ht.Note("test note via Case")
-	}, WithTestCases(1)))
+		ht.Note("test note via Test")
+	}, WithTestCases(1))
 }
 
 // =============================================================================
@@ -955,10 +955,10 @@ func TestFatalSentinelPath(t *testing.T) {
 }
 
 // =============================================================================
-// Case: noteFn (t.Log) is called on final replay
+// Test: noteFn (t.Log) is called on final replay
 // =============================================================================
 
-func TestCaseNoteFnOnFinal(t *testing.T) {
+func TestTestNoteFnOnFinal(t *testing.T) {
 
 	noted := false
 	err := runHegel(func(s *TestCase) {

--- a/state.go
+++ b/state.go
@@ -8,7 +8,7 @@ import (
 // Compile-time check that T satisfies testing.TB.
 var _ testing.TB = (*T)(nil)
 
-// T is the test context for property tests run via [Case].
+// T is the test context for property tests run via [Test].
 //
 // It embeds *[testing.T] and overrides methods like Fatal and Skip so they
 // work correctly inside a Hegel test body.


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Resolves #59 by replacing `hegel.Case(fn, opts...) func(*testing.T)` with `hegel.Test(t *testing.T, fn, opts...)`. A hegel test is a full Go test, not a subtest, so requiring a name via `t.Run` was a poor fit. Users who want subtests can still combine `hegel.Test` with `t.Run` in the standard way.

```go
// before
func TestA(t *testing.T) {
    t.Run("commutativity", hegel.Case(func(ht *hegel.T) {
        a := hegel.Draw(ht, hegel.Integers(-1000, 1000))
        b := hegel.Draw(ht, hegel.Integers(-1000, 1000))
        if a+b != b+a {
            ht.Fatal("addition is not commutative")
        }
    }))
}

// after
func TestA(t *testing.T) {
    hegel.Test(t, func(ht *hegel.T) {
        a := hegel.Draw(ht, hegel.Integers(-1000, 1000))
        b := hegel.Draw(ht, hegel.Integers(-1000, 1000))
        if a+b != b+a {
            ht.Fatal("addition is not commutative")
        }
    })
}
```

This is a breaking change, packaged as a `minor` release per the project's beta-period convention (matching `0.2.0`'s `Dicts → Maps` rename).

Updated `runner.go`, `state.go`, and `hegel.go` doc comments; rewrote all `Example*` functions in `example_test.go` (renaming `ExampleCase*` → `ExampleTest*` so `go doc` continues to associate them with the new function); updated the `README.md` quickstart; refreshed stale `Case`/`RunHegelTestE` references in `.claude/CLAUDE.md`; renamed `TestCaseSuccess`/`TestCaseNoteFnOnFinal` in `runner_test.go`. `TestDocExamplesCompile` continues to validate that all code blocks in `README.md` and `hegel.go` compile.

</details>
