### PR TITLE
claude: add WithDatabase and WithDerandomize options

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,8 +13,6 @@ just conformance        # Build conformance binaries + run Python conformance te
 go test -run TestName ./...  # Run a single test
 ```
 
-Tests must use `PATH="$(pwd)/.venv/bin:$PATH"` (absolute path) so the `hegel` binary is found.
-
 ## What This Is
 
 A Go implementation of the Hegel property-based testing library. Hegel is a
@@ -49,19 +47,24 @@ body.
 
 The `hegel` subprocess is managed by a global session that starts lazily on first
 use and shuts down automatically on process exit. Users never construct connections
-or sessions manually — `Test` (and the low-level `Run`) are plain free
-functions.
+or sessions manually — `Test`, `Run`, and `MustRun` are plain free functions.
 
 ## Public API
 
 The user-facing surface lives in `hegel.go` (canonical package doc). Entry points:
 
-- `hegel.Test(t, fn, opts...)` — runs a property test as part of `t`
+- `hegel.Test(t, fn, opts...)` — runs a property test against a `*testing.T`
+- `hegel.Run(fn, opts...) error` — runs a property test outside `*testing.T`
+  (conformance binaries, standalone tools); returns an error
+- `hegel.MustRun(fn, opts...)` — like Run, but panics on failure
 - `hegel.Draw(ht, gen)` — draws a value inside a test body
-- `hegel.T` — passed to the test body; methods include `Note`, `Fatal`, `Fatalf`
+- `hegel.T` — passed to the [Test] body; methods include `Note`, `Fatal`, `Fatalf`
 - Generators: `Integers`, `Floats`, `Text`, `Booleans`, `Lists`, `Maps`, ...
-- Options: `WithTestCases(n)` and other `Option` funcs configure runs
-- Low-level: `Run` is the bare runner Test wraps; useful in error-injection tests
+- Options: `WithTestCases(n)`, `WithDatabase(Database(path))`,
+  `WithDatabase(DatabaseDisabled())`, `WithDerandomize(bool)`,
+  `SuppressHealthCheck(...)`
+- Low-level: the unexported `runHegel` is what `Test`, `Run`, and `MustRun`
+  delegate to; useful in error-injection tests via direct call
 
 ## Testing Philosophy
 
@@ -77,8 +80,8 @@ The user-facing surface lives in `hegel.go` (canonical package doc). Entry point
 
 ### HEGEL_PROTOCOL_TEST_MODE — Error Injection
 
-Set the `HEGEL_PROTOCOL_TEST_MODE` environment variable before calling `Run` to
-trigger server-side error injection:
+Set the `HEGEL_PROTOCOL_TEST_MODE` environment variable before calling `Run` (or
+`runHegel` directly in tests) to trigger server-side error injection:
 
 | Mode                          | What it does                                      |
 |-------------------------------|---------------------------------------------------|
@@ -128,7 +131,6 @@ Failing to handle StopTest correctly causes `FlakyStrategyDefinition` errors.
 - **Error handling**: Return `error` for failable operations; `panic()` for truly unreachable code paths
 - **Doc comments**: Every exported symbol must have a doc comment starting with the symbol name
 - **Coverage**: 100% enforced via `go-test-coverage` with `// coverage-ignore` for exclusions; annotation count ratcheted in `.github/coverage-ratchet.json`
-- **Test execution**: Tests use `PATH="$(pwd)/.venv/bin:$PATH"` (absolute path) to find the `hegel` binary — relative paths don't work with `exec.LookPath`
 
 ## Developer Notes
 

--- a/.github/coverage-ratchet.json
+++ b/.github/coverage-ratchet.json
@@ -1,3 +1,3 @@
 {
-  "coverage_ignore_count": 42
+  "coverage_ignore_count": 45
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+RELEASE_TYPE: patch
+
+This release adds the `WithDatabase` option, which controls the location of the test case database:
+
+```go
+hegel.Test(t, func(ht *hegel.T) {
+    ...
+}, hegel.WithDatabase(hegel.Database("my_custom_directory")))
+
+// disable the database
+hegel.Test(t, func(ht *hegel.T) {
+    ...
+}, hegel.WithDatabase(hegel.DatabaseDisabled()))
+```
+
+This release also adds the `WithDerandomize` option, which can be set to make the test run deterministically:
+
+```go
+hegel.Test(t, func(ht *hegel.T) {
+    ...
+}, hegel.WithDerandomize(true))
+```

--- a/database_test.go
+++ b/database_test.go
@@ -1,0 +1,151 @@
+package hegel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func readValues(t *testing.T, dir, label string) []int64 {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, label))
+	if err != nil {
+		t.Fatalf("read values %s: %v", label, err)
+	}
+	var out []int64
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		n, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			t.Fatalf("parse %q: %v", line, err)
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+func TestDatabasePersistsFailingExamples(t *testing.T) {
+	clearCIEnv(t)
+	dbDir := t.TempDir()
+
+	entries, err := os.ReadDir(dbDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatal("expected empty database directory before the run")
+	}
+
+	err = runHegel(func(_ *TestCase) {
+		panic("")
+	}, stdoutNoteFn, []Option{
+		WithDatabase(Database(dbDir)),
+		withDatabaseKey([]byte("test_database_persists")),
+	})
+	if err == nil {
+		t.Fatal("expected property test failure")
+	}
+	if !strings.Contains(err.Error(), "property test failed") {
+		t.Errorf("error %q does not contain 'property test failed'", err.Error())
+	}
+
+	entries, err = os.ReadDir(dbDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected database directory to contain saved examples")
+	}
+}
+
+func TestDatabaseKeyReplaysFailure(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "database")
+	if err := os.MkdirAll(dbPath, 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	valuesPath := filepath.Join(tempDir, "values")
+	if err := os.MkdirAll(valuesPath, 0o755); err != nil {
+		t.Fatalf("mkdir values: %v", err)
+	}
+	dbStr := strings.ReplaceAll(dbPath, "\\", "/")
+
+	clearCIEnv(t)
+	t.Setenv("VALUES_DIR", valuesPath)
+
+	testCode := fmt.Sprintf(`package temptest
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"hegel.dev/go/hegel"
+)
+
+func recordTestCase(label string, n int64) {
+	path := filepath.Join(os.Getenv("VALUES_DIR"), label)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%%d\n", n)
+}
+
+func TestReplay1(t *testing.T) {
+	hegel.Test(t, func(ht *hegel.T) {
+		n := hegel.Draw[int64](ht, hegel.Integers[int64](math.MinInt64, math.MaxInt64))
+		recordTestCase("TestReplay1", n)
+		if n >= 1_000_000 {
+			panic(fmt.Sprintf("n=%%d", n))
+		}
+	}, hegel.WithDatabase(hegel.Database(%q)))
+}
+
+func TestReplay2(t *testing.T) {
+	hegel.Test(t, func(ht *hegel.T) {
+		n := hegel.Draw[int64](ht, hegel.Integers[int64](math.MinInt64, math.MaxInt64))
+		recordTestCase("TestReplay2", n)
+		if n >= 1_000_000 {
+			panic(fmt.Sprintf("n=%%d", n))
+		}
+	}, hegel.WithDatabase(hegel.Database(%q)))
+}
+`, dbStr, dbStr)
+
+	project := newTempGoProject(t)
+	project.writeFile("hegel_test.go", testCode)
+	project.expectFailure(`property test failed`)
+
+	// run TestReplay1: database now has a failing entry for it.
+	project.goTest("-run", "^TestReplay1$")
+	values := readValues(t, valuesPath, "TestReplay1")
+	shrunk := values[len(values)-1]
+	if shrunk != 1_000_000 {
+		t.Fatalf("shrunk value = %d, want 1000000", shrunk)
+	}
+
+	// clear the log file
+	if err := os.Remove(filepath.Join(valuesPath, "TestReplay1")); err != nil {
+		t.Fatalf("remove values: %v", err)
+	}
+
+	// run TestReplay1 again. It should replay the shrunk test case immediately.
+	project.goTest("-run", "^TestReplay1$")
+	values = readValues(t, valuesPath, "TestReplay1")
+	if values[0] != shrunk {
+		t.Fatalf("expected to replay shrunk test case %d first, got %d", shrunk, values[0])
+	}
+
+	// run TestReplay2. It should not replay the TestReplay1 shrunk test case.
+	project.goTest("-run", "^TestReplay2$")
+	values = readValues(t, valuesPath, "TestReplay2")
+	if values[0] == shrunk {
+		t.Fatalf("expected NOT to replay %d for TestReplay2, but got it", shrunk)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -29,14 +29,28 @@ func ExampleTest_withTestCases() {
 	}, hegel.WithTestCases(500))
 }
 
-func ExampleRun() {
-	err := hegel.Run(func(s *hegel.TestCase) {
-		n := hegel.Draw(s, hegel.Integers(0, 100))
-		if n < 0 || n > 100 {
-			panic("out of range")
+func ExampleTest_withDatabase() {
+	t := &testing.T{}
+	hegel.Test(t, func(ht *hegel.T) {
+		n := hegel.Draw(ht, hegel.Integers(0, 100))
+		if n < 0 {
+			ht.Fatal("negative integer should not be generated")
 		}
-	}, hegel.WithTestCases(50))
-	_ = err
+	}, hegel.WithDatabase(hegel.Database("my_hegel_database")))
+}
+
+func ExampleTest_disableDatabase() {
+	t := &testing.T{}
+	hegel.Test(t, func(ht *hegel.T) {
+		_ = hegel.Draw(ht, hegel.Booleans())
+	}, hegel.WithDatabase(hegel.DatabaseDisabled()))
+}
+
+func ExampleTest_withDerandomize() {
+	t := &testing.T{}
+	hegel.Test(t, func(ht *hegel.T) {
+		_ = hegel.Draw(ht, hegel.Integers(0, 100))
+	}, hegel.WithDerandomize(true))
 }
 
 func ExampleDraw() {

--- a/filter_test.go
+++ b/filter_test.go
@@ -125,14 +125,12 @@ func TestFilteredGeneratorGeneratePredicatePassesFirstTry(t *testing.T) {
 
 	// Filter that always passes: every value is accepted on first try.
 	gen := Filter(Integers[int](0, 100), func(v int) bool { return true })
-	if _err := Run(func(s *TestCase) {
-		n := gen.draw(s)
+	Test(t, func(ht *T) {
+		n := gen.draw(ht.TestCase)
 		if n < 0 || n > 100 {
 			panic(fmt.Sprintf("Filter: expected [0,100], got %d", n))
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // TestFilteredGeneratorGenerateWithRealPredicate verifies that Filter correctly
@@ -144,17 +142,15 @@ func TestFilteredGeneratorGenerateWithRealPredicate(t *testing.T) {
 	gen := Filter(Integers[int](0, 50), func(v int) bool {
 		return v%2 == 0
 	})
-	if _err := Run(func(s *TestCase) {
-		n := gen.draw(s)
+	Test(t, func(ht *T) {
+		n := gen.draw(ht.TestCase)
 		if n%2 != 0 {
 			panic(fmt.Sprintf("Filter even: expected even number, got %d", n))
 		}
 		if n < 0 || n > 50 {
 			panic(fmt.Sprintf("Filter even: expected [0,50], got %d", n))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestFilteredGeneratorGenerateChainedFilters verifies that chaining two Filter
@@ -168,14 +164,12 @@ func TestFilteredGeneratorGenerateChainedFilters(t *testing.T) {
 		Filter(Integers[int](0, 100), func(v int) bool { return v%2 == 0 }),
 		func(v int) bool { return v%4 == 0 },
 	)
-	if _err := Run(func(s *TestCase) {
-		n := gen.draw(s)
+	Test(t, func(ht *T) {
+		n := gen.draw(ht.TestCase)
 		if n%4 != 0 {
 			panic(fmt.Sprintf("chained filter: expected multiple of 4, got %d", n))
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // TestFilteredGeneratorGenerateThenMap verifies that Filter followed by Map
@@ -191,8 +185,8 @@ func TestFilteredGeneratorGenerateThenMap(t *testing.T) {
 	if _, ok := gen.(*mappedGenerator[int, int]); !ok {
 		t.Fatalf("Map(Filter(...)) should return *mappedGenerator, got %T", gen)
 	}
-	if _err := Run(func(s *TestCase) {
-		n := gen.draw(s)
+	Test(t, func(ht *T) {
+		n := gen.draw(ht.TestCase)
 		// result must be odd*10, so divisible by 10 but result/10 must be odd
 		quotient := n / 10
 		if quotient*10 != n {
@@ -201,7 +195,5 @@ func TestFilteredGeneratorGenerateThenMap(t *testing.T) {
 		if quotient%2 == 0 {
 			panic(fmt.Sprintf("filter+map: expected odd*10, got %d (quotient=%d is even)", n, quotient))
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }

--- a/formats_test.go
+++ b/formats_test.go
@@ -129,28 +129,24 @@ func TestDatetimesSchema(t *testing.T) {
 func TestEmailsE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		v := Draw(s, Emails())
+	Test(t, func(ht *T) {
+		v := Draw(ht, Emails())
 		if !strings.Contains(v, "@") {
 			panic("email does not contain '@': " + v)
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // TestURLsE2E verifies that generated URLs start with "http://" or "https://".
 func TestURLsE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		v := Draw(s, URLs())
+	Test(t, func(ht *T) {
+		v := Draw(ht, URLs())
 		if !strings.HasPrefix(v, "http://") && !strings.HasPrefix(v, "https://") {
 			panic("url does not start with http:// or https://: " + v)
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // isValidDomainChar returns true if r is a valid character in a domain label.
@@ -162,16 +158,14 @@ func isValidDomainChar(r rune) bool {
 func TestDomainsE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		v := Draw(s, Domains())
+	Test(t, func(ht *T) {
+		v := Draw(ht, Domains())
 		for _, r := range v {
 			if !isValidDomainChar(r) {
 				panic("domain contains invalid character '" + string(r) + "': " + v)
 			}
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // TestDomainsMaxLengthE2E verifies that generated domains respect the max_length constraint.
@@ -179,40 +173,34 @@ func TestDomainsMaxLengthE2E(t *testing.T) {
 	t.Parallel()
 
 	const maxLen = 20
-	if _err := Run(func(s *TestCase) {
-		v := Draw(s, Domains().MaxLength(maxLen))
+	Test(t, func(ht *T) {
+		v := Draw(ht, Domains().MaxLength(maxLen))
 		if len(v) > maxLen {
 			panic("domain exceeds max_length constraint: " + v)
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // TestDatesE2E verifies that generated dates are valid time.Time values.
 func TestDatesE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		v := Draw(s, Dates())
+	Test(t, func(ht *T) {
+		v := Draw(ht, Dates())
 		if v.IsZero() {
 			panic("date is zero value")
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // TestDatetimesE2E verifies that generated datetimes are valid time.Time values.
 func TestDatetimesE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		v := Draw(s, Datetimes())
+	Test(t, func(ht *T) {
+		v := Draw(ht, Datetimes())
 		if v.IsZero() {
 			panic("datetime is zero value")
 		}
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }

--- a/generators_test.go
+++ b/generators_test.go
@@ -78,13 +78,12 @@ func TestMappedGeneratorMapOnBasicInner(t *testing.T) {
 func TestCollectionStopTestOnNewCollection(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := Run(func(s *TestCase) {
-		max := 5
-		coll := newCollection(s, 0, &max)
-		_ = coll.More(s)
-	})
 	// Should not error -- the test was stopped, not failed.
-	_ = err
+	Test(t, func(ht *T) {
+		max := 5
+		coll := newCollection(ht.TestCase, 0, &max)
+		_ = coll.More(ht.TestCase)
+	})
 }
 
 // --- collection StopTest on collection_more ---
@@ -92,12 +91,11 @@ func TestCollectionStopTestOnNewCollection(t *testing.T) {
 func TestCollectionStopTestOnCollectionMore(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		max := 5
-		coll := newCollection(s, 0, &max)
-		_ = coll.More(s)
+		coll := newCollection(ht.TestCase, 0, &max)
+		_ = coll.More(ht.TestCase)
 	})
-	_ = err
 }
 
 // =============================================================================
@@ -144,15 +142,13 @@ func TestIntegersGeneratorHappyPath(t *testing.T) {
 	t.Parallel()
 
 	var vals []int64
-	if _err := Run(func(s *TestCase) {
-		v := Draw[int64](s, Integers[int64](0, 100))
+	Test(t, func(ht *T) {
+		v := Draw[int64](ht, Integers[int64](0, 100))
 		vals = append(vals, v)
 		if v < 0 || v > 100 {
 			panic(fmt.Sprintf("out of range: %d", v))
 		}
-	}, WithTestCases(10)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(10))
 	if len(vals) == 0 {
 		t.Error("test function was never called")
 	}
@@ -193,20 +189,18 @@ func TestIntegersInBounds(t *testing.T) {
 	runIntegersBoundsCheck[uint](t, "uint", 0, math.MaxUint)
 }
 
-func runIntegersBoundsCheck[T integer](t *testing.T, name string, lo, hi T) {
+func runIntegersBoundsCheck[I integer](t *testing.T, name string, lo, hi I) {
 	t.Helper()
 	t.Run(name, func(t *testing.T) {
 		t.Parallel()
 		var drew bool
-		if _err := Run(func(s *TestCase) {
-			v := Draw[T](s, Integers[T](lo, hi))
+		Test(t, func(ht *T) {
+			v := Draw[I](ht, Integers[I](lo, hi))
 			drew = true
 			if v < lo || v > hi {
 				panic(fmt.Sprintf("out of range: lo=%d hi=%d v=%d", lo, hi, v))
 			}
-		}, WithTestCases(20)); _err != nil {
-			t.Fatalf("run failed: %v", _err)
-		}
+		}, WithTestCases(20))
 		if !drew {
 			t.Error("test function was never called")
 		}
@@ -251,14 +245,12 @@ func TestJustTransformIgnoresInput(t *testing.T) {
 func TestJustE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		v := Draw[int](s, Just(42))
+	Test(t, func(ht *T) {
+		v := Draw[int](ht, Just(42))
 		if v != 42 {
 			panic(fmt.Sprintf("Just: expected 42, got %v", v))
 		}
-	}, WithTestCases(20)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(20))
 }
 
 // TestJustNonPrimitive verifies that Just works with non-primitive values (pointer identity).
@@ -267,14 +259,12 @@ func TestJustNonPrimitive(t *testing.T) {
 
 	type myStruct struct{ x int }
 	val := &myStruct{x: 99}
-	if _err := Run(func(s *TestCase) {
-		v := Draw[*myStruct](s, Just(val))
+	Test(t, func(ht *T) {
+		v := Draw[*myStruct](ht, Just(val))
 		if v != val {
 			panic("Just: pointer identity not preserved")
 		}
-	}, WithTestCases(10)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(10))
 }
 
 // =============================================================================
@@ -330,14 +320,12 @@ func TestSampledFromParseMapsIndices(t *testing.T) {
 func TestSampledFromSingleElement(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		v := Draw[string](s, SampledFrom([]string{"only"}))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, SampledFrom([]string{"only"}))
 		if v != "only" {
 			panic(fmt.Sprintf("SampledFrom single: expected 'only', got %v", v))
 		}
-	}, WithTestCases(20)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(20))
 }
 
 // TestSampledFromE2E verifies that SampledFrom only returns elements from the list
@@ -347,8 +335,8 @@ func TestSampledFromE2E(t *testing.T) {
 
 	choices := []string{"apple", "banana", "cherry"}
 	seen := map[string]bool{}
-	if _err := Run(func(s *TestCase) {
-		v := Draw[string](s, SampledFrom(choices))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, SampledFrom(choices))
 		found := false
 		for _, c := range choices {
 			if c == v {
@@ -360,9 +348,7 @@ func TestSampledFromE2E(t *testing.T) {
 			panic(fmt.Sprintf("SampledFrom: value %q not in choices", v))
 		}
 		seen[v] = true
-	}, WithTestCases(100)); _err != nil {
-		panic(_err)
-	}
+	})
 	// After 100 cases we expect all 3 values to have appeared.
 	for _, c := range choices {
 		if !seen[c] {
@@ -379,14 +365,12 @@ func TestSampledFromNonPrimitive(t *testing.T) {
 	type myStruct struct{ x int }
 	obj1 := &myStruct{x: 1}
 	obj2 := &myStruct{x: 2}
-	if _err := Run(func(s *TestCase) {
-		v := Draw[*myStruct](s, SampledFrom([]*myStruct{obj1, obj2}))
+	Test(t, func(ht *T) {
+		v := Draw[*myStruct](ht, SampledFrom([]*myStruct{obj1, obj2}))
 		if v != obj1 && v != obj2 {
 			panic("SampledFrom: value is not one of the original pointers")
 		}
-	}, WithTestCases(10)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(10))
 }
 
 // =============================================================================
@@ -424,8 +408,8 @@ func TestFromRegexE2E(t *testing.T) {
 	t.Parallel()
 
 	// Only digits, 1-5 chars
-	if _err := Run(func(s *TestCase) {
-		v := Draw[string](s, FromRegex(`[0-9]{1,5}`, true))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, FromRegex(`[0-9]{1,5}`, true))
 		if len(v) == 0 || len(v) > 5 {
 			panic(fmt.Sprintf("FromRegex: length out of range: %q", v))
 		}
@@ -434,9 +418,7 @@ func TestFromRegexE2E(t *testing.T) {
 				panic(fmt.Sprintf("FromRegex: non-digit character %q in %q", ch, v))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // =============================================================================
@@ -446,14 +428,10 @@ func TestFromRegexE2E(t *testing.T) {
 // TestBasicGeneratorGenerateErrorResponse covers the error path in
 // basicGenerator.draw when generateFromSchema returns a non-StopTest error.
 func TestBasicGeneratorGenerateErrorResponse(t *testing.T) {
-
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "error_response")
-	err := Run(func(s *TestCase) {
-		g := &basicGenerator[int64]{schema: map[string]any{"type": "integer"}, parse: func(v any) int64 { return extractInt(v) }}
-		_ = g.draw(s) // should panic with requestError -> caught as INTERESTING
-	})
-	// error_response causes the test to appear interesting (failing).
-	_ = err
+	newTempGoProject(t).
+		testBody(`_ = hegel.Draw[int64](ht, hegel.Integers[int64](0, 100))`).
+		goTest()
 }
 
 // =============================================================================
@@ -490,17 +468,15 @@ func TestMapBasicGeneratorE2E(t *testing.T) {
 	if _, ok := gen.(*basicGenerator[int]); !ok {
 		t.Fatalf("Map on basicGenerator should return *basicGenerator[int], got %T", gen)
 	}
-	if _err := Run(func(s *TestCase) {
-		n := Draw[int](s, gen)
+	Test(t, func(ht *T) {
+		n := Draw[int](ht, gen)
 		if n%2 != 0 {
 			panic(fmt.Sprintf("map(x*2): expected even number, got %d", n))
 		}
 		if n < 0 || n > 200 {
 			panic(fmt.Sprintf("map(x*2): expected [0,200], got %d", n))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestMapChainedBasicGeneratorE2E verifies that chaining two maps on a basicGenerator
@@ -517,8 +493,8 @@ func TestMapChainedBasicGeneratorE2E(t *testing.T) {
 	if _, ok := gen.(*basicGenerator[int]); !ok {
 		t.Fatalf("chained Map on basicGenerator should return *basicGenerator[int], got %T", gen)
 	}
-	if _err := Run(func(s *TestCase) {
-		n := Draw[int](s, gen)
+	Test(t, func(ht *T) {
+		n := Draw[int](ht, gen)
 		// (x+1)*2 is always even. x in [0,100] -> result in [2, 202].
 		if n%2 != 0 {
 			panic(fmt.Sprintf("map(x+1).map(x*2): expected even, got %d", n))
@@ -526,9 +502,7 @@ func TestMapChainedBasicGeneratorE2E(t *testing.T) {
 		if n < 2 || n > 202 {
 			panic(fmt.Sprintf("map(x+1).map(x*2): expected [2,202], got %d", n))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestMapNonBasicGeneratorE2E verifies that mapping a mappedGenerator (non-basic)
@@ -549,15 +523,13 @@ func TestMapNonBasicGeneratorE2E(t *testing.T) {
 	if _, ok := gen.(*mappedGenerator[int, int]); !ok {
 		t.Fatalf("Map on non-basic Generator should return *mappedGenerator, got %T", gen)
 	}
-	if _err := Run(func(s *TestCase) {
-		n := Draw[int](s, gen)
+	Test(t, func(ht *T) {
+		n := Draw[int](ht, gen)
 		// inner is Integers[int](1,5)*1, map(*3): result is in {3, 6, 9, 12, 15}
 		if n < 3 || n > 15 || n%3 != 0 {
 			panic(fmt.Sprintf("map(*3) on [1,5]: expected multiple of 3 in [3,15], got %d", n))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestMapSchemaPreservedUnit verifies unit-level schema properties of Map on basicGenerator.
@@ -655,34 +627,30 @@ func TestFilteredGeneratorMapMethod(t *testing.T) {
 func TestFilteredGeneratorE2EAlwaysPasses(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		gen := Filter[int](Integers[int](0, 100), func(v int) bool {
 			return v > 50
 		})
-		n := Draw[int](s, gen)
+		n := Draw[int](ht, gen)
 		if n <= 50 {
 			panic(fmt.Sprintf("filter(>50): expected n>50, got %d", n))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestFilteredGeneratorE2EEvenNumbers verifies filter for even numbers.
 func TestFilteredGeneratorE2EEvenNumbers(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		gen := Filter[int](Integers[int](0, 10), func(v int) bool {
 			return v%2 == 0
 		})
-		n := Draw[int](s, gen)
+		n := Draw[int](ht, gen)
 		if n%2 != 0 {
 			panic(fmt.Sprintf("filter(even): expected even, got %d", n))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestFilterOnNonBasicGenerators verifies that Filter works on non-basic generators.
@@ -954,16 +922,14 @@ func TestFlatMappedGeneratorE2E(t *testing.T) {
 	gen := FlatMap[int, string](Integers[int](1, 5), func(v int) Generator[string] {
 		return Text().MinSize(v).MaxSize(v) // exact length = n
 	})
-	if _err := Run(func(s *TestCase) {
-		v := Draw[string](s, gen)
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, gen)
 		count := len([]rune(v))
 		// n is in [1,5], so text length is in [1,5].
 		if count < 1 || count > 5 {
 			panic(fmt.Sprintf("flat_map text length %d out of [1,5]", count))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestFlatMappedGeneratorDependency verifies that the second generation genuinely depends
@@ -976,8 +942,8 @@ func TestFlatMappedGeneratorDependency(t *testing.T) {
 		sz := int(v)
 		return Lists[int64](Integers[int64](0, 100)).MinSize(sz).MaxSize(sz)
 	})
-	if _err := Run(func(s *TestCase) {
-		slice := Draw[[]int64](s, gen)
+	Test(t, func(ht *T) {
+		slice := Draw[[]int64](ht, gen)
 		if len(slice) < 2 || len(slice) > 4 {
 			panic(fmt.Sprintf("flat_map dependency: list length %d not in [2,4]", len(slice)))
 		}
@@ -986,9 +952,7 @@ func TestFlatMappedGeneratorDependency(t *testing.T) {
 				panic(fmt.Sprintf("flat_map dependency: element %d not in [0,100]", elem))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // =============================================================================
@@ -1174,19 +1138,17 @@ func TestRejectFinishedCollection(t *testing.T) {
 // continue iterating — the server should handle this gracefully.
 func TestRejectE2E(t *testing.T) {
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		max := 5
-		coll := newCollection(s, 0, &max)
-		if coll.More(s) {
+		coll := newCollection(ht.TestCase, 0, &max)
+		if coll.More(ht.TestCase) {
 			// Reject the first element — tells the server it doesn't count.
-			coll.Reject(s)
+			coll.Reject(ht.TestCase)
 		}
 		// Drain remaining elements.
-		for coll.More(s) {
+		for coll.More(ht.TestCase) {
 		}
-	}, WithTestCases(10)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(10))
 }
 
 // =============================================================================
@@ -1218,12 +1180,10 @@ func TestMapOnBasicGeneratorE2E(t *testing.T) {
 	if _, ok := gen.(*basicGenerator[string]); !ok {
 		t.Fatalf("Map on basicGenerator should return *basicGenerator[string], got %T", gen)
 	}
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, gen)
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, gen)
 		if v != "yes" && v != "no" {
 			panic(fmt.Sprintf("Map(Booleans): expected 'yes' or 'no', got %q", v))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }

--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@ export PATH := "/usr/local/go/bin:" + env("HOME") + "/go/bin:" + env("PATH")
 
 # Run tests with coverage.
 # We measure coverage only on the library package (not cmd/ binaries).
-test:
-    go test -race -coverprofile=coverage.out -covermode=atomic \
+test *args:
+    go test -race {{args}} -coverprofile=coverage.out -covermode=atomic \
         -coverpkg=hegel.dev/go/hegel \
         ./...
     python3 scripts/check-coverage.py

--- a/lists_test.go
+++ b/lists_test.go
@@ -166,16 +166,14 @@ func TestListsNegativeMinSizeError(t *testing.T) {
 func TestListsBasicIntegersE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		xs := Lists(Integers[int](0, 100)).MaxSize(10).draw(s)
+	Test(t, func(ht *T) {
+		xs := Lists(Integers[int](0, 100)).MaxSize(10).draw(ht.TestCase)
 		for _, x := range xs {
 			if x < 0 || x > 100 {
 				panic(fmt.Sprintf("Lists: element %d out of range [0, 100]", x))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestListsWithSizeBoundsE2E verifies that Lists with min_size and max_size constraints
@@ -183,14 +181,12 @@ func TestListsBasicIntegersE2E(t *testing.T) {
 func TestListsWithSizeBoundsE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		xs := Lists(Booleans()).MinSize(3).MaxSize(5).draw(s)
+	Test(t, func(ht *T) {
+		xs := Lists(Booleans()).MinSize(3).MaxSize(5).draw(ht.TestCase)
 		if len(xs) < 3 || len(xs) > 5 {
 			panic(fmt.Sprintf("Lists: length %d out of [3, 5]", len(xs)))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestListsNonBasicElementE2E verifies that Lists with a non-basic element generator
@@ -204,16 +200,14 @@ func TestListsNonBasicElementE2E(t *testing.T) {
 	})
 	nonBasic := &mappedGenerator[int, int]{inner: mapped, fn: func(v int) int { return v }}
 
-	if _err := Run(func(s *TestCase) {
-		xs := Lists(nonBasic).MaxSize(5).draw(s)
+	Test(t, func(ht *T) {
+		xs := Lists(nonBasic).MaxSize(5).draw(ht.TestCase)
 		for _, x := range xs {
 			if x%2 != 0 {
 				panic(fmt.Sprintf("Lists(non-basic): expected even element, got %d", x))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestListsNestedE2E verifies that nested lists work correctly:
@@ -221,8 +215,8 @@ func TestListsNonBasicElementE2E(t *testing.T) {
 func TestListsNestedE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		outer := Lists(Lists(Booleans()).MaxSize(3)).MaxSize(3).draw(s)
+	Test(t, func(ht *T) {
+		outer := Lists(Lists(Booleans()).MaxSize(3)).MaxSize(3).draw(ht.TestCase)
 		for i, inner := range outer {
 			for j, b := range inner {
 				// b is already bool due to typed generators; verify it is true or false.
@@ -231,9 +225,7 @@ func TestListsNestedE2E(t *testing.T) {
 				}
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestListsBasicWithParseE2E verifies that Lists on a basicGenerator with a composed
@@ -245,14 +237,12 @@ func TestListsBasicWithParseE2E(t *testing.T) {
 	doubled := Map(Integers[int](0, 10), func(n int) int {
 		return n * 2
 	})
-	if _err := Run(func(s *TestCase) {
-		xs := Lists(doubled).MaxSize(5).draw(s)
+	Test(t, func(ht *T) {
+		xs := Lists(doubled).MaxSize(5).draw(ht.TestCase)
 		for _, x := range xs {
 			if x%2 != 0 || x < 0 || x > 20 {
 				panic(fmt.Sprintf("Lists(basic+parse): element %d should be even in [0,20]", x))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }

--- a/maps_test.go
+++ b/maps_test.go
@@ -255,16 +255,15 @@ func TestPairsToMapNonSlicePair(t *testing.T) {
 func TestMapsStopTestOnNewCollection(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := Run(func(s *TestCase) {
+	// StopTest causes test to be skipped or aborted, not fail
+	Test(t, func(ht *T) {
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 10),
 			fn:    func(v int64) int64 { return v },
 		}
 		gen := Maps(nonBasicKeys, Integers[int64](0, 100)).MaxSize(3)
-		_ = gen.draw(s)
+		_ = gen.draw(ht.TestCase)
 	})
-	// StopTest causes test to be skipped or aborted, not fail
-	_ = err
 }
 
 // TestMapsStopTestOnCollectionMore verifies that StopTest during collection_more
@@ -272,15 +271,14 @@ func TestMapsStopTestOnNewCollection(t *testing.T) {
 func TestMapsStopTestOnCollectionMore(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 10),
 			fn:    func(v int64) int64 { return v },
 		}
 		gen := Maps(nonBasicKeys, Integers[int64](0, 100)).MaxSize(3)
-		_ = gen.draw(s)
+		_ = gen.draw(ht.TestCase)
 	})
-	_ = err
 }
 
 // =============================================================================
@@ -292,9 +290,9 @@ func TestMapsStopTestOnCollectionMore(t *testing.T) {
 func TestMapsBasicE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		gen := Maps(Text().MaxSize(5), Integers[int](0, 100)).MaxSize(3)
-		m := gen.draw(s)
+		m := gen.draw(ht.TestCase)
 		if len(m) > 3 {
 			panic(fmt.Sprintf("Maps: expected at most 3 entries, got %d", len(m)))
 		}
@@ -306,9 +304,7 @@ func TestMapsBasicE2E(t *testing.T) {
 				panic(fmt.Sprintf("Maps: value %d out of [0,100]", val))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestMapsBasicWithBoundsE2E verifies that Maps with min_size/max_size constraints
@@ -316,9 +312,9 @@ func TestMapsBasicE2E(t *testing.T) {
 func TestMapsBasicWithBoundsE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		gen := Maps(Integers[int](0, 10), Booleans()).MinSize(1).MaxSize(3)
-		m := gen.draw(s)
+		m := gen.draw(ht.TestCase)
 		if len(m) < 1 || len(m) > 3 {
 			panic(fmt.Sprintf("Maps bounded: expected 1-3 entries, got %d", len(m)))
 		}
@@ -327,27 +323,23 @@ func TestMapsBasicWithBoundsE2E(t *testing.T) {
 				panic(fmt.Sprintf("Maps bounded: key %d out of [0,10]", k))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestMapsCompositeNoMaxE2E verifies the composite Maps generator with no max_size
 // uses the default (min_size + 10).
 func TestMapsCompositeNoMaxE2E(t *testing.T) {
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 100),
 			fn:    func(n int64) int64 { return n },
 		}
 		// Omit MaxSize to trigger the !g.hasMax branch.
 		gen := Maps(nonBasicKeys, Just("v"))
-		m := gen.draw(s)
+		m := gen.draw(ht.TestCase)
 		_ = m // just verify it doesn't panic
-	}, WithTestCases(30)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // TestMapsCompositeE2E verifies the composite Maps generator (non-basic keys)
@@ -355,7 +347,7 @@ func TestMapsCompositeNoMaxE2E(t *testing.T) {
 func TestMapsCompositeE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		// mappedGenerator makes this non-basic -> composite path
 		nonBasicKeys := &mappedGenerator[int64, int64]{
 			inner: Integers[int64](0, 10),
@@ -367,16 +359,14 @@ func TestMapsCompositeE2E(t *testing.T) {
 			},
 		}
 		gen := Maps(nonBasicKeys, Just("val")).MaxSize(3)
-		m := gen.draw(s)
+		m := gen.draw(ht.TestCase)
 		// All values must be "val"
 		for k, val := range m {
 			if val != "val" {
 				panic(fmt.Sprintf("Maps composite: expected value 'val', got %v for key %v", val, k))
 			}
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestMapsNonBasicCollisions(t *testing.T) {
@@ -386,9 +376,7 @@ func TestMapsNonBasicCollisions(t *testing.T) {
 	vals := Integers[int](0, 100)
 	gen := Maps(keys, vals).MinSize(3).MaxSize(5)
 
-	if _err := Run(func(s *TestCase) {
-		_ = gen.draw(s)
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	Test(t, func(ht *T) {
+		_ = gen.draw(ht.TestCase)
+	}, WithTestCases(50))
 }

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -65,17 +65,15 @@ func TestOneOfPath1E2E(t *testing.T) {
 	sawShort := false
 	sawLong := false
 	combined := OneOf(Text().MinSize(1).MaxSize(3), Text().MinSize(10).MaxSize(15))
-	if _err := Run(func(s *TestCase) {
-		v := combined.draw(s)
+	Test(t, func(ht *T) {
+		v := combined.draw(ht.TestCase)
 		n := len([]rune(v))
 		if n >= 1 && n <= 3 {
 			sawShort = true
 		} else if n >= 10 && n <= 15 {
 			sawLong = true
 		}
-	}, WithTestCases(100)); _err != nil {
-		panic(_err)
-	}
+	})
 	if !sawShort {
 		t.Error("OneOf: never generated a short string")
 	}
@@ -203,14 +201,12 @@ func TestOneOfWithTransformsE2E(t *testing.T) {
 	gen2 := Map(Just(int(2)), func(v int) int { return v * 3 })
 	combined := OneOf(gen1, gen2)
 
-	if _err := Run(func(s *TestCase) {
-		v := combined.draw(s)
+	Test(t, func(ht *T) {
+		v := combined.draw(ht.TestCase)
 		if v != 2 && v != 6 {
 			panic(fmt.Sprintf("OneOf with transforms: expected 2 or 6, got %d", v))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // =============================================================================
@@ -267,8 +263,8 @@ func TestOneOfPath3E2E(t *testing.T) {
 
 	sawInt := false
 	sawStr := false
-	if _err := Run(func(s *TestCase) {
-		v := combined.draw(s)
+	Test(t, func(ht *T) {
+		v := combined.draw(ht.TestCase)
 		switch v.(type) {
 		case int:
 			sawInt = true
@@ -277,9 +273,7 @@ func TestOneOfPath3E2E(t *testing.T) {
 		default:
 			panic(fmt.Sprintf("OneOf Path3: unexpected type %T", v))
 		}
-	}, WithTestCases(100)); _err != nil {
-		panic(_err)
-	}
+	})
 	if !sawInt {
 		t.Error("OneOf Path3: never generated an integer")
 	}
@@ -322,8 +316,8 @@ func TestOptionalE2E(t *testing.T) {
 	sawNil := false
 	sawInt := false
 	g := Optional(Integers[int](0, 100))
-	if _err := Run(func(s *TestCase) {
-		v := g.draw(s)
+	Test(t, func(ht *T) {
+		v := g.draw(ht.TestCase)
 		if v == nil {
 			sawNil = true
 		} else {
@@ -332,9 +326,7 @@ func TestOptionalE2E(t *testing.T) {
 				panic(fmt.Sprintf("Optional: expected [0,100], got %d", *v))
 			}
 		}
-	}, WithTestCases(100)); _err != nil {
-		panic(_err)
-	}
+	})
 	if !sawNil {
 		t.Error("Optional: nil value never appeared")
 	}
@@ -355,16 +347,14 @@ func TestOptionalNonBasicE2E(t *testing.T) {
 	}
 	sawNil := false
 	sawVal := false
-	if _err := Run(func(s *TestCase) {
-		v := g.draw(s)
+	Test(t, func(ht *T) {
+		v := g.draw(ht.TestCase)
 		if v == nil {
 			sawNil = true
 		} else {
 			sawVal = true
 		}
-	}, WithTestCases(100)); _err != nil {
-		panic(_err)
-	}
+	})
 	if !sawNil {
 		t.Error("Optional(nonBasic): nil value never appeared")
 	}
@@ -461,14 +451,12 @@ func TestIPAddressesV4E2E(t *testing.T) {
 	t.Parallel()
 
 	g := IPAddresses().IPv4()
-	if _err := Run(func(s *TestCase) {
-		v := g.draw(s)
+	Test(t, func(ht *T) {
+		v := g.draw(ht.TestCase)
 		if !v.Is4() {
 			panic(fmt.Sprintf("IPv4 address should be v4: %v", v))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestIPAddressesV6E2E verifies IPv6 addresses contain colons.
@@ -476,14 +464,12 @@ func TestIPAddressesV6E2E(t *testing.T) {
 	t.Parallel()
 
 	g := IPAddresses().IPv6()
-	if _err := Run(func(s *TestCase) {
-		v := g.draw(s)
+	Test(t, func(ht *T) {
+		v := g.draw(ht.TestCase)
 		if !v.Is6() {
 			panic(fmt.Sprintf("IPv6 address should be v6: %v", v))
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 // TestIPAddressesDefaultE2E verifies default produces both IPv4 and IPv6.
@@ -493,16 +479,14 @@ func TestIPAddressesDefaultE2E(t *testing.T) {
 	sawV4 := false
 	sawV6 := false
 	g := IPAddresses()
-	if _err := Run(func(s *TestCase) {
-		v := g.draw(s)
+	Test(t, func(ht *T) {
+		v := g.draw(ht.TestCase)
 		if v.Is4() {
 			sawV4 = true
 		} else if v.Is6() {
 			sawV6 = true
 		}
-	}, WithTestCases(100)); _err != nil {
-		panic(_err)
-	}
+	})
 	if !sawV4 {
 		t.Error("IPAddresses default: no IPv4 address generated")
 	}
@@ -521,17 +505,15 @@ func TestOneOfWithMapMixedTypesE2E(t *testing.T) {
 		Map(Integers[int](0, 10), func(v int) int { return v * 2 }),
 		Just(int(0)),
 	)
-	if _err := Run(func(s *TestCase) {
-		v := gen.draw(s)
+	Test(t, func(ht *T) {
+		v := gen.draw(ht.TestCase)
 		if v%2 != 0 {
 			panic(fmt.Sprintf("OneOf map: expected even, got %d", v))
 		}
 		if v < 0 || v > 20 {
 			panic(fmt.Sprintf("OneOf map: expected [0,20], got %d", v))
 		}
-	}, WithTestCases(100)); _err != nil {
-		panic(_err)
-	}
+	})
 }
 
 // TestOneOfAllBranchesAppear verifies that both branches of OneOf appear
@@ -542,17 +524,15 @@ func TestOneOfAllBranchesAppear(t *testing.T) {
 	sawA := false
 	sawB := false
 	gen := OneOf(Text().MinSize(1).MaxSize(3), Text().MinSize(4).MaxSize(6))
-	if _err := Run(func(s *TestCase) {
-		v := gen.draw(s)
+	Test(t, func(ht *T) {
+		v := gen.draw(ht.TestCase)
 		n := len([]rune(v))
 		if n >= 1 && n <= 3 {
 			sawA = true
 		} else if n >= 4 && n <= 6 {
 			sawB = true
 		}
-	}, WithTestCases(200)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(200))
 	if !sawA {
 		t.Error("OneOf: Text(1,3) branch never appeared")
 	}
@@ -565,15 +545,16 @@ func TestOneOfAllBranchesAppear(t *testing.T) {
 // oneOfGenerator.draw when the server sends a requestError in response
 // to the index generate command on the composite path.
 func TestCompositeOneOfGenerateErrorResponse(t *testing.T) {
-
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "error_response")
-	// Non-basic branches force the composite draw path.
-	nonBasic1 := &mappedGenerator[int64, int64]{inner: Integers[int64](0, 5), fn: func(v int64) int64 { return v }}
-	nonBasic2 := &mappedGenerator[int64, int64]{inner: Integers[int64](6, 10), fn: func(v int64) int64 { return v }}
-	gen := &oneOfGenerator[int64]{generators: []Generator[int64]{nonBasic1, nonBasic2}}
-	err := Run(func(s *TestCase) {
-		_ = gen.draw(s) // should panic with requestError
-	})
-	// error_response makes the test appear interesting (failing).
-	_ = err
+	// Filter wrappers force each branch to be non-basic, which forces the
+	// composite (oneOfGenerator.draw) path rather than the flat-schema path.
+	// The error-response triggers a panic during the index draw, then the
+	// test-mode server exits before a final replay — assert on the resulting
+	// "server exited" diagnostic so we know the composite path was reached.
+	newTempGoProject(t).
+		testBody(`g1 := hegel.Filter(hegel.Integers[int64](0, 5), func(int64) bool { return true })
+g2 := hegel.Filter(hegel.Integers[int64](6, 10), func(int64) bool { return true })
+_ = hegel.Draw[int64](ht, hegel.OneOf(g1, g2))`).
+		expectFailure(`server process exited`).
+		goTest()
 }

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -19,19 +19,17 @@ import (
 
 func TestIntegersFullRangeE2E(t *testing.T) {
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		// Full-range integers: just verify the draw completes without error.
-		_ = Draw[int](s, Integers[int](math.MinInt, math.MaxInt))
-	}, WithTestCases(20)); _err != nil {
-		panic(_err)
-	}
+		_ = Draw[int](ht, Integers[int](math.MinInt, math.MaxInt))
+	}, WithTestCases(20))
 }
 
 func TestFloatsE2E_WithBounds(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		fv := Draw[float64](s, Floats[float64]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
+	Test(t, func(ht *T) {
+		fv := Draw[float64](ht, Floats[float64]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
 		if math.IsNaN(fv) {
 			panic("floats: NaN not allowed when allow_nan=false")
 		}
@@ -41,121 +39,101 @@ func TestFloatsE2E_WithBounds(t *testing.T) {
 		if fv < 0.0 || fv > 1.0 {
 			panic("floats: out of range [0.0, 1.0]")
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestFloatsE2E_Unbounded(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		// Unbounded floats may produce NaN or Inf -- any float64 is valid.
-		_ = Draw(s, Floats[float64]())
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+		_ = Draw(ht, Floats[float64]())
+	}, WithTestCases(50))
 }
 
 func TestFloatsE2E_OnlyMin(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		fv := Draw(s, Floats[float64]().Min(0.0))
+	Test(t, func(ht *T) {
+		fv := Draw(ht, Floats[float64]().Min(0.0))
 		// allow_nan is false (has min), allow_infinity is true (no max)
 		// Value should be >= 0.0 or Inf; NaN not allowed.
 		if math.IsNaN(fv) {
 			panic("floats: NaN not expected when min set")
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestFloatsE2E_Float32(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		fv := Draw(s, Floats[float32]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
+	Test(t, func(ht *T) {
+		fv := Draw(ht, Floats[float32]().Min(0.0).Max(1.0).AllowNaN(false).AllowInfinity(false))
 		if fv < 0.0 || fv > 1.0 {
 			panic("float32: out of range [0.0, 1.0]")
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestFloatsGenerateErrorResponse(t *testing.T) {
-
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "error_response")
-	err := Run(func(s *TestCase) {
-		_ = Floats[float64]().draw(s)
-	})
-	_ = err
+	newTempGoProject(t).
+		testBody(`_ = hegel.Draw[float64](ht, hegel.Floats[float64]())`).
+		goTest()
 }
 
 func TestBooleansE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		b := Draw[bool](s, Booleans())
+	Test(t, func(ht *T) {
+		b := Draw[bool](ht, Booleans())
 		// A valid assertion: b is either true or false.
 		if b != true && b != false {
 			panic("booleans: expected bool")
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestTextE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		sv := Draw[string](s, Text().MinSize(2).MaxSize(8))
+	Test(t, func(ht *T) {
+		sv := Draw[string](ht, Text().MinSize(2).MaxSize(8))
 		count := utf8.RuneCountInString(sv)
 		if count < 2 || count > 8 {
 			panic("text: codepoint count out of range [2, 8]")
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestTextE2E_Unbounded(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		sv := Draw[string](s, Text())
+	Test(t, func(ht *T) {
+		sv := Draw[string](ht, Text())
 		if !utf8.ValidString(sv) {
 			panic("text: invalid UTF-8 string")
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestBinaryE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		bv := Draw[[]byte](s, Binary(1, 10))
+	Test(t, func(ht *T) {
+		bv := Draw[[]byte](ht, Binary(1, 10))
 		if len(bv) < 1 || len(bv) > 10 {
 			panic("binary: byte length out of range [1, 10]")
 		}
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(50))
 }
 
 func TestBinaryE2E_Unbounded(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		_ = Draw[[]byte](s, Binary(0, -1))
-	}, WithTestCases(50)); _err != nil {
-		panic(_err)
-	}
+	Test(t, func(ht *T) {
+		_ = Draw[[]byte](ht, Binary(0, -1))
+	}, WithTestCases(50))
 }
 
 func TestFloatGeneratorBuildsBasicGenerator(t *testing.T) {
@@ -385,14 +363,12 @@ func TestTextAsBasic(t *testing.T) {
 func TestCharactersE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Characters().Codec("ascii"))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Characters().Codec("ascii"))
 		if utf8.RuneCountInString(v) != 1 {
 			panic("Characters: expected exactly one character")
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // =============================================================================
@@ -402,122 +378,106 @@ func TestCharactersE2E(t *testing.T) {
 func TestTextCodecE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Text().MinSize(1).MaxSize(10).Codec("ascii"))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(10).Codec("ascii"))
 		for _, r := range v {
 			if r > 127 {
 				panic("Text with Codec(ascii): non-ASCII character found")
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestTextAlphabetE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Text().MinSize(1).MaxSize(5).Alphabet("abc"))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(5).Alphabet("abc"))
 		for _, r := range v {
 			if r != 'a' && r != 'b' && r != 'c' {
 				panic("Text with Alphabet(abc): unexpected character")
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestTextSingleCharAlphabetE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Text().MinSize(1).MaxSize(5).Alphabet("x"))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(5).Alphabet("x"))
 		for _, r := range v {
 			if r != 'x' {
 				panic(fmt.Sprintf("Text with Alphabet(x): expected 'x', got %q", r))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestTextCodepointRangeE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Text().MinSize(1).MaxSize(20).MinCodepoint(0x41).MaxCodepoint(0x5A))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(20).MinCodepoint(0x41).MaxCodepoint(0x5A))
 		for _, r := range v {
 			if r < 0x41 || r > 0x5A {
 				panic(fmt.Sprintf("Text codepoint range: %U outside [U+0041, U+005A]", r))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestTextCategoriesE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Text().MinSize(1).MaxSize(20).Categories([]string{"Lu"}))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(20).Categories([]string{"Cc"}))
 		for _, r := range v {
-			if !unicode.In(r, unicode.Lu) {
-				panic(fmt.Sprintf("Text with Categories([Lu]): %q is not in category Lu", r))
+			if !unicode.In(r, unicode.Cc) {
+				panic(fmt.Sprintf("Text with Categories([Cc]): %q is not in category Cc", r))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestTextExcludeCategoriesE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Text().MinSize(1).MaxSize(20).ExcludeCategories([]string{"Lu"}))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(20).ExcludeCategories([]string{"Cc"}))
 		for _, r := range v {
-			if unicode.In(r, unicode.Lu) {
-				panic(fmt.Sprintf("Text with ExcludeCategories([Lu]): %q is in category Lu", r))
+			if unicode.In(r, unicode.Cc) {
+				panic(fmt.Sprintf("Text with ExcludeCategories([Cc]): %q is in category Cc", r))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestTextIncludeCharactersE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Text().MinSize(1).MaxSize(20).Categories([]string{}).IncludeCharacters("xyz"))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(20).Categories([]string{}).IncludeCharacters("xyz"))
 		for _, r := range v {
 			if !strings.ContainsRune("xyz", r) {
 				panic(fmt.Sprintf("Text with IncludeCharacters(xyz): %q not in allowed set", r))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestTextExcludeCharactersE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		excluded := "aeiou"
-		v := Draw[string](s, Text().MinSize(1).MaxSize(20).Codec("ascii").ExcludeCharacters(excluded))
+		v := Draw[string](ht, Text().MinSize(1).MaxSize(20).Codec("ascii").ExcludeCharacters(excluded))
 		for _, r := range v {
 			if strings.ContainsRune(excluded, r) {
 				panic(fmt.Sprintf("Text with ExcludeCharacters: %q should be excluded", r))
 			}
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 // =============================================================================
@@ -527,70 +487,60 @@ func TestTextExcludeCharactersE2E(t *testing.T) {
 func TestCharactersCodepointRangeE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Characters().MinCodepoint(0x41).MaxCodepoint(0x5A))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Characters().MinCodepoint(0x41).MaxCodepoint(0x5A))
 		r, _ := utf8.DecodeRuneInString(v)
 		if r < 0x41 || r > 0x5A {
 			panic(fmt.Sprintf("Characters codepoint range: %U outside [U+0041, U+005A]", r))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
-func TestCharactersCategoriesLuE2E(t *testing.T) {
+func TestCharactersCategoriesCcE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Characters().Categories([]string{"Lu"}))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Characters().Categories([]string{"Cc"}))
 		r, _ := utf8.DecodeRuneInString(v)
-		if !unicode.In(r, unicode.Lu) {
-			panic(fmt.Sprintf("Characters with Categories([Lu]): %q is not in category Lu", r))
+		if !unicode.In(r, unicode.Cc) {
+			panic(fmt.Sprintf("Characters with Categories([Cc]): %q is not in category Cc", r))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestCharactersExcludeCategoriesE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Characters().ExcludeCategories([]string{"Lu"}))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Characters().ExcludeCategories([]string{"Cc"}))
 		r, _ := utf8.DecodeRuneInString(v)
-		if unicode.In(r, unicode.Lu) {
-			panic(fmt.Sprintf("Characters with ExcludeCategories([Lu]): %q is in category Lu", r))
+		if unicode.In(r, unicode.Cc) {
+			panic(fmt.Sprintf("Characters with ExcludeCategories([Cc]): %q is in category Cc", r))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestCharactersIncludeCharactersE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
-		v := Draw[string](s, Characters().Categories([]string{}).IncludeCharacters("xyz"))
+	Test(t, func(ht *T) {
+		v := Draw[string](ht, Characters().Categories([]string{}).IncludeCharacters("xyz"))
 		r, _ := utf8.DecodeRuneInString(v)
 		if !strings.ContainsRune("xyz", r) {
 			panic(fmt.Sprintf("Characters with IncludeCharacters(xyz): %q not in allowed set", r))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }
 
 func TestCharactersExcludeCharactersE2E(t *testing.T) {
 	t.Parallel()
 
-	if _err := runHegel(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		excluded := "aeiou"
-		v := Draw[string](s, Characters().Codec("ascii").ExcludeCharacters(excluded))
+		v := Draw[string](ht, Characters().Codec("ascii").ExcludeCharacters(excluded))
 		r, _ := utf8.DecodeRuneInString(v)
 		if strings.ContainsRune(excluded, r) {
 			panic(fmt.Sprintf("Characters with ExcludeCharacters: %q should be excluded", r))
 		}
-	}, stderrNoteFn, []Option{WithTestCases(30)}); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(30))
 }

--- a/runner.go
+++ b/runner.go
@@ -20,7 +20,7 @@ type TestCase struct {
 	isFinal bool
 	aborted bool
 	failed  bool         // for T.Error/Fail deferred INTERESTING
-	noteFn  func(string) // injected: t.Log for Test, stderr for Run
+	noteFn  func(string) // injected: t.Log for Test, stdout for Run
 }
 
 // --- Sentinel errors ---
@@ -60,7 +60,7 @@ func (s *TestCase) Assume(condition bool) {
 
 // Note prints message, but only during the final (replay) test case.
 //
-// Output is routed to t.Log for [Test], or stderr for [Run].
+// Output is routed to t.Log for [Test], or stdout for [Run].
 func (s *TestCase) Note(message string) {
 	if s.isFinal && s.noteFn != nil {
 		s.noteFn(message)
@@ -176,10 +176,51 @@ func (h HealthCheck) String() string {
 
 // --- Test runner options ---
 
+// databaseState distinguishes between "user has not set the database" (default
+// server behavior applies), "user disabled the database", and "user supplied a
+// path". The first state corresponds to omitting the field on the wire; the
+// other two send null and a string respectively.
+type databaseState int
+
+const (
+	databaseUnset databaseState = iota
+	databaseDisabled
+	databasePath
+)
+
+// DatabaseSetting configures example-database persistence for a test run.
+// Construct one with [Database] (a path) or [DatabaseDisabled] (no
+// persistence) and pass it to [WithDatabase].
+type DatabaseSetting struct {
+	state databaseState
+	path  string
+}
+
+// Database returns a [DatabaseSetting] that persists failing examples to the
+// given directory. Failing test cases are saved there and replayed on
+// subsequent runs of the same test.
+func Database(path string) DatabaseSetting {
+	return DatabaseSetting{state: databasePath, path: path}
+}
+
+// DatabaseDisabled returns a [DatabaseSetting] that disables example-database
+// persistence. No failing examples are saved or replayed.
+//
+// In CI environments, the database is disabled by default; this setting is
+// useful when you want to disable it explicitly outside of CI.
+func DatabaseDisabled() DatabaseSetting {
+	return DatabaseSetting{state: databaseDisabled}
+}
+
 // runOptions holds options for property tests.
 type runOptions struct {
 	testCases           int
 	suppressHealthCheck []HealthCheck
+	database            DatabaseSetting
+	derandomize         bool
+	// databaseKey identifies the test for example-database lookups. Set by
+	// [Test] from t.Name(); nil for [Run]/[MustRun] (no test name available).
+	databaseKey []byte
 }
 
 // Option is a functional option for Test and Run.
@@ -198,13 +239,71 @@ func SuppressHealthCheck(checks ...HealthCheck) Option {
 	return func(o *runOptions) { o.suppressHealthCheck = append(o.suppressHealthCheck, checks...) }
 }
 
-// --- Public API ---
+// WithDatabase configures example-database persistence for this test.
+// Construct the setting with [Database] (a path) or [DatabaseDisabled].
+//
+// The default behavior (when WithDatabase is not specified) is to use the
+// server's default database location, except in CI environments where the
+// database is automatically disabled.
+func WithDatabase(db DatabaseSetting) Option {
+	return func(o *runOptions) { o.database = db }
+}
+
+// WithDerandomize sets whether to use a fixed seed for reproducible runs.
+func WithDerandomize(derandomize bool) Option {
+	return func(o *runOptions) { o.derandomize = derandomize }
+}
+
+// withDatabaseKey sets the example-database key. Unexported: only [Test]
+// supplies a key, deriving it from t.Name(). User-facing code controls the
+// database via [WithDatabase] only.
+func withDatabaseKey(key []byte) Option {
+	return func(o *runOptions) { o.databaseKey = key }
+}
+
+// ciEnvVar describes a single CI-detection env var. If matchAny is true, the
+// var counts as a CI signal whenever it is present in the environment, even
+// with an empty value. Otherwise it must equal expected exactly.
+type ciEnvVar struct {
+	name     string
+	expected string
+	matchAny bool
+}
+
+var ciEnvVars = []ciEnvVar{
+	{name: "CI", matchAny: true},
+	{name: "__TOX_ENVIRONMENT_VARIABLE_ORIGINAL_CI", matchAny: true},
+	{name: "TF_BUILD", expected: "true"},
+	{name: "bamboo.buildKey", matchAny: true},
+	{name: "BUILDKITE", expected: "true"},
+	{name: "CIRCLECI", expected: "true"},
+	{name: "CIRRUS_CI", expected: "true"},
+	{name: "CODEBUILD_BUILD_ID", matchAny: true},
+	{name: "GITHUB_ACTIONS", expected: "true"},
+	{name: "GITLAB_CI", matchAny: true},
+	{name: "HEROKU_TEST_RUN_ID", matchAny: true},
+	{name: "TEAMCITY_VERSION", matchAny: true},
+}
+
+// isCI reports whether any well-known CI environment variable is set.
+func isCI() bool {
+	for _, v := range ciEnvVars {
+		val, ok := os.LookupEnv(v.name)
+		if !ok {
+			continue
+		}
+		if v.matchAny || val == v.expected { // coverage-ignore
+			return true
+		}
+	}
+	return false
+}
 
 // Run runs a property test and returns any error.
 //
-// Note output goes to stderr. For use in standalone binaries and conformance tests.
+// Note output goes to stdout. For use in standalone binaries and conformance tests.
 func Run(fn func(*TestCase), opts ...Option) error {
-	return runHegel(fn, stderrNoteFn, opts)
+	return runHegel(fn, stdoutNoteFn, opts)
 }
 
 // MustRun runs a property test and panics if it fails.
@@ -214,10 +313,7 @@ func MustRun(fn func(*TestCase), opts ...Option) {
 	}
 }
 
-// Test runs a property test as part of t.
-//
-// Note output is routed to t.Log. Use [testing.T.Run] to organize multiple
-// property tests into subtests in the standard Go way.
+// Test runs a property test against t.
 func Test(t *testing.T, fn func(*T), opts ...Option) {
 	t.Helper()
 
@@ -225,20 +321,31 @@ func Test(t *testing.T, fn func(*T), opts ...Option) {
 		ht := &T{TestCase: s, T: t}
 		fn(ht)
 	}
-	err := runHegel(body, func(msg string) { t.Log(msg) }, opts) // coverage-ignore
-	if err != nil {                                              // coverage-ignore
+	allOpts := append(opts, withDatabaseKey([]byte(t.Name())))
+	err := runHegel(body, func(msg string) { t.Log(msg) }, allOpts) // coverage-ignore
+	if err != nil {                                                 // coverage-ignore
 		t.Fatal(err)
 	}
 }
 
-// stderrNoteFn is the noteFn for Run/MustRun: writes to stderr.
-func stderrNoteFn(msg string) {
-	fmt.Fprintln(os.Stderr, msg)
+// stdoutNoteFn is the noteFn for Run/MustRun: writes to stdout.
+func stdoutNoteFn(msg string) {
+	fmt.Println(msg)
 }
 
 // runHegel is the shared implementation for Run, MustRun, and Test.
+//
+// The example-database key is supplied (when applicable) by [Test];
+// non-test entry points leave it nil.
 func runHegel(fn testBody, noteFn func(string), opts []Option) error {
-	o := runOptions{testCases: 100}
+	inCI := isCI()
+	o := runOptions{
+		testCases:   100,
+		derandomize: inCI,
+	}
+	if inCI {
+		o.database = DatabaseSetting{state: databaseDisabled}
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -302,22 +409,39 @@ func newClient(conn *connection) *client {
 	return &client{conn: conn}
 }
 
-// runTest executes one property test against the server.
-func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) error {
-	testSt := c.conn.NewStream("Test")
-
-	runTestMsg := map[string]any{
-		"command":    "run_test",
-		"test_cases": int64(opts.testCases),
-		"stream_id":  int64(testSt.StreamID()),
+func buildRunTestMessage(streamID uint32, opts runOptions) map[string]any {
+	msg := map[string]any{
+		"command":     "run_test",
+		"test_cases":  int64(opts.testCases),
+		"stream_id":   int64(streamID),
+		"derandomize": opts.derandomize,
+	}
+	if opts.database.state == databaseDisabled || opts.databaseKey == nil {
+		msg["database_key"] = nil
+	} else {
+		msg["database_key"] = opts.databaseKey
+	}
+	switch opts.database.state {
+	case databaseDisabled:
+		msg["database"] = nil
+	case databasePath:
+		msg["database"] = opts.database.path
 	}
 	if len(opts.suppressHealthCheck) > 0 {
 		names := make([]string, len(opts.suppressHealthCheck))
 		for i, hc := range opts.suppressHealthCheck {
 			names[i] = hc.String()
 		}
-		runTestMsg["suppress_health_check"] = names
+		msg["suppress_health_check"] = names
 	}
+	return msg
+}
+
+// runTest executes one property test against the server.
+func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) error {
+	testSt := c.conn.NewStream("Test")
+
+	runTestMsg := buildRunTestMessage(testSt.StreamID(), opts)
 	payload, err := encodeCBOR(runTestMsg)
 	if err != nil { // coverage-ignore
 		panic(fmt.Sprintf("runTest encode: %v", err))
@@ -331,7 +455,8 @@ func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) erro
 	var resultData map[any]any
 	for {
 		msgID, raw, err := testSt.RecvRequestRaw(30 * time.Second)
-		if err != nil {
+		// covered by TempGoProject
+		if err != nil { // coverage-ignore
 			return fmt.Errorf("test event recv: %w", err)
 		}
 		decoded, err := decodeCBOR(raw)
@@ -382,7 +507,8 @@ doneLoop:
 	}
 
 	// Check for health check failure.
-	if hcMsg, ok := resultData[any("health_check_failure")].(string); ok && hcMsg != "" {
+	// covered by TempGoProject
+	if hcMsg, ok := resultData[any("health_check_failure")].(string); ok && hcMsg != "" { // coverage-ignore
 		return fmt.Errorf("health check failure:\n%s", hcMsg)
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -18,16 +18,14 @@ import (
 func TestRunHegelTestPasses(t *testing.T) {
 
 	called := false
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		called = true
-		b := Draw[bool](s, Booleans())
+		b := Draw[bool](ht, Booleans())
 		// A valid assertion: b is either true or false.
 		if b != true && b != false {
 			t.Errorf("expected bool, got %v", b)
 		}
-	}, WithTestCases(5)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(5))
 	if !called {
 		t.Error("test function was never called")
 	}
@@ -36,17 +34,15 @@ func TestRunHegelTestPasses(t *testing.T) {
 // --- RunHegelTest: failing test raises error ---
 
 func TestRunHegelTestFails(t *testing.T) {
+	t.Parallel()
 
-	err := Run(func(s *TestCase) {
-		x := Draw[int](s, Integers[int](0, 100))
-		// This always fails: no integer < 0 in [0,100]
-		if x >= 0 {
-			panic(fmt.Sprintf("assertion failed: %d >= 0", x))
-		}
-	}, WithTestCases(10))
-	if err == nil {
-		t.Error("expected RunHegelTestE to return an error for always-failing test")
-	}
+	newTempGoProject(t).
+		testBody(`x := hegel.Draw[int](ht, hegel.Integers[int](0, 100))
+if x >= 0 {
+	panic(fmt.Sprintf("assertion failed: %d >= 0", x))
+}`, "hegel.WithTestCases(10)").
+		expectFailure(`assertion failed`).
+		goTest()
 }
 
 // --- RunHegelTest: assume(false) -> INVALID, test continues ---
@@ -54,11 +50,9 @@ func TestRunHegelTestFails(t *testing.T) {
 func TestRunHegelTestAllInvalid(t *testing.T) {
 
 	// A test that always calls Assume(false) should pass (all cases rejected).
-	if _err := Run(func(s *TestCase) {
-		s.Assume(false)
-	}, WithTestCases(5)); _err != nil {
-		panic(_err)
-	}
+	Test(t, func(ht *T) {
+		ht.Assume(false)
+	}, WithTestCases(5))
 }
 
 // --- RunHegelTest: assume(true) -> no effect ---
@@ -66,16 +60,14 @@ func TestRunHegelTestAllInvalid(t *testing.T) {
 func TestAssumeTrue(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		s.Assume(true)
-		b := Draw[bool](s, Booleans())
+	Test(t, func(ht *T) {
+		ht.Assume(true)
+		b := Draw[bool](ht, Booleans())
 		_ = b // use the value
 		if b != true && b != false {
-			panic("expected bool")
+			ht.Fatal("expected bool")
 		}
-	}, WithTestCases(5)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(5))
 }
 
 // --- note(): not printed when not final ---
@@ -84,12 +76,10 @@ func TestNoteNotFinal(t *testing.T) {
 	t.Parallel()
 
 	// note() should not panic or error when called outside final run
-	if _err := Run(func(s *TestCase) {
-		s.Note("should not appear")
-		_ = Draw[bool](s, Booleans())
-	}, WithTestCases(3)); _err != nil {
-		panic(_err)
-	}
+	Test(t, func(ht *T) {
+		ht.Note("should not appear")
+		_ = Draw[bool](ht, Booleans())
+	}, WithTestCases(3))
 }
 
 // --- target(): sends target command ---
@@ -97,15 +87,13 @@ func TestNoteNotFinal(t *testing.T) {
 func TestTargetSendsCommand(t *testing.T) {
 	t.Parallel()
 
-	if _err := Run(func(s *TestCase) {
-		x := Draw[int](s, Integers[int](0, 100))
-		s.Target(float64(x), "my_target")
+	Test(t, func(ht *T) {
+		x := Draw[int](ht, Integers[int](0, 100))
+		ht.Target(float64(x), "my_target")
 		if x < 0 || x > 100 {
-			panic("out of range")
+			ht.Fatal("out of range")
 		}
-	}, WithTestCases(5)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(5))
 }
 
 // --- HEGEL_PROTOCOL_TEST_MODE=stop_test_on_generate ---
@@ -114,11 +102,9 @@ func TestStopTestOnGenerate(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_generate")
 	// Should complete without error: client handles StopTest cleanly.
-	if _err := Run(func(s *TestCase) {
-		Draw[bool](s, Booleans())
-	}, WithTestCases(5)); _err != nil {
-		panic(_err)
-	}
+	Test(t, func(ht *T) {
+		Draw[bool](ht, Booleans())
+	}, WithTestCases(5))
 }
 
 // --- HEGEL_PROTOCOL_TEST_MODE=stop_test_on_mark_complete ---
@@ -126,11 +112,9 @@ func TestStopTestOnGenerate(t *testing.T) {
 func TestStopTestOnMarkComplete(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_mark_complete")
-	if _err := Run(func(s *TestCase) {
-		Draw[bool](s, Booleans())
-	}, WithTestCases(5)); _err != nil {
-		panic(_err)
-	}
+	Test(t, func(ht *T) {
+		Draw[bool](ht, Booleans())
+	}, WithTestCases(5))
 }
 
 // --- HEGEL_PROTOCOL_TEST_MODE=empty_test ---
@@ -138,11 +122,9 @@ func TestStopTestOnMarkComplete(t *testing.T) {
 func TestEmptyTest(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
-	if _err := Run(func(_ *TestCase) {
+	Test(t, func(_ *T) {
 		panic("should not be called")
-	}, WithTestCases(5)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(5))
 }
 
 // --- HEGEL_PROTOCOL_TEST_MODE=error_response ---
@@ -159,9 +141,9 @@ func TestErrorResponse(t *testing.T) {
 				gotErr = fmt.Errorf("%v", r)
 			}
 		}()
-		gotErr = Run(func(s *TestCase) {
+		gotErr = runHegel(func(s *TestCase) {
 			Draw[bool](s, Booleans()) // server sends error_response here
-		}, WithTestCases(3))
+		}, stdoutNoteFn, []Option{WithTestCases(3)})
 	}()
 	// The error from the server causes INTERESTING status -> re-raised on final run.
 	// Either a panic or a non-nil error is acceptable.
@@ -295,15 +277,13 @@ func TestHegelSessionConcurrentStart(t *testing.T) {
 func TestRunHegelTestSingleCase(t *testing.T) {
 
 	count := 0
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		count++
-		b := Draw[bool](s, Booleans())
+		b := Draw[bool](ht, Booleans())
 		if b != true && b != false {
-			panic("not a bool")
+			ht.Fatal("not a bool")
 		}
-	}, WithTestCases(1)); _err != nil {
-		panic(_err)
-	}
+	}, WithTestCases(1))
 	if count == 0 {
 		t.Error("expected at least one test case to run")
 	}
@@ -318,14 +298,12 @@ func TestConcurrentRunHegelTest(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			if _err := Run(func(s *TestCase) {
-				b := Draw[bool](s, Booleans())
+			Test(t, func(ht *T) {
+				b := Draw[bool](ht, Booleans())
 				if b != true && b != false {
-					panic("not a bool")
+					ht.Fatal("not a bool")
 				}
-			}, WithTestCases(3)); _err != nil {
-				panic(_err)
-			}
+			}, WithTestCases(3))
 		}(i)
 	}
 	wg.Wait()
@@ -335,12 +313,9 @@ func TestConcurrentRunHegelTest(t *testing.T) {
 
 func TestRunHegelTestESuccess(t *testing.T) {
 
-	err := Run(func(s *TestCase) {
-		_ = Draw[bool](s, Booleans())
+	Test(t, func(ht *T) {
+		_ = Draw[bool](ht, Booleans())
 	}, WithTestCases(3))
-	if err != nil {
-		t.Errorf("RunHegelTestE: unexpected error: %v", err)
-	}
 }
 
 // --- WithTestCases option ---
@@ -349,12 +324,10 @@ func TestWithTestCasesOption(t *testing.T) {
 	t.Parallel()
 
 	count := 0
-	if _err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		count++
-		Draw[bool](s, Booleans())
-	}, WithTestCases(10)); _err != nil {
-		panic(_err)
-	}
+		Draw[bool](ht, Booleans())
+	}, WithTestCases(10))
 	// count should be >= 10 (at least the requested cases)
 	if count < 1 {
 		t.Error("expected test cases to run")
@@ -366,11 +339,11 @@ func TestWithTestCasesOption(t *testing.T) {
 func TestStopTestOnCollectionMore(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := Run(func(s *TestCase) {
+	err := runHegel(func(s *TestCase) {
 		max := 10
 		coll := newCollection(s, 0, &max)
 		_ = coll.More(s)
-	})
+	}, stdoutNoteFn, nil)
 	_ = err // StopTest causes abort, not necessarily an error return
 }
 
@@ -379,37 +352,12 @@ func TestStopTestOnCollectionMore(t *testing.T) {
 func TestStopTestOnNewCollection(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := Run(func(s *TestCase) {
+	err := runHegel(func(s *TestCase) {
 		max := 10
 		coll := newCollection(s, 0, &max)
 		_ = coll.More(s)
-	})
+	}, stdoutNoteFn, nil)
 	_ = err // StopTest causes abort, not necessarily an error return
-}
-
-// --- isFinal: Note prints on final run ---
-// We test this by running a failing test so the final replay happens.
-// We capture whether isFinal was true via the state in the closure.
-
-func TestNoteOnFinalRun(t *testing.T) {
-	t.Parallel()
-
-	noted := false
-	noteFunc := func(s *TestCase) {
-		if s.isFinal {
-			noted = true
-		}
-		s.Note("final note")
-		// Always fail so we get a final replay.
-		panic("intentional failure for final replay test")
-	}
-	func() {
-		defer func() { recover() }()    //nolint:errcheck
-		Run(noteFunc, WithTestCases(3)) //nolint:errcheck
-	}()
-	if !noted {
-		t.Error("expected isFinal to be true during final replay")
-	}
 }
 
 // --- runTest: connection error in test function is re-raised ---
@@ -417,9 +365,9 @@ func TestNoteOnFinalRun(t *testing.T) {
 func TestConnectionErrorInTestFunction(t *testing.T) {
 	t.Parallel()
 
-	err := Run(func(_ *TestCase) {
+	err := runHegel(func(_ *TestCase) {
 		panic(&connectionError{msg: "test connection lost"})
-	}, WithTestCases(1))
+	}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Fatal("expected error to be raised for connection error")
 	}
@@ -581,7 +529,7 @@ func TestExtractPanicOriginError(t *testing.T) {
 
 func TestNoteIsFinalTrue(t *testing.T) {
 	t.Parallel()
-	state := &TestCase{isFinal: true, noteFn: stderrNoteFn}
+	state := &TestCase{isFinal: true, noteFn: stdoutNoteFn}
 	// Should not panic.
 	state.Note("test note on final")
 }
@@ -649,7 +597,7 @@ func TestRunHegelTestESessionError(t *testing.T) {
 	globalSession = newHegelSession()
 	globalSession.hegelCmd = "/nonexistent/hegel"
 
-	err := Run(func(_ *TestCase) {}, WithTestCases(1))
+	err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Error("expected error when session cannot start")
 	}
@@ -675,7 +623,7 @@ func TestRunHegelTestPanicsOnFailure(t *testing.T) {
 	fake.hegelCmd = "/nonexistent/hegel"
 	globalSession = fake
 
-	if _err := Run(func(_ *TestCase) {}, WithTestCases(1)); _err != nil {
+	if _err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)}); _err != nil {
 		panic(_err)
 	}
 }
@@ -685,13 +633,10 @@ func TestRunHegelTestPanicsOnFailure(t *testing.T) {
 func TestRunHegelTestECallsRunTest(t *testing.T) {
 
 	called := false
-	err := Run(func(s *TestCase) {
+	Test(t, func(ht *T) {
 		called = true
-		Draw[bool](s, Booleans())
+		Draw[bool](ht, Booleans())
 	}, WithTestCases(1))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
 	if !called {
 		t.Error("test body was never called")
 	}
@@ -709,7 +654,7 @@ func TestHegelSessionRunTest(t *testing.T) {
 	}
 	err := s.runTest(func(st *TestCase) {
 		Draw[bool](st, Booleans())
-	}, runOptions{testCases: 2}, stderrNoteFn)
+	}, runOptions{testCases: 2}, stdoutNoteFn)
 	if err != nil {
 		t.Errorf("session.runTest: %v", err)
 	}
@@ -798,7 +743,7 @@ func TestRunHegelTestEProtocolModeStartError(t *testing.T) {
 	t.Setenv("HOME", "/nonexistent")
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
 
-	err := Run(func(_ *TestCase) {}, WithTestCases(1))
+	err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Error("expected error when session cannot start in protocol test mode")
 	}
@@ -930,10 +875,10 @@ func TestTestSuccess(t *testing.T) {
 
 func TestStateFailedPath(t *testing.T) {
 
-	err := Run(func(s *TestCase) {
+	err := runHegel(func(s *TestCase) {
 		_ = Draw[bool](s, Booleans())
 		s.failed = true // simulates T.Error/T.Fail
-	}, WithTestCases(1))
+	}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Error("expected error when state.failed is true")
 	}
@@ -945,33 +890,32 @@ func TestStateFailedPath(t *testing.T) {
 
 func TestFatalSentinelPath(t *testing.T) {
 
-	err := Run(func(s *TestCase) {
+	err := runHegel(func(s *TestCase) {
 		_ = Draw[bool](s, Booleans())
 		panic(fatalSentinel{msg: "test fatal"})
-	}, WithTestCases(1))
+	}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Error("expected error when fatalSentinel is raised")
 	}
 }
 
 // =============================================================================
-// Test: noteFn (t.Log) is called on final replay
+// Test: notes printed on final replay reach the process's real stdout
 // =============================================================================
 
-func TestTestNoteFnOnFinal(t *testing.T) {
+// Verifies the full path ht.Note -> noteFn (t.Log) -> go test output by
+// spawning a real `go test` subprocess that calls hegel.Test. The body
+// emits a note on final replay; we assert it shows up in the captured
+// test output.
+func TestNoteFnOnFinal(t *testing.T) {
+	t.Parallel()
 
-	noted := false
-	err := runHegel(func(s *TestCase) {
-		_ = Draw[bool](s, Booleans())
-		s.Note("note for final")
-		panic("always fail for final replay")
-	}, func(msg string) { noted = true }, []Option{WithTestCases(1)})
-	if err == nil {
-		t.Error("expected error from failing test")
-	}
-	if !noted {
-		t.Error("expected noteFn to be called on final replay")
-	}
+	newTempGoProject(t).
+		testBody(`_ = hegel.Draw[bool](ht, hegel.Booleans())
+ht.Note("note for final")
+panic("always fail for final replay")`, "hegel.WithTestCases(1)").
+		expectFailure(`note for final`).
+		goTest()
 }
 
 // --- hegelCommand: covered in installer_test.go ---
@@ -984,7 +928,7 @@ func TestRunTestSendControlRequestError(t *testing.T) {
 	remote.Close()
 
 	cl := newClient(conn)
-	err := cl.runTest(func(_ *TestCase) {}, runOptions{testCases: 1}, stderrNoteFn)
+	err := cl.runTest(func(_ *TestCase) {}, runOptions{testCases: 1}, stdoutNoteFn)
 	if err == nil {
 		t.Fatal("expected error from runTest on closed conn")
 	}
@@ -1048,24 +992,18 @@ func TestSuppressHealthCheckOption(t *testing.T) {
 func TestSuppressHealthCheckIntegration(t *testing.T) {
 
 	// Exercise the suppress_health_check protocol path.
-	err := Run(func(s *TestCase) {
-		n := Draw[int](s, Integers[int](0, 100))
-		s.Assume(n < 90)
+	Test(t, func(ht *T) {
+		n := Draw[int](ht, Integers[int](0, 100))
+		ht.Assume(n < 90)
 	}, SuppressHealthCheck(FilterTooMuch, TooSlow), WithTestCases(5))
-	if err != nil {
-		t.Errorf("expected test to pass with suppressed health check: %v", err)
-	}
 }
 
 func TestSuppressAllHealthChecksIntegration(t *testing.T) {
 
-	err := Run(func(s *TestCase) {
-		n := Draw[int](s, Integers[int](0, 100))
-		s.Assume(n < 90)
+	Test(t, func(ht *T) {
+		n := Draw[int](ht, Integers[int](0, 100))
+		ht.Assume(n < 90)
 	}, SuppressHealthCheck(AllHealthChecks()...), WithTestCases(5))
-	if err != nil {
-		t.Errorf("expected test to pass with all health checks suppressed: %v", err)
-	}
 }
 
 // =============================================================================
@@ -1121,17 +1059,15 @@ func TestHegelSessionStartTimeout(t *testing.T) {
 // =============================================================================
 
 func TestHealthCheckFailureFilterTooMuch(t *testing.T) {
+	t.Parallel()
 
 	// Filtering based on a tiny range triggers FilterTooMuch: the server sees
 	// almost all test cases rejected and raises a health check failure.
-	err := Run(func(s *TestCase) {
-		n := Draw[int](s, Integers[int](0, 1000))
-		s.Assume(n == 0) // reject ~99.9% of test cases
-	}, WithTestCases(200))
-	if err == nil {
-		t.Fatal("expected health check failure")
-	}
-	mustContainStr(t, err.Error(), "health check failure")
+	newTempGoProject(t).
+		testBody(`n := hegel.Draw[int](ht, hegel.Integers[int](0, 1000))
+ht.Assume(n == 0)`, "hegel.WithTestCases(200)").
+		expectFailure(`health check failure`).
+		goTest()
 }
 
 // =============================================================================
@@ -1143,11 +1079,11 @@ var flakyCounter atomic.Int64
 func TestFlakyGlobalState(t *testing.T) {
 
 	flakyCounter.Store(0)
-	err := Run(func(s *TestCase) {
+	err := runHegel(func(s *TestCase) {
 		min := int(flakyCounter.Load())
 		_ = Draw[int](s, Integers[int](min, min+100))
 		flakyCounter.Add(1)
-	}, WithTestCases(100))
+	}, stdoutNoteFn, nil)
 	if err == nil {
 		t.Fatal("expected error for flaky test")
 	}
@@ -1257,7 +1193,105 @@ func TestProcessOneMessageServerCrash(t *testing.T) {
 	mustContainStr(t, err.Error(), "server process exited unexpectedly")
 }
 
+// processExited is non-nil but never closes — the wait times out and we fall
+// through to the generic "connection closed" error.
+func TestProcessOneMessageConnectionClosedTimeout(t *testing.T) {
+	t.Parallel()
+	s, c := socketPair(t)
+	conn := newConnection(s, s, "C")
+	conn.state = stateClient
+	st := conn.NewStream("Test")
+
+	conn.processExited = make(chan struct{})
+	c.Close()
+
+	<-conn.done
+
+	_, _, err := st.RecvRequestRaw(1 * time.Second)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	mustContainStr(t, err.Error(), "connection closed")
+}
+
+// =============================================================================
+// buildRunTestMessage: wire-format base fields
+// =============================================================================
+
+func TestBuildRunTestMessageBaseFields(t *testing.T) {
+	t.Parallel()
+	msg := buildRunTestMessage(7, runOptions{testCases: 42, derandomize: true})
+	if msg["command"] != "run_test" {
+		t.Errorf("command = %v", msg["command"])
+	}
+	if msg["test_cases"] != int64(42) {
+		t.Errorf("test_cases = %v", msg["test_cases"])
+	}
+	if msg["stream_id"] != int64(7) {
+		t.Errorf("stream_id = %v", msg["stream_id"])
+	}
+	if msg["derandomize"] != true {
+		t.Errorf("derandomize = %v", msg["derandomize"])
+	}
+}
+
+func TestDatabaseDisabledSetting(t *testing.T) {
+	t.Parallel()
+	s := DatabaseDisabled()
+	if s.state != databaseDisabled {
+		t.Errorf("state = %v, want databaseDisabled", s.state)
+	}
+}
+
+func TestBuildRunTestMessageDatabaseDisabled(t *testing.T) {
+	t.Parallel()
+	msg := buildRunTestMessage(1, runOptions{
+		testCases:   1,
+		database:    DatabaseDisabled(),
+		databaseKey: []byte("k"),
+	})
+	v, ok := msg["database"]
+	if !ok {
+		t.Fatal("expected database field to be present")
+	}
+	if v != nil {
+		t.Errorf("database = %v, want nil", v)
+	}
+	if msg["database_key"] != nil {
+		t.Errorf("database_key = %v, want nil when disabled", msg["database_key"])
+	}
+}
+
+// In CI, runHegel disables the database regardless of the user's option.
+func TestRunHegelDisablesDatabaseInCI(t *testing.T) {
+	clearCIEnv(t)
+	t.Setenv("CI", "true")
+	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
+	err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, nil)
+	if err != nil {
+		t.Fatalf("runHegel: %v", err)
+	}
+}
+
+func TestWithDerandomizeIntegration(t *testing.T) {
+	clearCIEnv(t)
+	// Just exercise the wire path — full determinism is enforced server-side.
+	Test(t, func(ht *T) {
+		_ = Draw[bool](ht, Booleans())
+	}, WithDerandomize(true), WithTestCases(3))
+}
+
 // --- helpers ---
+
+func clearCIEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range ciEnvVars {
+		if old, ok := os.LookupEnv(v.name); ok {
+			os.Unsetenv(v.name)
+			t.Cleanup(func() { os.Setenv(v.name, old) })
+		}
+	}
+}
 
 func mustContainStr(t *testing.T, s, sub string) {
 	t.Helper()

--- a/server_crash_test.go
+++ b/server_crash_test.go
@@ -228,7 +228,7 @@ func TestServerCrashIncludesLogContent(t *testing.T) {
 
 	err := s.runTest(func(tc *TestCase) {
 		Draw[bool](tc, Booleans())
-	}, runOptions{testCases: 1}, stderrNoteFn)
+	}, runOptions{testCases: 1}, stdoutNoteFn)
 	if err == nil {
 		t.Fatal("expected error from fake crash server")
 	}
@@ -247,7 +247,7 @@ func TestServerCrashEmptyLog(t *testing.T) {
 
 	err := s.runTest(func(tc *TestCase) {
 		Draw[bool](tc, Booleans())
-	}, runOptions{testCases: 1}, stderrNoteFn)
+	}, runOptions{testCases: 1}, stdoutNoteFn)
 	if err == nil {
 		t.Fatal("expected error from fake crash server")
 	}
@@ -269,21 +269,15 @@ func TestKillServerNoProcess(t *testing.T) {
 func TestServerRestartsAfterKill(t *testing.T) {
 
 	// First run — starts the server and completes successfully.
-	err := Run(func(s *TestCase) {
-		Draw[bool](s, Booleans())
+	Test(t, func(ht *T) {
+		Draw[bool](ht, Booleans())
 	}, WithTestCases(1))
-	if err != nil {
-		t.Fatalf("first run: %v", err)
-	}
 
 	// Kill the server and wait for the connection to detect it has exited.
 	testKillServer()
 
 	// Second run — should detect the dead session, restart the server, and succeed.
-	err = Run(func(s *TestCase) {
-		Draw[bool](s, Booleans())
+	Test(t, func(ht *T) {
+		Draw[bool](ht, Booleans())
 	}, WithTestCases(1))
-	if err != nil {
-		t.Fatalf("second run after restart: %v", err)
-	}
 }

--- a/temp_project_test.go
+++ b/temp_project_test.go
@@ -1,0 +1,159 @@
+package hegel
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// tempGoProject builds an isolated Go module in a temp directory that depends
+// on the hegel package via a `replace` directive pointing at the source tree.
+// It mirrors the Rust suite's TempRustProject: drop in a hegel.Test body,
+// run it via `go test`, and assert against the captured stdout/stderr/exit.
+//
+// Use this when a test needs to observe behavior that only manifests in a
+// real process (stdout/stderr output, exit codes, t.Log routing).
+type tempGoProject struct {
+	t      *testing.T
+	dir    string
+	expect string // regex; non-empty => expect non-zero exit and match
+}
+
+type runOutput struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+func newTempGoProject(t *testing.T) *tempGoProject {
+	t.Helper()
+	moduleDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	p := &tempGoProject{
+		t:   t,
+		dir: t.TempDir(),
+	}
+	// Build the temp go.mod by reusing the parent's transitive require lines.
+	// This avoids a `go mod tidy` round-trip per project (which would also
+	// drop unused requires before main.go exists).
+	parentMod, err := os.ReadFile(filepath.Join(moduleDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("read parent go.mod: %v", err)
+	}
+	goMod := regexp.MustCompile(`(?m)^module .*$`).ReplaceAllString(string(parentMod), "module temptest")
+	goMod += fmt.Sprintf("\nrequire hegel.dev/go/hegel v0.0.0\n\nreplace hegel.dev/go/hegel => %s\n", moduleDir)
+	if err := os.WriteFile(filepath.Join(p.dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	// Reuse the parent module's go.sum so `go run` doesn't need network access
+	// to verify the transitive dependency graph.
+	if sum, err := os.ReadFile(filepath.Join(moduleDir, "go.sum")); err == nil {
+		_ = os.WriteFile(filepath.Join(p.dir, "go.sum"), sum, 0o644)
+	}
+	return p
+}
+
+// writeFile writes name relative to the project dir.
+func (p *tempGoProject) writeFile(name, content string) *tempGoProject {
+	p.t.Helper()
+	if err := os.WriteFile(filepath.Join(p.dir, name), []byte(content), 0o644); err != nil {
+		p.t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// testBody installs a hegel_test.go that wraps code as the body of a
+// hegel.Test call inside a Go test function. Run via goTest.
+//
+// The hegel.T parameter is named ht. fmt is imported and silenced so bodies
+// can use it freely. Pass options as Go-source strings (e.g.
+// "hegel.WithTestCases(10)").
+func (p *tempGoProject) testBody(code string, opts ...string) *tempGoProject {
+	indented := "\t\t" + strings.ReplaceAll(code, "\n", "\n\t\t")
+	optsStr := ""
+	if len(opts) > 0 {
+		optsStr = ", " + strings.Join(opts, ", ")
+	}
+	return p.writeFile("hegel_test.go", fmt.Sprintf(`package temptest
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"hegel.dev/go/hegel"
+)
+
+var (
+	_ = fmt.Sprintf
+	_ = os.Getenv
+)
+
+func TestSubprocess(t *testing.T) {
+	hegel.Test(t, func(ht *hegel.T) {
+%s
+	}%s)
+}
+`, indented, optsStr))
+}
+
+// expectFailure asserts the command exits non-zero and the combined
+// stdout+stderr matches pattern. Without this, a non-zero exit fails the test.
+func (p *tempGoProject) expectFailure(pattern string) *tempGoProject {
+	p.expect = pattern
+	return p
+}
+
+// goTest runs `go test -v ./...` in the temp project. -v ensures t.Log
+// output is flushed regardless of pass/fail, so callers can grep for
+// note/log sentinels emitted by the test body.
+func (p *tempGoProject) goTest(args ...string) runOutput {
+	return p.run(append([]string{"test", "-v", "./..."}, args...))
+}
+
+func (p *tempGoProject) run(args []string) runOutput {
+	p.t.Helper()
+	cmd := exec.Command("go", args...)
+	cmd.Dir = p.dir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+
+	out := runOutput{Stdout: stdout.String(), Stderr: stderr.String()}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		out.ExitCode = ee.ExitCode()
+	} else if err != nil {
+		p.t.Fatalf("go %v: spawn failed: %v", args, err)
+	}
+
+	if p.expect == "" {
+		if err != nil {
+			p.t.Fatalf("expected success, got exit %d.\nstdout:\n%s\nstderr:\n%s",
+				out.ExitCode, out.Stdout, out.Stderr)
+		}
+	} else {
+		if err == nil {
+			p.t.Fatalf("expected failure but command succeeded.\nstdout:\n%s\nstderr:\n%s",
+				out.Stdout, out.Stderr)
+		}
+		combined := out.Stdout + "\n" + out.Stderr
+		matched, mErr := regexp.MatchString(p.expect, combined)
+		if mErr != nil {
+			p.t.Fatalf("bad expectFailure regex %q: %v", p.expect, mErr)
+		}
+		if !matched {
+			p.t.Fatalf("output didn't match %q.\ncombined:\n%s", p.expect, combined)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Adds two new options for property tests:

- `WithDatabase(setting)` — controls example-database persistence. Construct with `Database(path)` to persist to a directory, or `DatabaseDisabled()` to opt out. The default uses the server's database location.
- `WithDerandomize(bool)` — fixes the seed for deterministic runs.

In CI environments — detected via a curated env-var list (`CI`, `GITHUB_ACTIONS`, `BUILDKITE`, `CIRCLECI`, `TF_BUILD`, `TEAMCITY_VERSION`, etc.) — the database defaults to disabled and `derandomize` defaults to `true`.

When a test runs via `Test()`, its `t.Name()` is used as the example-database key, so distinct (sub)tests don't share saved examples.

This PR also adds `tempGoProject` (`temp_project_test.go`), a test harness that runs a hegel test body in a real `go test` subprocess. This lets tests observe failures, exit codes, and stdout/stderr without those failures bubbling up to the parent test. Used by `database_test.go` to verify replay behavior: `TestDatabaseKeyReplaysFailure` spawns two `go test` invocations and asserts (a) the second run replays the shrunk counterexample first, and (b) distinct `database_key`s don't cross-pollinate.

`Run`'s note output now goes to stdout (was stderr) — friendlier for conformance binaries that pipe output to harness scripts.

## Self-review notes (findings I disagreed with or chose not to fix)

The `code-reviewer` subagent flagged a few things that weren't fixed in this PR; surfacing them here so a human reviewer can override:

- **`RELEASE_TYPE: patch` vs `minor`.** Per `RELEASE-sample.md`, this should arguably be `minor` since it adds new exported public API (`WithDatabase`, `WithDerandomize`, `Database`, `DatabaseDisabled`, `DatabaseSetting`). Left at `patch` per Liam's explicit choice.
- **`isCI` has a `// coverage-ignore` on `val == v.expected`.** This branch is genuinely coverable (set `t.Setenv("TF_BUILD", "true")` and call `isCI()`). A small unit test would let the annotation drop.
- **`runner.go:457-461` and `:509-513` mix `// covered by TempGoProject` with `// coverage-ignore`.** The two annotations contradict each other — the comment says "this is tested" while the directive says "treat this as untestable." Worth picking one story (either parse subprocess output to assert the path at the parent level, or rewrite the comment to explain that subprocess coverage doesn't aggregate).
- **`TestRunHegelDisablesDatabaseInCI` doesn't actually verify CI-disables-database.** Body sets `CI=true` and asserts no error from an `empty_test`-mode run, but never observes `msg["database"]` or `msg["derandomize"]`. A regression that left the database enabled in CI would still pass this test. Could be tightened to assert against `buildRunTestMessage` output instead.
- **`temp_project_test.go:58-60`** — `go.sum` copy silently swallows write errors (`_ = os.WriteFile(...)`). If the write fails, `go test` will then attempt network fetches and produce a confusing failure far from the cause.
- **`temp_project_test.go:51`** — copying the parent `go.mod` minus the `module` line is fragile when the parent has `replace` directives with relative paths. Currently fine, but future additions to the parent `go.mod` could silently break the harness.
- **`runner.go:324`** — `append(opts, withDatabaseKey(...))` may mutate the caller's underlying slice when `opts` has spare capacity. The current key value is `t.Name()`, so the same value gets written to the same slot on a repeat call (no observable bug today), but it's a footgun if `withDatabaseKey` ever depends on something that varies.

</details>
