### PR TITLE
Add `hegel.Composite` generator

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+RELEASE_TYPE: patch
+
+This release adds `hegel.Composite`, for defining custom generators:
+
+```go
+type Person struct {
+    Name           string
+    Age            int
+    DrivingLicense bool
+}
+
+personGen := hegel.Composite(func(tc *hegel.TestCase) Person {
+    age := hegel.Draw(tc, hegel.Integers(0, 120))
+    name := hegel.Draw(tc, hegel.Text())
+    p := Person{Age: age, Name: name}
+    if age >= 18 {
+        p.DrivingLicense = hegel.Draw(tc, hegel.Booleans())
+    }
+    return p
+})
+
+hegel.Test(t, func(ht *hegel.T) {
+    p := hegel.Draw(ht, personGen)
+    // ...
+})
+```

--- a/composite.go
+++ b/composite.go
@@ -1,0 +1,86 @@
+package hegel
+
+// labelComposite marks a user-defined composite generation span.
+//
+// Composites are imperative: the user's function may call Draw any number of
+// times, in any order, possibly recursively. The server treats every composite
+// span as opaque for shrinking purposes — the structure inside is whatever the
+// user's function decides on this run.
+const labelComposite spanLabel = 16
+
+// compositeGenerator is a user-defined generator built from an imperative
+// function that calls Draw on other generators.
+type compositeGenerator[T any] struct {
+	label string
+	fn    func(*TestCase) T
+}
+
+// draw runs the user's function inside a COMPOSITE span. The label string is
+// emitted via Note so it appears in replay output for shrunk failures, but the
+// span itself uses the fixed labelComposite int so the server's shrinker
+// treats every composite uniformly without protocol changes.
+//
+//lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
+func (g *compositeGenerator[T]) draw(s *TestCase) T {
+	startSpan(s, labelComposite)
+	if g.label != "" {
+		s.Note("composite: " + g.label)
+	}
+	result := g.fn(s)
+	stopSpan(s, false)
+	return result
+}
+
+// asBasic always returns not-basic. A composite is imperative by definition —
+// it may issue an unbounded number of generate requests, branch on intermediate
+// values, and recurse. None of that fits a single JSON schema.
+//
+//lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
+func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
+	return nil, false, nil
+}
+
+// Composite returns a Generator backed by an imperative function.
+//
+// Inside fn, call [Draw] on other generators to assemble the value. The
+// function may call Draw any number of times, branch on intermediate results,
+// and recurse — Hegel records each draw in a span tree so shrinking still
+// works. The label string appears in replay output and aids debugging shrunk
+// failures; it does not affect generation or shrinking.
+//
+// Composite is the analog of Hypothesis's @composite. Reach for it when the
+// shape of generation is genuinely state-dependent — the number of draws
+// depends on a previously drawn value, fields appear conditionally on a
+// discriminator, or the structure recurses. For independent fixed-shape
+// values, prefer the declarative combinators ([Lists], [Maps], [OneOf],
+// [Optional]); they give the shrinker more structural visibility.
+//
+// Example: a generator for a Person whose driving license field only appears
+// when age >= 18.
+//
+//	type Person struct {
+//	    Name           string
+//	    Age            int
+//	    DrivingLicense bool
+//	}
+//
+//	personGen := hegel.Composite("person", func(tc *hegel.TestCase) Person {
+//	    age := hegel.Draw(tc, hegel.Integers(0, 120))
+//	    name := hegel.Draw(tc, hegel.Text().MinSize(1).MaxSize(50))
+//	    p := Person{Age: age, Name: name}
+//	    if age >= 18 {
+//	        p.DrivingLicense = hegel.Draw(tc, hegel.Booleans())
+//	    }
+//	    return p
+//	})
+//
+//	hegel.Test(t, func(ht *hegel.T) {
+//	    p := hegel.Draw(ht, personGen)
+//	    // assert properties of p
+//	})
+func Composite[T any](label string, fn func(*TestCase) T) Generator[T] {
+	if fn == nil {
+		panic("Composite requires a non-nil function")
+	}
+	return &compositeGenerator[T]{label: label, fn: fn}
+}

--- a/composite.go
+++ b/composite.go
@@ -1,39 +1,20 @@
 package hegel
 
-// labelComposite marks a user-defined composite generation span.
-//
-// Composites are imperative: the user's function may call Draw any number of
-// times, in any order, possibly recursively. The server treats every composite
-// span as opaque for shrinking purposes — the structure inside is whatever the
-// user's function decides on this run.
-const labelComposite spanLabel = 16
-
-// compositeGenerator is a user-defined generator built from an imperative
-// function that calls Draw on other generators.
+// compositeGenerator is a Generator built from an imperative function that
+// composes other generators via [Draw]. It has no schema and always falls
+// back to compositional generation.
 type compositeGenerator[T any] struct {
-	label string
-	fn    func(*TestCase) T
+	fn func(*TestCase) T
 }
 
-// draw runs the user's function inside a COMPOSITE span. The label string is
-// emitted via Note so it appears in replay output for shrunk failures, but the
-// span itself uses the fixed labelComposite int so the server's shrinker
-// treats every composite uniformly without protocol changes.
+// draw invokes the composed function with the given TestCase.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
 func (g *compositeGenerator[T]) draw(s *TestCase) T {
-	startSpan(s, labelComposite)
-	if g.label != "" {
-		s.Note("composite: " + g.label)
-	}
-	result := g.fn(s)
-	stopSpan(s, false)
-	return result
+	return g.fn(s)
 }
 
-// asBasic always returns not-basic. A composite is imperative by definition —
-// it may issue an unbounded number of generate requests, branch on intermediate
-// values, and recurse. None of that fits a single JSON schema.
+// asBasic always returns not-basic — composite generators have no schema.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
 func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
@@ -43,17 +24,9 @@ func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 // Composite returns a Generator backed by an imperative function.
 //
 // Inside fn, call [Draw] on other generators to assemble the value. The
-// function may call Draw any number of times, branch on intermediate results,
-// and recurse — Hegel records each draw in a span tree so shrinking still
-// works. The label string appears in replay output and aids debugging shrunk
-// failures; it does not affect generation or shrinking.
+// function may call Draw any number of times.
 //
-// Composite is the analog of Hypothesis's @composite. Reach for it when the
-// shape of generation is genuinely state-dependent — the number of draws
-// depends on a previously drawn value, fields appear conditionally on a
-// discriminator, or the structure recurses. For independent fixed-shape
-// values, prefer the declarative combinators ([Lists], [Maps], [OneOf],
-// [Optional]); they give the shrinker more structural visibility.
+// The function receives the same *TestCase that test bodies receive.
 //
 // Example: a generator for a Person whose driving license field only appears
 // when age >= 18.
@@ -64,9 +37,9 @@ func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 //	    DrivingLicense bool
 //	}
 //
-//	personGen := hegel.Composite("person", func(tc *hegel.TestCase) Person {
+//	personGen := hegel.Composite(func(tc *hegel.TestCase) Person {
 //	    age := hegel.Draw(tc, hegel.Integers(0, 120))
-//	    name := hegel.Draw(tc, hegel.Text().MinSize(1).MaxSize(50))
+//	    name := hegel.Draw(tc, hegel.Text())
 //	    p := Person{Age: age, Name: name}
 //	    if age >= 18 {
 //	        p.DrivingLicense = hegel.Draw(tc, hegel.Booleans())
@@ -78,9 +51,6 @@ func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 //	    p := hegel.Draw(ht, personGen)
 //	    // assert properties of p
 //	})
-func Composite[T any](label string, fn func(*TestCase) T) Generator[T] {
-	if fn == nil {
-		panic("Composite requires a non-nil function")
-	}
-	return &compositeGenerator[T]{label: label, fn: fn}
+func Composite[T any](fn func(*TestCase) T) Generator[T] {
+	return &compositeGenerator[T]{fn: fn}
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -3,91 +3,140 @@ package hegel
 // composite_test.go tests the Composite function and compositeGenerator type.
 
 import (
+	"fmt"
 	"testing"
 )
 
 // =============================================================================
-// Composite — return-type and asBasic checks
+// Composite function unit tests — verify return types
 // =============================================================================
 
 // TestCompositeReturnsCompositeGenerator verifies that Composite returns a
-// *compositeGenerator[T].
+// *compositeGenerator.
 func TestCompositeReturnsCompositeGenerator(t *testing.T) {
 	t.Parallel()
-	g := Composite("test", func(*TestCase) int { return 0 })
-	if _, ok := g.(*compositeGenerator[int]); !ok {
-		t.Fatalf("Composite should return *compositeGenerator[int], got %T", g)
+	gen := Composite(func(s *TestCase) int {
+		return Draw(s, Integers[int](0, 10))
+	})
+	if _, ok := gen.(*compositeGenerator[int]); !ok {
+		t.Fatalf("Composite should return *compositeGenerator[int], got %T", gen)
 	}
 }
 
-// TestCompositeAsBasicAlwaysFalse verifies that a compositeGenerator never
-// reduces to a basic schema — its body is imperative and may issue an unbounded
-// number of draws.
-func TestCompositeAsBasicAlwaysFalse(t *testing.T) {
+// TestCompositeGeneratorAsBasicReturnsNotBasic verifies that compositeGenerator
+// is never basic — composite generators have no schema.
+func TestCompositeGeneratorAsBasicReturnsNotBasic(t *testing.T) {
 	t.Parallel()
-	g := Composite("test", func(*TestCase) int { return 0 })
-	bg, ok, err := g.(*compositeGenerator[int]).asBasic()
-	if bg != nil || ok || err != nil {
-		t.Fatalf("Composite.asBasic should return (nil, false, nil); got (%v, %v, %v)", bg, ok, err)
+	gen := Composite(func(s *TestCase) int {
+		return Draw(s, Integers[int](0, 10))
+	})
+	bg, ok, err := gen.(*compositeGenerator[int]).asBasic()
+	if err != nil {
+		t.Fatalf("asBasic returned error: %v", err)
+	}
+	if ok {
+		t.Fatal("compositeGenerator should never be basic")
+	}
+	if bg != nil {
+		t.Fatal("compositeGenerator.asBasic should return nil bg")
 	}
 }
 
-// TestCompositeNilFunctionPanics verifies that Composite panics when given a
-// nil function — silent acceptance would yield a generator that nil-panics on
-// first draw, far from the bug site.
-func TestCompositeNilFunctionPanics(t *testing.T) {
+// TestCompositeGeneratorMapReturnsMappedGenerator verifies that Map on a
+// composite generator returns a *mappedGenerator (the non-basic path).
+func TestCompositeGeneratorMapReturnsMappedGenerator(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("Composite(nil) should panic")
-		}
-	}()
-	_ = Composite[int]("x", nil)
+	gen := Composite(func(s *TestCase) int {
+		return Draw(s, Integers[int](0, 10))
+	})
+	mapped := Map(gen, func(v int) string { return fmt.Sprintf("%d", v) })
+	if _, ok := mapped.(*mappedGenerator[int, string]); !ok {
+		t.Fatalf("Map(compositeGenerator) should return *mappedGenerator, got %T", mapped)
+	}
 }
 
 // =============================================================================
-// Composite — end-to-end via Run, against the real hegel-core server
+// compositeGenerator.draw tests using real hegel binary
 // =============================================================================
 
-// TestCompositeMultipleDrawsE2E exercises the basic composite use case: a
-// function that draws several values and combines them. Verifies both that
-// generation actually runs and that drawn values stay within their declared
-// bounds.
-func TestCompositeMultipleDrawsE2E(t *testing.T) {
+// TestCompositeDrawsSubGenerators verifies that a Composite generator correctly
+// draws values from its sub-generators and combines them.
+func TestCompositeDrawsSubGenerators(t *testing.T) {
 	t.Parallel()
-
-	type point struct{ x, y int }
-	pointGen := Composite("point", func(tc *TestCase) point {
+	type point struct {
+		x int
+		y int
+	}
+	gen := Composite(func(s *TestCase) point {
 		return point{
-			x: Draw(tc, Integers[int](-100, 100)),
-			y: Draw(tc, Integers[int](-100, 100)),
+			x: Draw(s, Integers[int](0, 100)),
+			y: Draw(s, Integers[int](-100, 0)),
 		}
 	})
-
-	cases := 0
-	if err := Run(func(s *TestCase) {
-		p := pointGen.(*compositeGenerator[point]).draw(s)
-		cases++
-		if p.x < -100 || p.x > 100 || p.y < -100 || p.y > 100 {
-			t.Errorf("point %+v out of bounds", p)
+	Test(t, func(ht *T) {
+		p := Draw(ht, gen)
+		if p.x < 0 || p.x > 100 {
+			ht.Fatalf("x=%d out of range [0,100]", p.x)
 		}
-	}, WithTestCases(50)); err != nil {
-		t.Fatalf("Run failed: %v", err)
+		if p.y < -100 || p.y > 0 {
+			ht.Fatalf("y=%d out of range [-100,0]", p.y)
+		}
+	}, WithTestCases(30))
+}
+
+// TestCompositeNestedInLists verifies that a Composite generator works when
+// used as the element generator for Lists — exercising the compositional draw
+// path through the collection protocol.
+func TestCompositeNestedInLists(t *testing.T) {
+	t.Parallel()
+	type pair struct {
+		a int
+		b int
 	}
-	if cases == 0 {
-		t.Fatal("Composite: no test cases ran")
-	}
+	pairGen := Composite(func(s *TestCase) pair {
+		return pair{
+			a: Draw(s, Integers[int](0, 10)),
+			b: Draw(s, Integers[int](0, 10)),
+		}
+	})
+	listGen := Lists(pairGen).MaxSize(5)
+	Test(t, func(ht *T) {
+		ps := Draw(ht, listGen)
+		if len(ps) > 5 {
+			ht.Fatalf("len=%d > 5", len(ps))
+		}
+		for _, p := range ps {
+			if p.a < 0 || p.a > 10 || p.b < 0 || p.b > 10 {
+				ht.Fatalf("pair out of range: %+v", p)
+			}
+		}
+	}, WithTestCases(30))
+}
+
+// TestCompositeUsesAssume verifies that Assume works inside a composite
+// generator body — exercising the same TestCase methods test bodies use.
+func TestCompositeUsesAssume(t *testing.T) {
+	t.Parallel()
+	gen := Composite(func(s *TestCase) int {
+		v := Draw(s, Integers[int](0, 100))
+		s.Assume(v%2 == 0)
+		return v
+	})
+	Test(t, func(ht *T) {
+		v := Draw(ht, gen)
+		if v%2 != 0 {
+			ht.Fatalf("expected even, got %d", v)
+		}
+	}, WithTestCases(30))
 }
 
 // TestCompositeDataDependentDrawsE2E exercises the use case Composite exists
 // for: the number of draws depends on a previously drawn value. This is the
-// pattern that FlatMap cascades cannot express cleanly. It mirrors the proto-
-// generator shape in resource-manager: pick a field count, then draw that many
-// fields.
+// pattern that FlatMap cascades cannot express cleanly.
 func TestCompositeDataDependentDrawsE2E(t *testing.T) {
 	t.Parallel()
 
-	listGen := Composite("variable_list", func(tc *TestCase) []int {
+	listGen := Composite(func(tc *TestCase) []int {
 		n := Draw(tc, Integers[int](0, 10))
 		out := make([]int, n)
 		for i := range n {
@@ -133,7 +182,7 @@ func TestCompositeRecursiveE2E(t *testing.T) {
 	type pair struct {
 		a, b int
 	}
-	pairGen := Composite("pair", func(tc *TestCase) pair {
+	pairGen := Composite(func(tc *TestCase) pair {
 		return pair{
 			a: Draw(tc, Integers[int](0, 10)),
 			b: Draw(tc, Integers[int](0, 10)),
@@ -142,7 +191,7 @@ func TestCompositeRecursiveE2E(t *testing.T) {
 
 	// listOfPairs draws a length, then draws that many pairs — proving that
 	// pairGen can be composed inside another composite without restructuring.
-	listOfPairs := Composite("list_of_pairs", func(tc *TestCase) []pair {
+	listOfPairs := Composite(func(tc *TestCase) []pair {
 		n := Draw(tc, Integers[int](0, 5))
 		out := make([]pair, n)
 		for i := range n {
@@ -168,18 +217,15 @@ func TestCompositeRecursiveE2E(t *testing.T) {
 	}
 }
 
-// TestCompositeShrinksToFailingCase verifies that the span machinery is wired
-// correctly: when a composite-generated value triggers a failure, the engine
-// shrinks toward a minimal failing input. Without start_span/stop_span around
-// the composite body, shrinking would treat the draws as unrelated and
-// produce garbage minimal cases.
+// TestCompositeShrinksToFailingCase verifies that when a composite-generated
+// value triggers a failure, the engine shrinks toward a minimal failing input.
 func TestCompositeShrinksToFailingCase(t *testing.T) {
 	t.Parallel()
 
 	// Generator: a struct with two ints. Property under test: a + b < 100.
 	// Smallest counterexample: a=0, b=100 (or a=100, b=0).
 	type pair struct{ a, b int }
-	pairGen := Composite("pair", func(tc *TestCase) pair {
+	pairGen := Composite(func(tc *TestCase) pair {
 		return pair{
 			a: Draw(tc, Integers[int](0, 1000)),
 			b: Draw(tc, Integers[int](0, 1000)),
@@ -195,13 +241,13 @@ func TestCompositeShrinksToFailingCase(t *testing.T) {
 		}
 	}, WithTestCases(200))
 	if err == nil {
-		t.Skip("never found a failing case — try again or raise WithTestCases")
+		t.Fatal("never found a failing case")
 	}
 
-	// We don't assert exact equality (shrinking may land on any minimal pair),
-	// but the sum should be near the boundary, not arbitrarily large.
-	if minimalA+minimalB > 200 {
-		t.Errorf("shrinker did not minimize: got a=%d b=%d (sum=%d), expected sum near 100",
-			minimalA, minimalB, minimalA+minimalB)
+	// The shrinker minimizes left-to-right: it drives a to 0, then finds the
+	// smallest b satisfying a+b >= 100, which is 100.
+	if minimalA != 0 || minimalB != 100 {
+		t.Errorf("shrinker did not minimize: got a=%d b=%d, want a=0 b=100",
+			minimalA, minimalB)
 	}
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -1,0 +1,207 @@
+package hegel
+
+// composite_test.go tests the Composite function and compositeGenerator type.
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// Composite — return-type and asBasic checks
+// =============================================================================
+
+// TestCompositeReturnsCompositeGenerator verifies that Composite returns a
+// *compositeGenerator[T].
+func TestCompositeReturnsCompositeGenerator(t *testing.T) {
+	t.Parallel()
+	g := Composite("test", func(*TestCase) int { return 0 })
+	if _, ok := g.(*compositeGenerator[int]); !ok {
+		t.Fatalf("Composite should return *compositeGenerator[int], got %T", g)
+	}
+}
+
+// TestCompositeAsBasicAlwaysFalse verifies that a compositeGenerator never
+// reduces to a basic schema — its body is imperative and may issue an unbounded
+// number of draws.
+func TestCompositeAsBasicAlwaysFalse(t *testing.T) {
+	t.Parallel()
+	g := Composite("test", func(*TestCase) int { return 0 })
+	bg, ok, err := g.(*compositeGenerator[int]).asBasic()
+	if bg != nil || ok || err != nil {
+		t.Fatalf("Composite.asBasic should return (nil, false, nil); got (%v, %v, %v)", bg, ok, err)
+	}
+}
+
+// TestCompositeNilFunctionPanics verifies that Composite panics when given a
+// nil function — silent acceptance would yield a generator that nil-panics on
+// first draw, far from the bug site.
+func TestCompositeNilFunctionPanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Composite(nil) should panic")
+		}
+	}()
+	_ = Composite[int]("x", nil)
+}
+
+// =============================================================================
+// Composite — end-to-end via Run, against the real hegel-core server
+// =============================================================================
+
+// TestCompositeMultipleDrawsE2E exercises the basic composite use case: a
+// function that draws several values and combines them. Verifies both that
+// generation actually runs and that drawn values stay within their declared
+// bounds.
+func TestCompositeMultipleDrawsE2E(t *testing.T) {
+	t.Parallel()
+
+	type point struct{ x, y int }
+	pointGen := Composite("point", func(tc *TestCase) point {
+		return point{
+			x: Draw(tc, Integers[int](-100, 100)),
+			y: Draw(tc, Integers[int](-100, 100)),
+		}
+	})
+
+	cases := 0
+	if err := Run(func(s *TestCase) {
+		p := pointGen.(*compositeGenerator[point]).draw(s)
+		cases++
+		if p.x < -100 || p.x > 100 || p.y < -100 || p.y > 100 {
+			t.Errorf("point %+v out of bounds", p)
+		}
+	}, WithTestCases(50)); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if cases == 0 {
+		t.Fatal("Composite: no test cases ran")
+	}
+}
+
+// TestCompositeDataDependentDrawsE2E exercises the use case Composite exists
+// for: the number of draws depends on a previously drawn value. This is the
+// pattern that FlatMap cascades cannot express cleanly. It mirrors the proto-
+// generator shape in resource-manager: pick a field count, then draw that many
+// fields.
+func TestCompositeDataDependentDrawsE2E(t *testing.T) {
+	t.Parallel()
+
+	listGen := Composite("variable_list", func(tc *TestCase) []int {
+		n := Draw(tc, Integers[int](0, 10))
+		out := make([]int, n)
+		for i := range n {
+			out[i] = Draw(tc, Integers[int](0, 1000))
+		}
+		return out
+	})
+
+	sawEmpty := false
+	sawNonEmpty := false
+	if err := Run(func(s *TestCase) {
+		v := listGen.(*compositeGenerator[[]int]).draw(s)
+		if len(v) > 10 {
+			t.Errorf("length %d exceeds bound", len(v))
+		}
+		if len(v) == 0 {
+			sawEmpty = true
+		} else {
+			sawNonEmpty = true
+		}
+		for _, x := range v {
+			if x < 0 || x > 1000 {
+				t.Errorf("element %d out of bounds", x)
+			}
+		}
+	}, WithTestCases(100)); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !sawEmpty {
+		t.Error("Composite: never generated an empty list across 100 cases")
+	}
+	if !sawNonEmpty {
+		t.Error("Composite: never generated a non-empty list across 100 cases")
+	}
+}
+
+// TestCompositeRecursiveE2E verifies that a composite generator can be a
+// reusable value composed with itself — proves the "generator-as-value"
+// abstraction this PoC was built to restore.
+func TestCompositeRecursiveE2E(t *testing.T) {
+	t.Parallel()
+
+	type pair struct {
+		a, b int
+	}
+	pairGen := Composite("pair", func(tc *TestCase) pair {
+		return pair{
+			a: Draw(tc, Integers[int](0, 10)),
+			b: Draw(tc, Integers[int](0, 10)),
+		}
+	})
+
+	// listOfPairs draws a length, then draws that many pairs — proving that
+	// pairGen can be composed inside another composite without restructuring.
+	listOfPairs := Composite("list_of_pairs", func(tc *TestCase) []pair {
+		n := Draw(tc, Integers[int](0, 5))
+		out := make([]pair, n)
+		for i := range n {
+			out[i] = Draw(tc, pairGen)
+		}
+		return out
+	})
+
+	cases := 0
+	if err := Run(func(s *TestCase) {
+		v := listOfPairs.(*compositeGenerator[[]pair]).draw(s)
+		cases++
+		for _, p := range v {
+			if p.a < 0 || p.a > 10 || p.b < 0 || p.b > 10 {
+				t.Errorf("pair %+v out of bounds", p)
+			}
+		}
+	}, WithTestCases(50)); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if cases == 0 {
+		t.Fatal("Composite: no test cases ran")
+	}
+}
+
+// TestCompositeShrinksToFailingCase verifies that the span machinery is wired
+// correctly: when a composite-generated value triggers a failure, the engine
+// shrinks toward a minimal failing input. Without start_span/stop_span around
+// the composite body, shrinking would treat the draws as unrelated and
+// produce garbage minimal cases.
+func TestCompositeShrinksToFailingCase(t *testing.T) {
+	t.Parallel()
+
+	// Generator: a struct with two ints. Property under test: a + b < 100.
+	// Smallest counterexample: a=0, b=100 (or a=100, b=0).
+	type pair struct{ a, b int }
+	pairGen := Composite("pair", func(tc *TestCase) pair {
+		return pair{
+			a: Draw(tc, Integers[int](0, 1000)),
+			b: Draw(tc, Integers[int](0, 1000)),
+		}
+	})
+
+	var minimalA, minimalB int
+	err := Run(func(s *TestCase) {
+		p := pairGen.(*compositeGenerator[pair]).draw(s)
+		if p.a+p.b >= 100 {
+			minimalA, minimalB = p.a, p.b
+			panic(fatalSentinel{msg: "property violated"})
+		}
+	}, WithTestCases(200))
+	if err == nil {
+		t.Skip("never found a failing case — try again or raise WithTestCases")
+	}
+
+	// We don't assert exact equality (shrinking may land on any minimal pair),
+	// but the sum should be near the boundary, not arbitrarily large.
+	if minimalA+minimalB > 200 {
+		t.Errorf("shrinker did not minimize: got a=%d b=%d (sum=%d), expected sum near 100",
+			minimalA, minimalB, minimalA+minimalB)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -156,3 +156,83 @@ func ExampleTest_target() {
 		}
 	}, hegel.WithTestCases(1000))
 }
+
+func ExampleComposite() {
+	type person struct {
+		Name string
+		Age  int
+	}
+
+	personGen := hegel.Composite("person", func(tc *hegel.TestCase) person {
+		return person{
+			Name: hegel.Draw(tc, hegel.Text().MinSize(1).MaxSize(50)),
+			Age:  hegel.Draw(tc, hegel.Integers(0, 120)),
+		}
+	})
+
+	t := &testing.T{}
+	hegel.Test(t, func(ht *hegel.T) {
+		p := hegel.Draw(ht, personGen)
+		if p.Age < 0 || p.Age > 120 {
+			ht.Fatalf("age out of range: %d", p.Age)
+		}
+	})
+}
+
+func ExampleComposite_dataDependentDrawCount() {
+	// The number of element draws depends on n, drawn moments earlier.
+	// FlatMap can express this for fixed depth; Composite scales to
+	// arbitrary, schema-driven shapes.
+	variableList := hegel.Composite("variable_list", func(tc *hegel.TestCase) []int {
+		n := hegel.Draw(tc, hegel.Integers(0, 10))
+		out := make([]int, n)
+		for i := range n {
+			out[i] = hegel.Draw(tc, hegel.Integers(0, 1000))
+		}
+		return out
+	})
+
+	t := &testing.T{}
+	hegel.Test(t, func(ht *hegel.T) {
+		v := hegel.Draw(ht, variableList)
+		if len(v) > 10 {
+			ht.Fatalf("length %d exceeds bound", len(v))
+		}
+	})
+}
+
+func ExampleComposite_recursive() {
+	// A binary tree generator that references itself: each node may contain
+	// subtrees produced by the same generator. The forward declaration lets
+	// the closure capture nodeGen before it's assigned.
+	//
+	// Recursion is explicitly bounded by a depth counter held in the closure
+	// — incremented before each recursive Draw and decremented after, so it
+	// tracks the live recursion stack. This is the safest pattern; an
+	// unbounded variant relying purely on Hegel's per-test-case data budget
+	// is possible but harder to reason about.
+	type Node struct {
+		Value int
+		Left  *Node
+		Right *Node
+	}
+
+	const maxDepth = 5
+	depth := 0
+	var nodeGen hegel.Generator[*Node]
+	nodeGen = hegel.Composite("node", func(tc *hegel.TestCase) *Node {
+		n := &Node{Value: hegel.Draw(tc, hegel.Integers(0, 100))}
+		if depth < maxDepth && hegel.Draw(tc, hegel.Booleans()) {
+			depth++
+			n.Left = hegel.Draw(tc, nodeGen)
+			n.Right = hegel.Draw(tc, nodeGen)
+			depth--
+		}
+		return n
+	})
+
+	t := &testing.T{}
+	hegel.Test(t, func(ht *hegel.T) {
+		_ = hegel.Draw(ht, nodeGen)
+	})
+}

--- a/example_test.go
+++ b/example_test.go
@@ -163,9 +163,9 @@ func ExampleComposite() {
 		Age  int
 	}
 
-	personGen := hegel.Composite("person", func(tc *hegel.TestCase) person {
+	personGen := hegel.Composite(func(tc *hegel.TestCase) person {
 		return person{
-			Name: hegel.Draw(tc, hegel.Text().MinSize(1).MaxSize(50)),
+			Name: hegel.Draw(tc, hegel.Text()),
 			Age:  hegel.Draw(tc, hegel.Integers(0, 120)),
 		}
 	})
@@ -180,10 +180,7 @@ func ExampleComposite() {
 }
 
 func ExampleComposite_dataDependentDrawCount() {
-	// The number of element draws depends on n, drawn moments earlier.
-	// FlatMap can express this for fixed depth; Composite scales to
-	// arbitrary, schema-driven shapes.
-	variableList := hegel.Composite("variable_list", func(tc *hegel.TestCase) []int {
+	variableList := hegel.Composite(func(tc *hegel.TestCase) []int {
 		n := hegel.Draw(tc, hegel.Integers(0, 10))
 		out := make([]int, n)
 		for i := range n {
@@ -220,7 +217,7 @@ func ExampleComposite_recursive() {
 	const maxDepth = 5
 	depth := 0
 	var nodeGen hegel.Generator[*Node]
-	nodeGen = hegel.Composite("node", func(tc *hegel.TestCase) *Node {
+	nodeGen = hegel.Composite(func(tc *hegel.TestCase) *Node {
 		n := &Node{Value: hegel.Draw(tc, hegel.Integers(0, 100))}
 		if depth < maxDepth && hegel.Draw(tc, hegel.Booleans()) {
 			depth++


### PR DESCRIPTION
I wasn't sure if composite is making a return in Hegel, so I hacked one myself (with a bit of Claude steering). Feel free to close if you have other plans, I just thought it would be easier to communicate intent with code


This is an equivalent of hypothesis' @composite strategy or rapid.Custom (with similar semantics).

I came across this when evaluating if I could port my existing go PBT stack to hegel - main challenge I observed was the lack of a composite strat. In our use case we construct generators that produce protobuf messages matching a schema and apply some CEL expressions to these.

It requires a fairly dynamic setup because the process goes as follows:

1. user imports our testing library and supplies two schemas and some CEL expressions
2. we evaluate these expressions on rapid generated proto objects and assert that the expression satisfies some predefined properties that we want to enforce on those programs (similar to encode(decode(in)) = in and decode(encode(out)) = out)

This pattern generalizes to other cases in more high level terms which I'm certain you know better than me, but for sake of documentation:

1. draw `n` then draw `n` things
2. draw a discriminator and draw fields depending on value of that (e.g. drawing instances for protobuf `oneof`)
3. all other cases of iterative sequential generation

A few notes on the implementation:

- no protocol changes - it's all built on the existing start_span / stop_span / generate commands and works against an unmodified hegel-core 0.5.0
- the span label is a single fixed int (labelComposite = 16) so the shrinker treats every composite uniformly, and the user-supplied string label rides along via TestCase.Note for readable replay output - dodges having to extend the int-label scheme
- asBasic always returns (nil, false, nil) since composites are imperative by definition