### PR TITLE
claude: add WithSeed option to pin a fixed seed for property tests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,7 +61,7 @@ The user-facing surface lives in `hegel.go` (canonical package doc). Entry point
 - `hegel.T` — passed to the [Test] body; methods include `Note`, `Fatal`, `Fatalf`
 - Generators: `Integers`, `Floats`, `Text`, `Booleans`, `Lists`, `Maps`, ...
 - Options: `WithTestCases(n)`, `WithDatabase(Database(path))`,
-  `WithDatabase(DatabaseDisabled())`, `WithDerandomize(bool)`,
+  `WithDatabase(DatabaseDisabled())`, `WithDerandomize(bool)`, `WithSeed(n)`,
   `SuppressHealthCheck(...)`
 - Low-level: the unexported `runHegel` is what `Test`, `Run`, and `MustRun`
   delegate to; useful in error-injection tests via direct call

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: just lint
       - name: Install zizmor
-        run: pip install zizmor
+        run: pip install zizmor==1.23.1
       - name: Run zizmor
         run: zizmor --format plain .github/
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+Add `WithSeed(seed int64)` option to pin a fixed seed for property test
+runs, analogous to Hypothesis's `@seed(N)`. When both `WithSeed` and
+`WithDerandomize` are set, `WithSeed` takes precedence (matching
+Hypothesis).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-Add `WithSeed(seed int64)` option to pin a fixed seed for property test
-runs, analogous to Hypothesis's `@seed(N)`. When both `WithSeed` and
-`WithDerandomize` are set, `WithSeed` takes precedence (matching
-Hypothesis).
+Add a `WithSeed(seed int64)` option to set a fixed seed for a test:
+
+```go
+hegel.Test(t, func(ht *hegel.T) {
+    ...
+}, hegel.WithSeed(42))

--- a/example_test.go
+++ b/example_test.go
@@ -53,6 +53,13 @@ func ExampleTest_withDerandomize() {
 	}, hegel.WithDerandomize(true))
 }
 
+func ExampleTest_withSeed() {
+	t := &testing.T{}
+	hegel.Test(t, func(ht *hegel.T) {
+		_ = hegel.Draw(ht, hegel.Integers(0, 100))
+	}, hegel.WithSeed(42))
+}
+
 func ExampleDraw() {
 	t := &testing.T{}
 	hegel.Test(t, func(ht *hegel.T) {

--- a/runner.go
+++ b/runner.go
@@ -305,15 +305,7 @@ func WithDerandomize(derandomize bool) Option {
 	return func(o *runOptions) { o.derandomize = derandomize }
 }
 
-// WithSeed sets a fixed seed for the test. The seed pins the generator's RNG;
-// for fully reproducible runs you also want to disable the example database
-// (via [WithDatabase] with [DatabaseDisabled]), since its replay phases can
-// inject saved examples that are not derived from the seed.
-//
-// If unset, the server picks a seed (deterministic when WithDerandomize is
-// true, random otherwise). When both WithSeed and WithDerandomize are
-// provided, WithSeed takes precedence — this matches Hypothesis's
-// @seed semantics.
+// WithSeed sets a fixed random seed for the test, making it deterministic.
 func WithSeed(seed int64) Option {
 	return func(o *runOptions) { o.seed = &seed }
 }

--- a/runner.go
+++ b/runner.go
@@ -268,6 +268,7 @@ type runOptions struct {
 	suppressHealthCheck []HealthCheck
 	database            DatabaseSetting
 	derandomize         bool
+	seed                *int64
 	// databaseKey identifies the test for example-database lookups. Set by
 	// [Test] from t.Name(); nil for [Run]/[MustRun] (no test name available).
 	databaseKey []byte
@@ -302,6 +303,19 @@ func WithDatabase(db DatabaseSetting) Option {
 // WithDerandomize sets whether to use a fixed seed for reproducible runs.
 func WithDerandomize(derandomize bool) Option {
 	return func(o *runOptions) { o.derandomize = derandomize }
+}
+
+// WithSeed sets a fixed seed for the test. The seed pins the generator's RNG;
+// for fully reproducible runs you also want to disable the example database
+// (via [WithDatabase] with [DatabaseDisabled]), since its replay phases can
+// inject saved examples that are not derived from the seed.
+//
+// If unset, the server picks a seed (deterministic when WithDerandomize is
+// true, random otherwise). When both WithSeed and WithDerandomize are
+// provided, WithSeed takes precedence — this matches Hypothesis's
+// @seed semantics.
+func WithSeed(seed int64) Option {
+	return func(o *runOptions) { o.seed = &seed }
 }
 
 // withDatabaseKey sets the example-database key. Unexported: only [Test]
@@ -465,6 +479,9 @@ func buildRunTestMessage(streamID uint32, opts runOptions) map[string]any {
 		"test_cases":  int64(opts.testCases),
 		"stream_id":   int64(streamID),
 		"derandomize": opts.derandomize,
+	}
+	if opts.seed != nil {
+		msg["seed"] = *opts.seed
 	}
 	if opts.database.state == databaseDisabled || opts.databaseKey == nil {
 		msg["database_key"] = nil

--- a/runner_test.go
+++ b/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1245,6 +1246,35 @@ func TestBuildRunTestMessageBaseFields(t *testing.T) {
 	if msg["derandomize"] != true {
 		t.Errorf("derandomize = %v", msg["derandomize"])
 	}
+	// seed is omitted entirely when unset.
+	if _, ok := msg["seed"]; ok {
+		t.Errorf("seed should be absent when unset, got %v", msg["seed"])
+	}
+}
+
+func TestBuildRunTestMessageSeedSet(t *testing.T) {
+	t.Parallel()
+	seed := int64(42)
+	msg := buildRunTestMessage(1, runOptions{testCases: 1, seed: &seed})
+	v, ok := msg["seed"]
+	if !ok {
+		t.Fatal("expected seed field to be present")
+	}
+	if v != int64(42) {
+		t.Errorf("seed = %v, want 42", v)
+	}
+}
+
+func TestWithSeedOption(t *testing.T) {
+	t.Parallel()
+	var o runOptions
+	WithSeed(123)(&o)
+	if o.seed == nil {
+		t.Fatal("seed was not set")
+	}
+	if *o.seed != 123 {
+		t.Errorf("seed = %d, want 123", *o.seed)
+	}
 }
 
 func TestDatabaseDisabledSetting(t *testing.T) {
@@ -1291,6 +1321,31 @@ func TestWithDerandomizeIntegration(t *testing.T) {
 	Test(t, func(ht *T) {
 		_ = Draw[bool](ht, Booleans())
 	}, WithDerandomize(true), WithTestCases(3))
+}
+
+// TestWithSeedIntegration verifies that the same seed produces the same
+// sequence of drawn values across two runs.
+//
+// The example database is disabled so the test asserts seed-only determinism;
+// otherwise the database's replay phases could prepend saved examples that
+// are not derived from the seed.
+func TestWithSeedIntegration(t *testing.T) {
+	clearCIEnv(t)
+	run := func() []int {
+		var drawn []int
+		Test(t, func(ht *T) {
+			drawn = append(drawn, Draw[int](ht, Integers[int](0, 1_000_000)))
+		}, WithSeed(42), WithDatabase(DatabaseDisabled()), WithTestCases(20))
+		return drawn
+	}
+	first := run()
+	second := run()
+	if len(first) == 0 {
+		t.Fatal("no values drawn")
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("WithSeed(42) was not deterministic:\n  first  = %v\n  second = %v", first, second)
+	}
 }
 
 // --- helpers ---


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Adds a `WithSeed(int64)` option that lets users pin a fixed seed for
property test runs, mirroring Hypothesis's `@seed(N)`. This brings
hegel-go to parity with hegel-rust / hegel-cpp / hegel-typescript /
hegel-ocaml, which already expose an equivalent.

- `seed` is stored as `*int64` on `runOptions` so absence is distinguishable
  from a zero seed.
- The field is omitted from the `run_test` payload when unset; the server
  uses `.get("seed")`, so missing is treated as None.
- `WithSeed` and `WithDerandomize` remain independent; the server already
  prefers `seed` over `derandomize`, matching Hypothesis. The doc-comment
  notes the precedence and also recommends pairing with
  `WithDatabase(DatabaseDisabled())` for fully reproducible runs (the
  example database's replay phases can otherwise inject non-seed inputs).
- Type is `int64` — matches Go stdlib `math/rand.NewSource(seed int64)`.
  Rust/C++ use `u64`/`uint64_t`, but signedness doesn't matter on the wire
  since the server stringifies the value.

Tests cover the unset/set wire format, the option setter, and an integration
test that runs the same `Test` body twice with `WithSeed(42)` and asserts
the sequences of drawn values match. `just check` passes (100% coverage).

</details>
