### PR TITLE
make TestCase an interface, demote the implementation to testCase

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release changes `hegel.TestCase` from a struct to an interface. Code that previously named the type as `*hegel.TestCase` should now use `hegel.TestCase`:
+
+```go
+// before
+personGen := hegel.Composite(func(tc *hegel.TestCase) Person { ... })
+
+// after
+personGen := hegel.Composite(func(tc hegel.TestCase) Person { ... })
+```

--- a/collections.go
+++ b/collections.go
@@ -81,27 +81,27 @@ func (g ListGenerator[T]) asBasic() (*basicGenerator[[]T], bool, error) {
 
 // draw produces a list by dispatching to the basic schema when possible,
 // falling back to the collection protocol otherwise.
-func (g ListGenerator[T]) draw(s *TestCase) ([]T, error) {
+func (g ListGenerator[T]) draw(tc TestCase) ([]T, error) {
 	bg, ok, err := g.asBasic()
 	if err != nil {
 		return nil, err
 	}
 	if ok {
-		return bg.draw(s)
+		return bg.draw(tc)
 	}
 	var maxSize *int
 	if g.hasMax {
 		m := g.maxSize
 		maxSize = &m
 	}
-	return withSpan(s, labelList, func() ([]T, error) {
+	return withSpan(tc, labelList, func() ([]T, error) {
 		var result []T
-		coll, err := newCollection(s, g.minSize, maxSize)
+		coll, err := newCollection(tc, g.minSize, maxSize)
 		if err != nil {
 			return nil, err
 		}
-		for coll.More(s) {
-			v, err := g.elements.draw(s)
+		for coll.More(tc) {
+			v, err := g.elements.draw(tc)
 			if err != nil {
 				return nil, err
 			}
@@ -192,35 +192,35 @@ func (g MapGenerator[K, V]) asBasic() (*basicGenerator[map[K]V], bool, error) {
 
 // draw produces a map by dispatching to the basic schema when possible,
 // falling back to the collection protocol otherwise.
-func (g MapGenerator[K, V]) draw(s *TestCase) (map[K]V, error) {
+func (g MapGenerator[K, V]) draw(tc TestCase) (map[K]V, error) {
 	bg, ok, err := g.asBasic()
 	if err != nil {
 		return nil, err
 	}
 	if ok {
-		return bg.draw(s)
+		return bg.draw(tc)
 	}
 	var maxSize *int
 	if g.hasMax {
 		m := g.maxSize
 		maxSize = &m
 	}
-	return withSpan(s, labelMap, func() (map[K]V, error) {
+	return withSpan(tc, labelMap, func() (map[K]V, error) {
 		result := map[K]V{}
-		coll, err := newCollection(s, g.minSize, maxSize)
+		coll, err := newCollection(tc, g.minSize, maxSize)
 		if err != nil {
 			return nil, err
 		}
-		for coll.More(s) {
-			k, err := g.keys.draw(s)
+		for coll.More(tc) {
+			k, err := g.keys.draw(tc)
 			if err != nil {
 				return nil, err
 			}
 			if _, exists := result[k]; exists {
-				coll.Reject(s)
+				coll.Reject(tc)
 				continue
 			}
-			v, err := g.values.draw(s)
+			v, err := g.values.draw(tc)
 			if err != nil {
 				return nil, err
 			}

--- a/combinators.go
+++ b/combinators.go
@@ -49,18 +49,18 @@ func (g *oneOfGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 
 // draw produces a value by dispatching to the basic schema when possible,
 // falling back to a server-side index draw otherwise.
-func (g *oneOfGenerator[T]) draw(s *TestCase) (T, error) {
+func (g *oneOfGenerator[T]) draw(tc TestCase) (T, error) {
 	var zero T
 	bg, ok, err := g.asBasic()
 	if err != nil {
 		return zero, err
 	}
 	if ok {
-		return bg.draw(s)
+		return bg.draw(tc)
 	}
-	return withSpan(s, labelOneOf, func() (T, error) {
+	return withSpan(tc, labelOneOf, func() (T, error) {
 		n := len(g.generators)
-		idx, err := s.generateFromSchema(map[string]any{
+		idx, err := tc.generateFromSchema(map[string]any{
 			"type":      "integer",
 			"min_value": int64(0),
 			"max_value": int64(n - 1),
@@ -68,7 +68,7 @@ func (g *oneOfGenerator[T]) draw(s *TestCase) (T, error) {
 		if err != nil { // coverage-ignore
 			return zero, err
 		}
-		return g.generators[extractInt(idx)].draw(s)
+		return g.generators[extractInt(idx)].draw(tc)
 	})
 }
 
@@ -134,16 +134,16 @@ func (g *optionalGenerator[T]) asBasic() (*basicGenerator[*T], bool, error) {
 
 // draw generates either nil or a value by dispatching to the basic schema
 // when inner is basic, falling back to a server-side index draw otherwise.
-func (g *optionalGenerator[T]) draw(s *TestCase) (*T, error) {
+func (g *optionalGenerator[T]) draw(tc TestCase) (*T, error) {
 	bg, ok, err := g.asBasic()
 	if err != nil {
 		return nil, err
 	}
 	if ok {
-		return bg.draw(s)
+		return bg.draw(tc)
 	}
-	return withSpan(s, labelOneOf, func() (*T, error) {
-		idx, err := s.generateFromSchema(map[string]any{
+	return withSpan(tc, labelOneOf, func() (*T, error) {
+		idx, err := tc.generateFromSchema(map[string]any{
 			"type":      "integer",
 			"min_value": int64(0),
 			"max_value": int64(1),
@@ -154,7 +154,7 @@ func (g *optionalGenerator[T]) draw(s *TestCase) (*T, error) {
 		if extractInt(idx) == 0 {
 			return nil, nil
 		}
-		v, err := g.inner.draw(s)
+		v, err := g.inner.draw(tc)
 		if err != nil {
 			return nil, err
 		}
@@ -216,10 +216,10 @@ func (g IPAddressGenerator) asBasic() (*basicGenerator[netip.Addr], bool, error)
 }
 
 // draw produces an IP address by dispatching to the basic schema returned by asBasic.
-func (g IPAddressGenerator) draw(s *TestCase) (netip.Addr, error) {
+func (g IPAddressGenerator) draw(tc TestCase) (netip.Addr, error) {
 	bg, _, err := g.asBasic()
 	if err != nil { // coverage-ignore
 		return netip.Addr{}, err
 	}
-	return bg.draw(s)
+	return bg.draw(tc)
 }

--- a/composite.go
+++ b/composite.go
@@ -4,10 +4,10 @@ package hegel
 // composes other generators via [Draw]. It has no schema and always falls
 // back to compositional generation.
 type compositeGenerator[T any] struct {
-	fn func(*TestCase) T
+	fn func(TestCase) T
 }
 
-// draw invokes the composed function with the given TestCase.
+// draw invokes the composed function with the given test case.
 //
 // The user fn calls [Draw], which panics at the exported boundary with the
 // sentinel error types. Those panics propagate up to the runner's recover,
@@ -18,8 +18,8 @@ type compositeGenerator[T any] struct {
 // point at the user's code rather than this defer site.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
-func (g *compositeGenerator[T]) draw(s *TestCase) (T, error) {
-	return g.fn(s), nil
+func (g *compositeGenerator[T]) draw(tc TestCase) (T, error) {
+	return g.fn(tc), nil
 }
 
 // asBasic always returns not-basic — composite generators have no schema.
@@ -34,8 +34,6 @@ func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 // Inside fn, call [Draw] on other generators to assemble the value. The
 // function may call Draw any number of times.
 //
-// The function receives the same *TestCase that test bodies receive.
-//
 // Example: a generator for a Person whose driving license field only appears
 // when age >= 18.
 //
@@ -45,7 +43,7 @@ func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 //	    DrivingLicense bool
 //	}
 //
-//	personGen := hegel.Composite(func(tc *hegel.TestCase) Person {
+//	personGen := hegel.Composite(func(tc hegel.TestCase) Person {
 //	    age := hegel.Draw(tc, hegel.Integers(0, 120))
 //	    name := hegel.Draw(tc, hegel.Text())
 //	    p := Person{Age: age, Name: name}
@@ -59,6 +57,6 @@ func (g *compositeGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 //	    p := hegel.Draw(ht, personGen)
 //	    // assert properties of p
 //	})
-func Composite[T any](fn func(*TestCase) T) Generator[T] {
+func Composite[T any](fn func(TestCase) T) Generator[T] {
 	return &compositeGenerator[T]{fn: fn}
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -15,7 +15,7 @@ import (
 // *compositeGenerator.
 func TestCompositeReturnsCompositeGenerator(t *testing.T) {
 	t.Parallel()
-	gen := Composite(func(s *TestCase) int {
+	gen := Composite(func(s TestCase) int {
 		return Draw(s, Integers[int](0, 10))
 	})
 	if _, ok := gen.(*compositeGenerator[int]); !ok {
@@ -27,7 +27,7 @@ func TestCompositeReturnsCompositeGenerator(t *testing.T) {
 // is never basic — composite generators have no schema.
 func TestCompositeGeneratorAsBasicReturnsNotBasic(t *testing.T) {
 	t.Parallel()
-	gen := Composite(func(s *TestCase) int {
+	gen := Composite(func(s TestCase) int {
 		return Draw(s, Integers[int](0, 10))
 	})
 	bg, ok, err := gen.(*compositeGenerator[int]).asBasic()
@@ -46,7 +46,7 @@ func TestCompositeGeneratorAsBasicReturnsNotBasic(t *testing.T) {
 // composite generator returns a *mappedGenerator (the non-basic path).
 func TestCompositeGeneratorMapReturnsMappedGenerator(t *testing.T) {
 	t.Parallel()
-	gen := Composite(func(s *TestCase) int {
+	gen := Composite(func(s TestCase) int {
 		return Draw(s, Integers[int](0, 10))
 	})
 	mapped := Map(gen, func(v int) string { return fmt.Sprintf("%d", v) })
@@ -67,7 +67,7 @@ func TestCompositeDrawsSubGenerators(t *testing.T) {
 		x int
 		y int
 	}
-	gen := Composite(func(s *TestCase) point {
+	gen := Composite(func(s TestCase) point {
 		return point{
 			x: Draw(s, Integers[int](0, 100)),
 			y: Draw(s, Integers[int](-100, 0)),
@@ -93,7 +93,7 @@ func TestCompositeNestedInLists(t *testing.T) {
 		a int
 		b int
 	}
-	pairGen := Composite(func(s *TestCase) pair {
+	pairGen := Composite(func(s TestCase) pair {
 		return pair{
 			a: Draw(s, Integers[int](0, 10)),
 			b: Draw(s, Integers[int](0, 10)),
@@ -114,10 +114,10 @@ func TestCompositeNestedInLists(t *testing.T) {
 }
 
 // TestCompositeUsesAssume verifies that Assume works inside a composite
-// generator body — exercising the same TestCase methods test bodies use.
+// generator body — exercising the same testCase methods test bodies use.
 func TestCompositeUsesAssume(t *testing.T) {
 	t.Parallel()
-	gen := Composite(func(s *TestCase) int {
+	gen := Composite(func(s TestCase) int {
 		v := Draw(s, Integers[int](0, 100))
 		s.Assume(v%2 == 0)
 		return v
@@ -136,7 +136,7 @@ func TestCompositeUsesAssume(t *testing.T) {
 func TestCompositeDataDependentDrawsE2E(t *testing.T) {
 	t.Parallel()
 
-	listGen := Composite(func(tc *TestCase) []int {
+	listGen := Composite(func(tc TestCase) []int {
 		n := Draw(tc, Integers[int](0, 10))
 		out := make([]int, n)
 		for i := range n {
@@ -147,7 +147,7 @@ func TestCompositeDataDependentDrawsE2E(t *testing.T) {
 
 	sawEmpty := false
 	sawNonEmpty := false
-	if err := Run(func(s *TestCase) {
+	if err := Run(func(s TestCase) {
 		v := Draw(s, listGen)
 		if len(v) > 10 {
 			t.Errorf("length %d exceeds bound", len(v))
@@ -182,7 +182,7 @@ func TestCompositeRecursiveE2E(t *testing.T) {
 	type pair struct {
 		a, b int
 	}
-	pairGen := Composite(func(tc *TestCase) pair {
+	pairGen := Composite(func(tc TestCase) pair {
 		return pair{
 			a: Draw(tc, Integers[int](0, 10)),
 			b: Draw(tc, Integers[int](0, 10)),
@@ -191,7 +191,7 @@ func TestCompositeRecursiveE2E(t *testing.T) {
 
 	// listOfPairs draws a length, then draws that many pairs — proving that
 	// pairGen can be composed inside another composite without restructuring.
-	listOfPairs := Composite(func(tc *TestCase) []pair {
+	listOfPairs := Composite(func(tc TestCase) []pair {
 		n := Draw(tc, Integers[int](0, 5))
 		out := make([]pair, n)
 		for i := range n {
@@ -201,7 +201,7 @@ func TestCompositeRecursiveE2E(t *testing.T) {
 	})
 
 	cases := 0
-	if err := Run(func(s *TestCase) {
+	if err := Run(func(s TestCase) {
 		v := Draw(s, listOfPairs)
 		cases++
 		for _, p := range v {
@@ -225,7 +225,7 @@ func TestCompositeShrinksToFailingCase(t *testing.T) {
 	// Generator: a struct with two ints. Property under test: a + b < 100.
 	// Smallest counterexample: a=0, b=100 (or a=100, b=0).
 	type pair struct{ a, b int }
-	pairGen := Composite(func(tc *TestCase) pair {
+	pairGen := Composite(func(tc TestCase) pair {
 		return pair{
 			a: Draw(tc, Integers[int](0, 1000)),
 			b: Draw(tc, Integers[int](0, 1000)),
@@ -233,7 +233,7 @@ func TestCompositeShrinksToFailingCase(t *testing.T) {
 	})
 
 	var minimalA, minimalB int
-	err := Run(func(s *TestCase) {
+	err := Run(func(s TestCase) {
 		p := Draw(s, pairGen)
 		if p.a+p.b >= 100 {
 			minimalA, minimalB = p.a, p.b

--- a/database_test.go
+++ b/database_test.go
@@ -38,7 +38,7 @@ func TestDatabasePersistsFailingExamples(t *testing.T) {
 		t.Fatal("expected empty database directory before the run")
 	}
 
-	err = runHegel(func(_ *TestCase) {
+	err = runHegel(func(_ TestCase) {
 		panic("")
 	}, stdoutNoteFn, []Option{
 		WithDatabase(Database(dbDir)),

--- a/example_stateful_test.go
+++ b/example_stateful_test.go
@@ -13,13 +13,13 @@ type stateCounter struct{ n int }
 func (c *stateCounter) reset() { c.n = 0 }
 
 // RuleIncrement bumps the counter up by one.
-func (c *stateCounter) RuleIncrement(_ *hegel.TestCase) { c.n++ }
+func (c *stateCounter) RuleIncrement(_ hegel.TestCase) { c.n++ }
 
 // RuleDecrement bumps the counter down by one.
-func (c *stateCounter) RuleDecrement(_ *hegel.TestCase) { c.n-- }
+func (c *stateCounter) RuleDecrement(_ hegel.TestCase) { c.n-- }
 
 // InvariantSensible panics if the counter has drifted out of range.
-func (c *stateCounter) InvariantSensible(_ *hegel.TestCase) {
+func (c *stateCounter) InvariantSensible(_ hegel.TestCase) {
 	if c.n < -10000 || c.n > 10000 {
 		panic("counter out of sensible range")
 	}
@@ -27,7 +27,7 @@ func (c *stateCounter) InvariantSensible(_ *hegel.TestCase) {
 
 func ExampleRunStateful() {
 	var c stateCounter
-	hegel.MustRun(func(tc *hegel.TestCase) {
+	hegel.MustRun(func(tc hegel.TestCase) {
 		// Reset model state before each case — in a real scenario this
 		// might flush a database or other shared store.
 		c.reset()

--- a/example_test.go
+++ b/example_test.go
@@ -163,7 +163,7 @@ func ExampleComposite() {
 		Age  int
 	}
 
-	personGen := hegel.Composite(func(tc *hegel.TestCase) person {
+	personGen := hegel.Composite(func(tc hegel.TestCase) person {
 		return person{
 			Name: hegel.Draw(tc, hegel.Text()),
 			Age:  hegel.Draw(tc, hegel.Integers(0, 120)),
@@ -180,7 +180,7 @@ func ExampleComposite() {
 }
 
 func ExampleComposite_dataDependentDrawCount() {
-	variableList := hegel.Composite(func(tc *hegel.TestCase) []int {
+	variableList := hegel.Composite(func(tc hegel.TestCase) []int {
 		n := hegel.Draw(tc, hegel.Integers(0, 10))
 		out := make([]int, n)
 		for i := range n {
@@ -217,7 +217,7 @@ func ExampleComposite_recursive() {
 	const maxDepth = 5
 	depth := 0
 	var nodeGen hegel.Generator[*Node]
-	nodeGen = hegel.Composite(func(tc *hegel.TestCase) *Node {
+	nodeGen = hegel.Composite(func(tc hegel.TestCase) *Node {
 		n := &Node{Value: hegel.Draw(tc, hegel.Integers(0, 100))}
 		if depth < maxDepth && hegel.Draw(tc, hegel.Booleans()) {
 			depth++
@@ -235,7 +235,7 @@ func ExampleComposite_recursive() {
 }
 
 func ExampleWorkload() {
-	hegel.Workload(func(tc *hegel.TestCase) {
+	hegel.Workload(func(tc hegel.TestCase) {
 		_ = hegel.Draw(tc, hegel.Integers(0, 100))
 	})
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -185,7 +185,7 @@ func TestFilteredGeneratorStartSpanConnectionError(t *testing.T) {
 	conn.streams[1] = st
 	s.Close()
 
-	state := &TestCase{stream: st}
+	state := &testCase{stream: st}
 	gen := Filter(Booleans(), func(bool) bool { return true })
 
 	var caught any

--- a/generators.go
+++ b/generators.go
@@ -48,13 +48,13 @@ const (
 //
 // It is a sealed interface — only types within this package can implement it.
 type Generator[T any] interface {
-	// draw produces a value from the Hegel server using the given state.
+	// draw produces a value from the Hegel server using the given test case.
 	// Unexported to seal the interface to this package.
 	//
 	// Returns the sentinel errors [*dataExhausted] / [flakyAbort] when the
 	// server aborts the test case, [*connectionError] for transport
 	// failures, and [assumeRejected] when a Filter exhausts its retries.
-	draw(s *TestCase) (T, error)
+	draw(tc TestCase) (T, error)
 
 	// asBasic returns the basic-schema form of this generator, when one exists.
 	// The three return values encode three distinct states:
@@ -66,8 +66,12 @@ type Generator[T any] interface {
 	asBasic() (*basicGenerator[T], bool, error)
 }
 
-// testCase is the test context for a Hegel property test.
-type testCase interface {
+// TestCase is the test context for a Hegel property test.
+//
+// It is passed to [Run] bodies and [Composite] callbacks directly, and is
+// embedded in the *[T] passed to [Test] bodies, so generator code written
+// against TestCase works under either entry point.
+type TestCase interface {
 	// Assume rejects the current test case if condition is false.
 	Assume(condition bool)
 
@@ -77,13 +81,32 @@ type testCase interface {
 	// Target sends a target value to guide test generation.
 	Target(value float64, label string)
 
-	// internal returns the underlying TestCase. Unexported to seal the interface.
-	internal() *TestCase
+	// Errorf logs the formatted message via Note and marks the test case as
+	// failed. The test case continues running but is treated as a failure
+	// after return.
+	Errorf(format string, args ...any)
+
+	// Fail marks the test case as failed without stopping it.
+	Fail()
+
+	// FailNow marks the test case as failed and stops the test body.
+	FailNow()
+
+	// Log routes the message through Note (only emitted on final replay).
+	Log(args ...any)
+
+	// doRequest sends a CBOR-encoded request to the server and returns the
+	// decoded reply. Unexported to seal the interface to this package.
+	doRequest(msg map[string]any) (any, error)
+
+	// generateFromSchema sends a generate command for schema and returns the
+	// decoded value. Unexported to seal the interface to this package.
+	generateFromSchema(schema map[string]any) (any, error)
 }
 
 // Draw produces a value from a Generator using the given State context.
-func Draw[T any](tc testCase, g Generator[T]) T {
-	v, err := g.draw(tc.internal())
+func Draw[T any](tc TestCase, g Generator[T]) T {
+	v, err := g.draw(tc)
 	if err != nil {
 		panic(err)
 	}
@@ -100,8 +123,8 @@ type basicGenerator[T any] struct {
 }
 
 // draw sends a generate command to the server and returns the result.
-func (g *basicGenerator[T]) draw(s *TestCase) (T, error) {
-	v, err := s.generateFromSchema(g.schema)
+func (g *basicGenerator[T]) draw(tc TestCase) (T, error) {
+	v, err := tc.generateFromSchema(g.schema)
 	if err != nil {
 		var zero T
 		return zero, err
@@ -128,10 +151,10 @@ type mappedGenerator[T, U any] struct {
 // draw calls the inner generator inside a MAPPED span and applies fn.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
-func (g *mappedGenerator[T, U]) draw(s *TestCase) (U, error) {
-	return withSpan(s, labelMapped, func() (U, error) {
+func (g *mappedGenerator[T, U]) draw(tc TestCase) (U, error) {
+	return withSpan(tc, labelMapped, func() (U, error) {
 		var zero U
-		v, err := g.inner.draw(s)
+		v, err := g.inner.draw(tc)
 		if err != nil {
 			return zero, err
 		}
@@ -164,23 +187,23 @@ const maxFilterAttempts = 3
 // draw tries up to maxFilterAttempts times to produce a value satisfying predicate.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
-func (g *filteredGenerator[T]) draw(s *TestCase) (T, error) {
+func (g *filteredGenerator[T]) draw(tc TestCase) (T, error) {
 	var zero T
 	for range maxFilterAttempts {
-		if err := startSpan(s, labelFilter); err != nil {
+		if err := startSpan(tc, labelFilter); err != nil {
 			return zero, err
 		}
-		value, err := g.source.draw(s)
+		value, err := g.source.draw(tc)
 		if err != nil {
 			return zero, err
 		}
 		if g.predicate(value) {
-			if err := stopSpan(s, false); err != nil { // coverage-ignore
+			if err := stopSpan(tc, false); err != nil { // coverage-ignore
 				return zero, err
 			}
 			return value, nil
 		}
-		if err := stopSpan(s, true); err != nil { // coverage-ignore
+		if err := stopSpan(tc, true); err != nil { // coverage-ignore
 			return zero, err
 		}
 	}
@@ -206,14 +229,14 @@ type flatMappedGenerator[T, U any] struct {
 // draw generates from source, then from the dependent generator, inside a FLAT_MAP span.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
-func (g *flatMappedGenerator[T, U]) draw(s *TestCase) (U, error) {
-	return withSpan(s, labelFlatMap, func() (U, error) {
+func (g *flatMappedGenerator[T, U]) draw(tc TestCase) (U, error) {
+	return withSpan(tc, labelFlatMap, func() (U, error) {
 		var zero U
-		first, err := g.source.draw(s)
+		first, err := g.source.draw(tc)
 		if err != nil {
 			return zero, err
 		}
-		return g.f(first).draw(s)
+		return g.f(first).draw(tc)
 	})
 }
 
@@ -258,8 +281,8 @@ func Filter[T any](g Generator[T], pred func(T) bool) Generator[T] {
 // --- Span helpers ---
 
 // startSpan notifies the server that a new generation span has started.
-func startSpan(gs *TestCase, label spanLabel) error {
-	_, err := gs.doRequest(map[string]any{
+func startSpan(tc TestCase, label spanLabel) error {
+	_, err := tc.doRequest(map[string]any{
 		"command": "start_span",
 		"label":   int64(label),
 	})
@@ -267,8 +290,8 @@ func startSpan(gs *TestCase, label spanLabel) error {
 }
 
 // stopSpan notifies the server that the current generation span has ended.
-func stopSpan(gs *TestCase, discard bool) error {
-	_, err := gs.doRequest(map[string]any{
+func stopSpan(tc TestCase, discard bool) error {
+	_, err := tc.doRequest(map[string]any{
 		"command": "stop_span",
 		"discard": discard,
 	})
@@ -283,16 +306,16 @@ func stopSpan(gs *TestCase, discard bool) error {
 //
 // Use the inline startSpan/stopSpan pair when the discard decision depends
 // on the body's outcome (see filteredGenerator.draw).
-func withSpan[T any](s *TestCase, label spanLabel, body func() (T, error)) (T, error) {
+func withSpan[T any](tc TestCase, label spanLabel, body func() (T, error)) (T, error) {
 	var zero T
-	if err := startSpan(s, label); err != nil {
+	if err := startSpan(tc, label); err != nil {
 		return zero, err
 	}
 	v, err := body()
 	if err != nil {
 		return zero, err
 	}
-	if err := stopSpan(s, false); err != nil { // coverage-ignore
+	if err := stopSpan(tc, false); err != nil { // coverage-ignore
 		return zero, err
 	}
 	return v, nil
@@ -317,7 +340,7 @@ func (c *collection) Err() error {
 
 // newCollection starts a new collection on the server with the given size bounds.
 // A nil maxSize means unbounded (omitted from the payload).
-func newCollection(gs *TestCase, minSize int, maxSize *int) (*collection, error) {
+func newCollection(tc TestCase, minSize int, maxSize *int) (*collection, error) {
 	msg := map[string]any{
 		"command":  "new_collection",
 		"min_size": int64(minSize),
@@ -325,7 +348,7 @@ func newCollection(gs *TestCase, minSize int, maxSize *int) (*collection, error)
 	if maxSize != nil {
 		msg["max_size"] = int64(*maxSize)
 	}
-	v, err := gs.doRequest(msg)
+	v, err := tc.doRequest(msg)
 	if err != nil {
 		return nil, err
 	}
@@ -337,11 +360,11 @@ func newCollection(gs *TestCase, minSize int, maxSize *int) (*collection, error)
 //
 // Returns false once the collection is finished or an error has been
 // recorded; check Err after the loop to distinguish those cases.
-func (c *collection) More(gs *TestCase) bool {
+func (c *collection) More(tc TestCase) bool {
 	if c.finished || c.err != nil {
 		return false
 	}
-	v, err := gs.doRequest(map[string]any{
+	v, err := tc.doRequest(map[string]any{
 		"command":       "collection_more",
 		"collection_id": c.collectionID,
 	})
@@ -359,11 +382,11 @@ func (c *collection) More(gs *TestCase) bool {
 // Reject tells the server that the last generated element should not count.
 //
 // Errors are recorded on the collection and surfaced via Err.
-func (c *collection) Reject(gs *TestCase) {
+func (c *collection) Reject(tc TestCase) {
 	if c.finished || c.err != nil {
 		return
 	}
-	if _, err := gs.doRequest(map[string]any{
+	if _, err := tc.doRequest(map[string]any{
 		"command":       "collection_reject",
 		"collection_id": c.collectionID,
 	}); err != nil {

--- a/generators_test.go
+++ b/generators_test.go
@@ -82,11 +82,11 @@ func TestCollectionStopTestOnNewCollection(t *testing.T) {
 	// Should not error -- the test was stopped, not failed.
 	Test(t, func(ht *T) {
 		max := 5
-		coll, err := newCollection(ht.TestCase, 0, &max)
+		coll, err := newCollection(ht.testCase, 0, &max)
 		if err != nil {
 			panic(err)
 		}
-		coll.More(ht.TestCase)
+		coll.More(ht.testCase)
 		if err := coll.Err(); err != nil {
 			panic(err)
 		}
@@ -100,11 +100,11 @@ func TestCollectionStopTestOnCollectionMore(t *testing.T) {
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
 	Test(t, func(ht *T) {
 		max := 5
-		coll, err := newCollection(ht.TestCase, 0, &max)
+		coll, err := newCollection(ht.testCase, 0, &max)
 		if err != nil {
 			panic(err)
 		}
-		coll.More(ht.TestCase)
+		coll.More(ht.testCase)
 		if err := coll.Err(); err != nil {
 			panic(err)
 		}
@@ -1122,7 +1122,7 @@ func TestExtractFloatAsFloat64(t *testing.T) {
 
 func TestStartSpanAborted(t *testing.T) {
 	t.Parallel()
-	s := &TestCase{aborted: true}
+	s := &testCase{aborted: true}
 	if err := startSpan(s, labelOneOf); !errors.Is(err, errTestCaseAborted) {
 		t.Fatalf("startSpan on aborted: got %v, want errTestCaseAborted", err)
 	}
@@ -1130,7 +1130,7 @@ func TestStartSpanAborted(t *testing.T) {
 
 func TestStopSpanAborted(t *testing.T) {
 	t.Parallel()
-	s := &TestCase{aborted: true}
+	s := &testCase{aborted: true}
 	if err := stopSpan(s, false); !errors.Is(err, errTestCaseAborted) {
 		t.Fatalf("stopSpan on aborted: got %v, want errTestCaseAborted", err)
 	}
@@ -1143,7 +1143,7 @@ func TestStopSpanAborted(t *testing.T) {
 func TestRejectFinishedCollection(t *testing.T) {
 	t.Parallel()
 	c := &collection{finished: true}
-	s := &TestCase{}
+	s := &testCase{}
 	// Should be a no-op since finished = true.
 	c.Reject(s)
 	if err := c.Err(); err != nil {
@@ -1158,16 +1158,16 @@ func TestRejectE2E(t *testing.T) {
 
 	Test(t, func(ht *T) {
 		max := 5
-		coll, err := newCollection(ht.TestCase, 0, &max)
+		coll, err := newCollection(ht.testCase, 0, &max)
 		if err != nil {
 			panic(err)
 		}
-		if coll.More(ht.TestCase) {
+		if coll.More(ht.testCase) {
 			// Reject the first element — tells the server it doesn't count.
-			coll.Reject(ht.TestCase)
+			coll.Reject(ht.testCase)
 		}
 		// Drain remaining elements.
-		for coll.More(ht.TestCase) {
+		for coll.More(ht.testCase) {
 		}
 		if err := coll.Err(); err != nil {
 			panic(err)

--- a/internal/conformance/cmd/test_binary/main.go
+++ b/internal/conformance/cmd/test_binary/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	gen := hegel.Binary(params.MinSize, maxSize)
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		v := hegel.Draw(s, gen)
 		conformance.WriteMetrics(map[string]any{

--- a/internal/conformance/cmd/test_booleans/main.go
+++ b/internal/conformance/cmd/test_booleans/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		v := hegel.Draw(s, hegel.Booleans())
 		conformance.WriteMetrics(map[string]any{

--- a/internal/conformance/cmd/test_floats/main.go
+++ b/internal/conformance/cmd/test_floats/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	gen := g
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		val := hegel.Draw(s, gen)
 		isNaN := math.IsNaN(val)

--- a/internal/conformance/cmd/test_hashmaps/main.go
+++ b/internal/conformance/cmd/test_hashmaps/main.go
@@ -45,7 +45,7 @@ func main() {
 		}
 		gen := hegel.Maps(keysGen, valsGen).MinSize(params.MinSize).MaxSize(params.MaxSize)
 
-		hegel.MustRun(func(s *hegel.TestCase) {
+		hegel.MustRun(func(s hegel.TestCase) {
 			defer conformance.EnsureMetric()
 			m := hegel.Draw(s, gen)
 			size := len(m)
@@ -95,7 +95,7 @@ func main() {
 		}
 		gen := hegel.Maps(keysGen, valsGen).MinSize(params.MinSize).MaxSize(params.MaxSize)
 
-		hegel.MustRun(func(s *hegel.TestCase) {
+		hegel.MustRun(func(s hegel.TestCase) {
 			defer conformance.EnsureMetric()
 			m := hegel.Draw(s, gen)
 			size := len(m)

--- a/internal/conformance/cmd/test_integers/main.go
+++ b/internal/conformance/cmd/test_integers/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	gen := hegel.Integers[int](minVal, maxVal)
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		val := hegel.Draw(s, gen)
 		conformance.WriteMetrics(map[string]any{

--- a/internal/conformance/cmd/test_lists/main.go
+++ b/internal/conformance/cmd/test_lists/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		items := hegel.Draw(s, gen)
 		elements := make([]any, len(items))

--- a/internal/conformance/cmd/test_oneof/main.go
+++ b/internal/conformance/cmd/test_oneof/main.go
@@ -49,7 +49,7 @@ func main() {
 	gen := hegel.OneOf(gens...)
 
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		val := hegel.Draw(s, gen)
 		conformance.WriteMetrics(map[string]any{

--- a/internal/conformance/cmd/test_origin_dedup/main.go
+++ b/internal/conformance/cmd/test_origin_dedup/main.go
@@ -29,17 +29,17 @@ func main() {
 
 	n := conformance.GetTestCases()
 
-	var body func(s *hegel.TestCase)
+	var body func(s hegel.TestCase)
 	switch params.Mode {
 	case "value_in_error_message":
-		body = func(s *hegel.TestCase) {
+		body = func(s hegel.TestCase) {
 			v := hegel.Draw(s, hegel.Integers[int](0, 1000))
 			conformance.WriteMetrics(map[string]any{"value": v})
 			panic(fmt.Sprintf("failing with value %d", v))
 		}
 
 	case "multiple_call_sites":
-		body = func(s *hegel.TestCase) {
+		body = func(s hegel.TestCase) {
 			v := hegel.Draw(s, hegel.Integers[int](1, 1000))
 			conformance.WriteMetrics(map[string]any{"value": v})
 			if v%2 == 0 {
@@ -53,7 +53,7 @@ func main() {
 		panic("test_origin_dedup: unknown mode: " + params.Mode)
 	}
 
-	_ = hegel.Run(func(s *hegel.TestCase) {
+	_ = hegel.Run(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		body(s)
 	}, hegel.WithTestCases(n))

--- a/internal/conformance/cmd/test_sampled_from/main.go
+++ b/internal/conformance/cmd/test_sampled_from/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	gen := hegel.SampledFrom(params.Options)
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		val := hegel.Draw(s, gen)
 		conformance.WriteMetrics(map[string]any{

--- a/internal/conformance/cmd/test_text/main.go
+++ b/internal/conformance/cmd/test_text/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	gen := g
 	n := conformance.GetTestCases()
-	hegel.MustRun(func(s *hegel.TestCase) {
+	hegel.MustRun(func(s hegel.TestCase) {
 		defer conformance.EnsureMetric()
 		val := hegel.Draw(s, gen)
 		codepoints := make([]int, 0, len(val))

--- a/primitives.go
+++ b/primitives.go
@@ -200,13 +200,13 @@ func (g FloatGenerator[T]) asBasic() (*basicGenerator[T], bool, error) {
 }
 
 // draw produces a floating-point value from the Hegel server.
-func (g FloatGenerator[T]) draw(s *TestCase) (T, error) {
+func (g FloatGenerator[T]) draw(tc TestCase) (T, error) {
 	bg, _, err := g.asBasic()
 	if err != nil {
 		var zero T
 		return zero, err
 	}
-	return bg.draw(s)
+	return bg.draw(tc)
 }
 
 // Booleans returns a Generator that produces boolean values.
@@ -424,12 +424,12 @@ func (g TextGenerator) asBasic() (*basicGenerator[string], bool, error) {
 	return &basicGenerator[string]{schema: schema, parse: extractString}, true, nil
 }
 
-func (g TextGenerator) draw(s *TestCase) (string, error) {
+func (g TextGenerator) draw(tc TestCase) (string, error) {
 	bg, _, err := g.asBasic()
 	if err != nil {
 		return "", err
 	}
-	return bg.draw(s)
+	return bg.draw(tc)
 }
 
 // CharactersGenerator configures and generates single-character strings.
@@ -505,12 +505,12 @@ func (g CharactersGenerator) asBasic() (*basicGenerator[string], bool, error) {
 	return &basicGenerator[string]{schema: schema, parse: extractString}, true, nil
 }
 
-func (g CharactersGenerator) draw(s *TestCase) (string, error) {
+func (g CharactersGenerator) draw(tc TestCase) (string, error) {
 	bg, _, err := g.asBasic()
 	if err != nil {
 		return "", err
 	}
-	return bg.draw(s)
+	return bg.draw(tc)
 }
 
 // Binary returns a Generator that produces byte slices with length in [minSize, maxSize].
@@ -592,12 +592,12 @@ func (g DomainGenerator) asBasic() (*basicGenerator[string], bool, error) {
 	}, true, nil
 }
 
-func (g DomainGenerator) draw(s *TestCase) (string, error) {
+func (g DomainGenerator) draw(tc TestCase) (string, error) {
 	bg, _, err := g.asBasic()
 	if err != nil {
 		return "", err
 	}
-	return bg.draw(s)
+	return bg.draw(tc)
 }
 
 // Dates returns a Generator that produces time.Time values from ISO 8601 date strings (YYYY-MM-DD).

--- a/runner.go
+++ b/runner.go
@@ -15,10 +15,10 @@ import (
 	"time"
 )
 
-// TestCase holds the per-test-case context.
+// testCase holds the per-test-case context.
 //
 // It is compatible with most popular TestingT interfaces from assert libraries.
-type TestCase struct {
+type testCase struct {
 	stream  *stream
 	isFinal bool
 	aborted bool
@@ -57,52 +57,37 @@ const (
 	flakyReplay             = "FlakyReplay"
 )
 
-// internal returns the underlying TestCase, satisfying the State interface.
-func (s *TestCase) internal() *TestCase { return s }
-
-// Assume rejects the current test case if condition is false.
-func (s *TestCase) Assume(condition bool) {
+func (s *testCase) Assume(condition bool) {
 	if !condition {
 		panic(assumeRejected{})
 	}
 }
 
-// Note prints message, but only during the final (replay) test case.
-//
-// Output is routed to t.Log for [Test], or stdout for [Run].
-func (s *TestCase) Note(message string) {
+func (s *testCase) Note(message string) {
 	if s.isFinal && s.noteFn != nil {
 		s.noteFn(message)
 	}
 }
 
-// Errorf logs the formatted message via [TestCase.Note] and marks the test case
-// as failed.
-//
-// The test case continues running but will be treated as a failure after return.
-func (s *TestCase) Errorf(format string, args ...any) {
+func (s *testCase) Errorf(format string, args ...any) {
 	s.Note(fmt.Sprintf(format, args...))
 	s.failed = true
 }
 
-// Fail marks the test case as failed without stopping it.
-func (s *TestCase) Fail() {
+func (s *testCase) Fail() {
 	s.failed = true
 }
 
-// FailNow marks the test case as failed and stops the test body.
-func (s *TestCase) FailNow() {
+func (s *testCase) FailNow() {
 	s.failed = true
 	panic(fatalSentinel{msg: "FailNow called"})
 }
 
-// Log routes the message through [TestCase.Note].
-func (s *TestCase) Log(args ...any) {
+func (s *testCase) Log(args ...any) {
 	s.Note(fmt.Sprint(args...))
 }
 
-// Target guides Hegel toward values that maximize the given metric.
-func (s *TestCase) Target(value float64, label string) {
+func (s *testCase) Target(value float64, label string) {
 	if _, err := s.doRequest(map[string]any{
 		"command": "target",
 		"value":   value,
@@ -137,7 +122,7 @@ func toInt64(v any) (int64, bool) {
 //
 // Panics if msg cannot be CBOR-encoded — unreachable for the fixed-shape maps
 // constructed inside this package.
-func (s *TestCase) doRequest(msg map[string]any) (any, error) {
+func (s *testCase) doRequest(msg map[string]any) (any, error) {
 	if s.aborted {
 		return nil, errTestCaseAborted
 	}
@@ -171,7 +156,7 @@ func (s *TestCase) doRequest(msg map[string]any) (any, error) {
 
 // generateFromSchema sends a generate command for schema and returns the
 // decoded value.
-func (s *TestCase) generateFromSchema(schema map[string]any) (any, error) {
+func (s *testCase) generateFromSchema(schema map[string]any) (any, error) {
 	return s.doRequest(map[string]any{"command": "generate", "schema": schema})
 }
 
@@ -181,8 +166,8 @@ type fatalSentinel struct{ msg string }
 func (f fatalSentinel) Error() string { return f.msg }
 
 // testBody is the internal representation of a test function.
-// It receives the TestCase for the current test case.
-type testBody func(s *TestCase)
+// It receives the [TestCase] for the current test case.
+type testBody func(TestCase)
 
 // --- Health checks ---
 
@@ -352,12 +337,12 @@ func isCI() bool {
 // Run runs a property test and returns any error.
 //
 // Note output goes to stdout. For use in standalone binaries and conformance tests.
-func Run(fn func(*TestCase), opts ...Option) error {
+func Run(fn func(TestCase), opts ...Option) error {
 	return runHegel(fn, stdoutNoteFn, opts)
 }
 
 // MustRun runs a property test and panics if it fails.
-func MustRun(fn func(*TestCase), opts ...Option) {
+func MustRun(fn func(TestCase), opts ...Option) {
 	if err := Run(fn, opts...); err != nil {
 		panic(err)
 	}
@@ -367,8 +352,8 @@ func MustRun(fn func(*TestCase), opts ...Option) {
 func Test(t *testing.T, fn func(*T), opts ...Option) {
 	t.Helper()
 
-	body := func(s *TestCase) {
-		ht := &T{TestCase: s, T: t}
+	body := func(tc TestCase) {
+		ht := &T{testCase: tc.(*testCase), T: t}
 		fn(ht)
 	}
 	allOpts := append(opts, withDatabaseKey([]byte(t.Name())))
@@ -605,7 +590,7 @@ doneLoop:
 
 // runTestCase executes one test case and sends mark_complete to the server.
 func (c *client) runTestCase(st *stream, fn testBody, isFinal bool, noteFn func(string)) (finalErr error) {
-	state := &TestCase{
+	state := &testCase{
 		stream:  st,
 		isFinal: isFinal,
 		aborted: false,

--- a/runner_test.go
+++ b/runner_test.go
@@ -141,7 +141,7 @@ func TestErrorResponse(t *testing.T) {
 				gotErr = fmt.Errorf("%v", r)
 			}
 		}()
-		gotErr = runHegel(func(s *TestCase) {
+		gotErr = runHegel(func(s TestCase) {
 			Draw[bool](s, Booleans()) // server sends error_response here
 		}, stdoutNoteFn, []Option{WithTestCases(3)})
 	}()
@@ -160,7 +160,7 @@ func TestDrawWithNilStreamState(t *testing.T) {
 			t.Error("expected panic when Draw called with nil-stream state")
 		}
 	}()
-	s := &TestCase{} // stream is nil -> will panic
+	s := &testCase{} // stream is nil -> will panic
 	Draw[bool](s, Booleans())
 }
 
@@ -168,14 +168,14 @@ func TestDrawWithNilStreamState(t *testing.T) {
 
 func TestAssumeOutsideContext(t *testing.T) {
 	t.Parallel()
-	// Assume(false) on a nil *TestCase should panic.
+	// Assume(false) on a nil *testCase should panic.
 	defer func() {
 		r := recover()
 		if r == nil {
 			t.Error("expected panic from Assume outside test context")
 		}
 	}()
-	var s *TestCase
+	var s *testCase
 	s.Assume(false)
 }
 
@@ -183,8 +183,8 @@ func TestAssumeOutsideContext(t *testing.T) {
 
 func TestNoteOutsideContext(t *testing.T) {
 	t.Parallel()
-	// Note() on a zero-value *TestCase should not panic (isFinal=false).
-	s := &TestCase{}
+	// Note() on a zero-value *testCase should not panic (isFinal=false).
+	s := &testCase{}
 	s.Note("outside context -- safe")
 }
 
@@ -198,7 +198,7 @@ func TestTargetOutsideContext(t *testing.T) {
 			t.Error("expected panic from Target outside test context")
 		}
 	}()
-	s := &TestCase{} // stream is nil -> panic
+	s := &testCase{} // stream is nil -> panic
 	s.Target(1.0, "x")
 }
 
@@ -339,13 +339,13 @@ func TestWithTestCasesOption(t *testing.T) {
 func TestStopTestOnCollectionMore(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := runHegel(func(s *TestCase) {
+	err := runHegel(func(tc TestCase) {
 		max := 10
-		coll, err := newCollection(s, 0, &max)
+		coll, err := newCollection(tc, 0, &max)
 		if err != nil {
 			panic(err)
 		}
-		coll.More(s)
+		coll.More(tc)
 		if err := coll.Err(); err != nil {
 			panic(err)
 		}
@@ -358,13 +358,13 @@ func TestStopTestOnCollectionMore(t *testing.T) {
 func TestStopTestOnNewCollection(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := runHegel(func(s *TestCase) {
+	err := runHegel(func(tc TestCase) {
 		max := 10
-		coll, err := newCollection(s, 0, &max)
+		coll, err := newCollection(tc, 0, &max)
 		if err != nil {
 			panic(err)
 		}
-		coll.More(s)
+		coll.More(tc)
 		if err := coll.Err(); err != nil {
 			panic(err)
 		}
@@ -377,7 +377,7 @@ func TestStopTestOnNewCollection(t *testing.T) {
 func TestConnectionErrorInTestFunction(t *testing.T) {
 	t.Parallel()
 
-	err := runHegel(func(_ *TestCase) {
+	err := runHegel(func(_ TestCase) {
 		panic(&connectionError{msg: "test connection lost"})
 	}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
@@ -440,7 +440,7 @@ func TestServerCrashMessageNoLogFile(t *testing.T) {
 
 func TestAbortedFlagDirect(t *testing.T) {
 	t.Parallel()
-	state := &TestCase{}
+	state := &testCase{}
 	state.aborted = true
 	if !state.aborted {
 		t.Error("expected aborted to be true after direct assignment")
@@ -462,7 +462,7 @@ func TestGenerateFromSchemaConnectionError(t *testing.T) {
 	// Close the underlying conn so SendPacket fails.
 	s.Close()
 
-	state := &TestCase{stream: st}
+	state := &testCase{stream: st}
 
 	var caught any
 	func() {
@@ -489,7 +489,7 @@ func TestTargetConnectionError(t *testing.T) {
 	conn.streams[1] = st
 	s.Close()
 
-	state := &TestCase{stream: st}
+	state := &testCase{stream: st}
 
 	var caught any
 	func() {
@@ -541,7 +541,7 @@ func TestExtractPanicOriginError(t *testing.T) {
 
 func TestNoteIsFinalTrue(t *testing.T) {
 	t.Parallel()
-	state := &TestCase{isFinal: true, noteFn: stdoutNoteFn}
+	state := &testCase{isFinal: true, noteFn: stdoutNoteFn}
 	// Should not panic.
 	state.Note("test note on final")
 }
@@ -609,7 +609,7 @@ func TestRunHegelTestESessionError(t *testing.T) {
 	globalSession = newHegelSession()
 	globalSession.hegelCmd = "/nonexistent/hegel"
 
-	err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
+	err := runHegel(func(_ TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Error("expected error when session cannot start")
 	}
@@ -635,7 +635,7 @@ func TestRunHegelTestPanicsOnFailure(t *testing.T) {
 	fake.hegelCmd = "/nonexistent/hegel"
 	globalSession = fake
 
-	if _err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)}); _err != nil {
+	if _err := runHegel(func(_ TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)}); _err != nil {
 		panic(_err)
 	}
 }
@@ -664,7 +664,7 @@ func TestHegelSessionRunTest(t *testing.T) {
 	if err := s.start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	err := s.runTest(func(st *TestCase) {
+	err := s.runTest(func(st TestCase) {
 		Draw[bool](st, Booleans())
 	}, runOptions{testCases: 2}, stdoutNoteFn)
 	if err != nil {
@@ -755,7 +755,7 @@ func TestRunHegelTestEProtocolModeStartError(t *testing.T) {
 	t.Setenv("HOME", "/nonexistent")
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
 
-	err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
+	err := runHegel(func(_ TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Error("expected error when session cannot start in protocol test mode")
 	}
@@ -841,7 +841,7 @@ func TestMustRunPanicsOnError(t *testing.T) {
 			t.Error("expected MustRun to panic on error")
 		}
 	}()
-	MustRun(func(*TestCase) {}, WithTestCases(1))
+	MustRun(func(TestCase) {}, WithTestCases(1))
 }
 
 // =============================================================================
@@ -850,7 +850,7 @@ func TestMustRunPanicsOnError(t *testing.T) {
 
 func TestRunPublicAPI(t *testing.T) {
 
-	err := Run(func(s *TestCase) {
+	err := Run(func(s TestCase) {
 		_ = Draw[bool](s, Booleans())
 	}, WithTestCases(1))
 	if err != nil {
@@ -864,7 +864,7 @@ func TestRunPublicAPI(t *testing.T) {
 
 func TestMustRunSuccess(t *testing.T) {
 
-	MustRun(func(s *TestCase) {
+	MustRun(func(s TestCase) {
 		_ = Draw[bool](s, Booleans())
 	}, WithTestCases(1))
 }
@@ -887,9 +887,9 @@ func TestTestSuccess(t *testing.T) {
 
 func TestStateFailedPath(t *testing.T) {
 
-	err := runHegel(func(s *TestCase) {
-		_ = Draw[bool](s, Booleans())
-		s.failed = true // simulates T.Error/T.Fail
+	err := runHegel(func(tc TestCase) {
+		_ = Draw[bool](tc, Booleans())
+		tc.Fail()
 	}, stdoutNoteFn, []Option{WithTestCases(1)})
 	if err == nil {
 		t.Error("expected error when state.failed is true")
@@ -902,7 +902,7 @@ func TestStateFailedPath(t *testing.T) {
 
 func TestFatalSentinelPath(t *testing.T) {
 
-	err := runHegel(func(s *TestCase) {
+	err := runHegel(func(s TestCase) {
 		_ = Draw[bool](s, Booleans())
 		panic(fatalSentinel{msg: "test fatal"})
 	}, stdoutNoteFn, []Option{WithTestCases(1)})
@@ -940,7 +940,7 @@ func TestRunTestSendControlRequestError(t *testing.T) {
 	remote.Close()
 
 	cl := newClient(conn)
-	err := cl.runTest(func(_ *TestCase) {}, runOptions{testCases: 1}, stdoutNoteFn)
+	err := cl.runTest(func(_ TestCase) {}, runOptions{testCases: 1}, stdoutNoteFn)
 	if err == nil {
 		t.Fatal("expected error from runTest on closed conn")
 	}
@@ -1091,7 +1091,7 @@ var flakyCounter atomic.Int64
 func TestFlakyGlobalState(t *testing.T) {
 
 	flakyCounter.Store(0)
-	err := runHegel(func(s *TestCase) {
+	err := runHegel(func(s TestCase) {
 		min := int(flakyCounter.Load())
 		_ = Draw[int](s, Integers[int](min, min+100))
 		flakyCounter.Add(1)
@@ -1123,7 +1123,7 @@ func TestGenerateServerCrashOnRequest(t *testing.T) {
 
 	s.Close()
 
-	state := &TestCase{stream: st}
+	state := &testCase{stream: st}
 	var caught any
 	func() {
 		defer func() { caught = recover() }()
@@ -1163,7 +1163,7 @@ func TestGenerateServerCrashOnGet(t *testing.T) {
 		c.Close()
 	}()
 
-	state := &TestCase{stream: st}
+	state := &testCase{stream: st}
 	var caught any
 	func() {
 		defer func() { caught = recover() }()
@@ -1279,7 +1279,7 @@ func TestRunHegelDisablesDatabaseInCI(t *testing.T) {
 	clearCIEnv(t)
 	t.Setenv("CI", "true")
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
-	err := runHegel(func(_ *TestCase) {}, stdoutNoteFn, nil)
+	err := runHegel(func(_ TestCase) {}, stdoutNoteFn, nil)
 	if err != nil {
 		t.Fatalf("runHegel: %v", err)
 	}

--- a/server_crash_test.go
+++ b/server_crash_test.go
@@ -226,7 +226,7 @@ func TestServerCrashIncludesLogContent(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	err := s.runTest(func(tc *TestCase) {
+	err := s.runTest(func(tc TestCase) {
 		Draw[bool](tc, Booleans())
 	}, runOptions{testCases: 1}, stdoutNoteFn)
 	if err == nil {
@@ -245,7 +245,7 @@ func TestServerCrashEmptyLog(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	err := s.runTest(func(tc *TestCase) {
+	err := s.runTest(func(tc TestCase) {
 		Draw[bool](tc, Booleans())
 	}, runOptions{testCases: 1}, stdoutNoteFn)
 	if err == nil {

--- a/state.go
+++ b/state.go
@@ -8,27 +8,35 @@ import (
 // Compile-time check that T satisfies testing.TB.
 var _ testing.TB = (*T)(nil)
 
-// Compile-time checks that *TestCase satisfies the TestingT interfaces used by
+// Compile-time checks that *testCase and *T both satisfy [TestCase]. This
+// is what lets a [Composite] callback typed `func(TestCase) T` be invoked
+// from either entry point.
+var (
+	_ TestCase = (*testCase)(nil)
+	_ TestCase = (*T)(nil)
+)
+
+// Compile-time checks that *testCase satisfies the TestingT interfaces used by
 // popular assertion libraries (testify, gotest.tools, gomega). This lets
 // assertions be used directly inside [Composite] callbacks and [Run] bodies,
-// where only a *TestCase is available.
+// where only a *testCase is available.
 var _ interface {
 	Errorf(format string, args ...any)
 	FailNow()
-} = (*TestCase)(nil)
+} = (*testCase)(nil)
 
 var _ interface {
 	Fail()
 	FailNow()
 	Log(args ...any)
-} = (*TestCase)(nil)
+} = (*testCase)(nil)
 
 // T is the test context for property tests run via [Test].
 //
 // It embeds *[testing.T] and overrides methods like Fatal and Skip so they
 // work correctly inside a Hegel test body.
 type T struct {
-	*TestCase
+	*testCase
 	*testing.T
 }
 
@@ -46,11 +54,6 @@ func (t *T) Fatalf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	t.Note(msg)
 	panic(fatalSentinel{msg: msg})
-}
-
-// FailNow marks the test case as failed and stops the test body.
-func (t *T) FailNow() {
-	t.TestCase.FailNow()
 }
 
 // Skip discards the current test case.
@@ -76,27 +79,12 @@ func (t *T) SkipNow() {
 func (t *T) Error(args ...any) {
 	msg := fmt.Sprint(args...)
 	t.Note(msg)
-	t.TestCase.failed = true
-}
-
-// Errorf logs the formatted message via [TestCase.Note] and sets the failed flag.
-func (t *T) Errorf(format string, args ...any) {
-	t.TestCase.Errorf(format, args...)
-}
-
-// Fail sets the failed flag without stopping the test case.
-func (t *T) Fail() {
-	t.TestCase.Fail()
+	t.testCase.Fail()
 }
 
 // Failed reports whether the test case has been marked as failed.
 func (t *T) Failed() bool {
-	return t.TestCase.failed
-}
-
-// Log routes the message through [TestCase.Note] (only emitted on final replay).
-func (t *T) Log(args ...any) {
-	t.TestCase.Log(args...)
+	return t.testCase.failed
 }
 
 // Logf routes the formatted message through [TestCase.Note].

--- a/state_test.go
+++ b/state_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 )
 
-// makeFakeT creates a *T with a zero TestCase and a real *testing.T
+// makeFakeT creates a *T with a zero testCase and a real *testing.T
 // for unit testing T methods in state.go.
 func makeFakeT(t *testing.T) *T {
 	return &T{
-		TestCase: &TestCase{},
+		testCase: &testCase{},
 		T:        t,
 	}
 }
@@ -131,11 +131,11 @@ func TestTErrorSetsFailedAndCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
 	// Make state final so Note actually fires (verify no panic).
-	ht.TestCase.isFinal = true
+	ht.testCase.isFinal = true
 	noted := false
-	ht.TestCase.noteFn = func(msg string) { noted = true }
+	ht.testCase.noteFn = func(msg string) { noted = true }
 	ht.Error("something went wrong")
-	if !ht.TestCase.failed {
+	if !ht.testCase.failed {
 		t.Error("expected failed to be true after Error()")
 	}
 	if !noted {
@@ -146,11 +146,11 @@ func TestTErrorSetsFailedAndCallsNote(t *testing.T) {
 func TestTErrorfSetsFailedAndCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	ht.TestCase.isFinal = true
+	ht.testCase.isFinal = true
 	noted := false
-	ht.TestCase.noteFn = func(msg string) { noted = true }
+	ht.testCase.noteFn = func(msg string) { noted = true }
 	ht.Errorf("error: %d", 99)
-	if !ht.TestCase.failed {
+	if !ht.testCase.failed {
 		t.Error("expected failed to be true after Errorf()")
 	}
 	if !noted {
@@ -181,9 +181,9 @@ func TestTFailSetsFailed(t *testing.T) {
 func TestTLogCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	ht.TestCase.isFinal = true
+	ht.testCase.isFinal = true
 	var gotMsg string
-	ht.TestCase.noteFn = func(msg string) { gotMsg = msg }
+	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
 	ht.Log("hello", " world")
 	if gotMsg != "hello world" {
 		t.Errorf("expected %q, got %q", "hello world", gotMsg)
@@ -193,9 +193,9 @@ func TestTLogCallsNote(t *testing.T) {
 func TestTLogfCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	ht.TestCase.isFinal = true
+	ht.testCase.isFinal = true
 	var gotMsg string
-	ht.TestCase.noteFn = func(msg string) { gotMsg = msg }
+	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
 	ht.Logf("value=%d", 42)
 	if gotMsg != "value=42" {
 		t.Errorf("expected %q, got %q", "value=42", gotMsg)

--- a/stateful.go
+++ b/stateful.go
@@ -24,7 +24,7 @@ type stateMachine struct {
 // a bound function value with the receiver pre-applied at discovery time.
 type stateMachineRule struct {
 	name string
-	fn   func(*TestCase)
+	fn   func(TestCase)
 }
 
 // newStateMachine inspects machine's method set and returns a runner.
@@ -36,7 +36,7 @@ func newStateMachine[M any, T interface{ *M }](machine T) (*stateMachine, error)
 
 	rt := reflect.TypeOf(machine)
 	rv := reflect.ValueOf(machine)
-	tcType := reflect.TypeFor[*TestCase]()
+	tcType := reflect.TypeFor[TestCase]()
 
 	for i := range rt.NumMethod() {
 		m := rt.Method(i)
@@ -56,14 +56,14 @@ func newStateMachine[M any, T interface{ *M }](machine T) (*stateMachine, error)
 
 		if !isRule && !isInvariant {
 			if takesTestCase {
-				return nil, fmt.Errorf("method %s takes *TestCase but is not prefixed with Rule or Invariant", name)
+				return nil, fmt.Errorf("method %s takes TestCase but is not prefixed with Rule or Invariant", name)
 			}
 			continue
 		}
 
-		fn, ok := rv.Method(i).Interface().(func(*TestCase))
+		fn, ok := rv.Method(i).Interface().(func(TestCase))
 		if !ok {
-			return nil, fmt.Errorf("method %s: rules and invariants must have signature func(*TestCase) with no return", name)
+			return nil, fmt.Errorf("method %s: rules and invariants must have signature func(TestCase) with no return", name)
 		}
 
 		r := stateMachineRule{name: name, fn: fn}
@@ -88,11 +88,10 @@ func newStateMachine[M any, T interface{ *M }](machine T) (*stateMachine, error)
 //
 // Rules that reject the current pre-state via [TestCase.Assume] are
 // skipped and another rule is drawn, up to a retry budget.
-func (sm *stateMachine) Run(tc testCase) {
-	s := tc.internal()
-	s.Note("Initial invariant check.")
+func (sm *stateMachine) Run(tc TestCase) {
+	tc.Note("Initial invariant check.")
 	for _, inv := range sm.invariants {
-		if err := callInvariant(s, inv.fn); err != nil {
+		if err := callInvariant(tc, inv.fn); err != nil {
 			panic(err)
 		}
 	}
@@ -108,9 +107,9 @@ func (sm *stateMachine) Run(tc testCase) {
 			idx = Draw(tc, Integers(0, len(sm.rules)-1))
 		}
 		rule := sm.rules[idx]
-		s.Note(fmt.Sprintf("Step %d: %s", step, rule.name))
+		tc.Note(fmt.Sprintf("Step %d: %s", step, rule.name))
 
-		ok, err := callRule(s, rule.fn)
+		ok, err := callRule(tc, rule.fn)
 		if err != nil { // coverage-ignore
 			panic(err)
 		}
@@ -120,29 +119,29 @@ func (sm *stateMachine) Run(tc testCase) {
 		}
 		stepsSucceeded++
 		for _, inv := range sm.invariants {
-			if err := callInvariant(s, inv.fn); err != nil { // coverage-ignore
+			if err := callInvariant(tc, inv.fn); err != nil { // coverage-ignore
 				panic(err)
 			}
 		}
 	}
 }
 
-// callInvariant brackets fn(s) in a labelStateful span. Panics propagate
+// callInvariant brackets fn(tc) in a labelStateful span. Panics propagate
 // to the caller; invariant failures must surface as test failures.
-func callInvariant(s *TestCase, fn func(*TestCase)) error {
-	_, err := withSpan(s, labelStateful, func() (struct{}, error) {
-		fn(s)
+func callInvariant(tc TestCase, fn func(TestCase)) error {
+	_, err := withSpan(tc, labelStateful, func() (struct{}, error) {
+		fn(tc)
 		return struct{}{}, nil
 	})
 	return err
 }
 
-// callRule brackets fn(s) in a labelStateful span and recovers from
+// callRule brackets fn(tc) in a labelStateful span and recovers from
 // [TestCase.Assume] rejections so the caller can try a different rule.
 // It returns true if fn ran to completion, false if it rejected via
 // Assume. Other panics propagate to the caller.
-func callRule(s *TestCase, fn func(*TestCase)) (bool, error) {
-	return withSpan(s, labelStateful, func() (ok bool, err error) {
+func callRule(tc TestCase, fn func(TestCase)) (bool, error) {
+	return withSpan(tc, labelStateful, func() (ok bool, err error) {
 		defer func() {
 			r := recover()
 			if r == nil {
@@ -153,7 +152,7 @@ func callRule(s *TestCase, fn func(*TestCase)) (bool, error) {
 			}
 			panic(r)
 		}()
-		fn(s)
+		fn(tc)
 		return true, nil
 	})
 }
@@ -164,14 +163,14 @@ func callRule(s *TestCase, fn func(*TestCase)) (bool, error) {
 // of rules and invariants.
 //
 // Methods whose name starts with "Rule" and whose signature is
-// func(*TestCase) are registered as rules. Methods whose name
+// func(TestCase) are registered as rules. Methods whose name
 // starts with "Invariant" with the same signature are registered as
 // invariants.
 //
-// It panics if a method takes *TestCase but is not prefixed
+// It panics if a method takes TestCase but is not prefixed
 // with Rule or Invariant, if a Rule- or Invariant-prefixed method has
 // the wrong signature, or if the machine has no rules.
-func RunStateful[M any, T interface{ *M }](tc testCase, machine T) {
+func RunStateful[M any, T interface{ *M }](tc TestCase, machine T) {
 	sm, err := newStateMachine(machine)
 	if err != nil {
 		panic(err)

--- a/stateful_test.go
+++ b/stateful_test.go
@@ -7,9 +7,9 @@ import (
 
 type goodCounter struct{ n int }
 
-func (c *goodCounter) RuleIncrement(_ *TestCase) { c.n++ }
-func (c *goodCounter) RuleDecrement(_ *TestCase) { c.n-- }
-func (c *goodCounter) InvariantSensible(_ *TestCase) {
+func (c *goodCounter) RuleIncrement(_ TestCase) { c.n++ }
+func (c *goodCounter) RuleDecrement(_ TestCase) { c.n-- }
+func (c *goodCounter) InvariantSensible(_ TestCase) {
 	if c.n < -10000 || c.n > 10000 {
 		panic("counter out of sensible range")
 	}
@@ -17,34 +17,34 @@ func (c *goodCounter) InvariantSensible(_ *TestCase) {
 
 type singleRuleMachine struct{ n int }
 
-func (m *singleRuleMachine) RuleStep(_ *TestCase) { m.n++ }
+func (m *singleRuleMachine) RuleStep(_ TestCase) { m.n++ }
 
 type helperMachine struct{ n int }
 
-func (m *helperMachine) RuleBump(_ *TestCase) { m.n++ }
-func (m *helperMachine) Helper() int          { return m.n } //nolint:unused
+func (m *helperMachine) RuleBump(_ TestCase) { m.n++ }
+func (m *helperMachine) Helper() int         { return m.n } //nolint:unused
 
 type noRulesMachine struct{}
 
-func (noRulesMachine) InvariantTrue(_ *TestCase) {}
+func (noRulesMachine) InvariantTrue(_ TestCase) {}
 
 type badRuleSig struct{}
 
-func (badRuleSig) RuleBad(_ *TestCase, _ string) {}
+func (badRuleSig) RuleBad(_ TestCase, _ string) {}
 
 type badInvariantSig struct{}
 
-func (badInvariantSig) RuleOK(_ *TestCase)    {}
+func (badInvariantSig) RuleOK(_ TestCase)     {}
 func (badInvariantSig) InvariantBad(_ string) {}
 
 type strayTestCaseMachine struct{}
 
-func (strayTestCaseMachine) RuleOK(_ *TestCase)  {}
-func (strayTestCaseMachine) DoStuff(_ *TestCase) {}
+func (strayTestCaseMachine) RuleOK(_ TestCase)  {}
+func (strayTestCaseMachine) DoStuff(_ TestCase) {}
 
 type assumeRejecting struct{}
 
-func (assumeRejecting) RuleReject(tc *TestCase) { tc.Assume(false) }
+func (assumeRejecting) RuleReject(tc TestCase) { tc.Assume(false) }
 
 // gatedMachine.RuleGated rejects via Assume until RuleOpen has run, so
 // the test exercises that an Assume rejection retries with a different
@@ -54,21 +54,21 @@ type gatedMachine struct {
 	gateCount int
 }
 
-func (m *gatedMachine) RuleOpen(_ *TestCase) { m.opened = true }
+func (m *gatedMachine) RuleOpen(_ TestCase) { m.opened = true }
 
-func (m *gatedMachine) RuleGated(tc *TestCase) {
+func (m *gatedMachine) RuleGated(tc TestCase) {
 	tc.Assume(m.opened)
 	m.gateCount++
 }
 
 type rulePanicker struct{}
 
-func (rulePanicker) RuleBoom(_ *TestCase) { panic("rule panic propagated") }
+func (rulePanicker) RuleBoom(_ TestCase) { panic("rule panic propagated") }
 
 type invariantViolator struct{ n int }
 
-func (m *invariantViolator) RuleStep(_ *TestCase) { m.n++ }
-func (m *invariantViolator) InvariantSmall(_ *TestCase) {
+func (m *invariantViolator) RuleStep(_ TestCase) { m.n++ }
+func (m *invariantViolator) InvariantSmall(_ TestCase) {
 	if m.n >= 3 {
 		panic(fmt.Sprintf("counter reached %d", m.n))
 	}
@@ -95,7 +95,7 @@ func TestNewStateMachineValidationErrors(t *testing.T) {
 		{
 			name:        "BadRuleSignature",
 			newMachine:  func() (*stateMachine, error) { return newStateMachine(&badRuleSig{}) },
-			wantSubstrs: []string{"RuleBad", "func(*TestCase)"},
+			wantSubstrs: []string{"RuleBad", "func(TestCase)"},
 		},
 		{
 			name:        "BadInvariantSignature",
@@ -162,7 +162,7 @@ func TestRunStatefulSingleRule(t *testing.T) {
 func TestRunStatefulPanicsOnValidationError(t *testing.T) {
 	t.Parallel()
 	assertPanicsWithMessage(t, "no rules", func() {
-		RunStateful(&TestCase{}, &noRulesMachine{})
+		RunStateful(&testCase{}, &noRulesMachine{})
 	})
 }
 
@@ -176,7 +176,7 @@ func TestRunStatefulRuleAssumeFalse(t *testing.T) {
 func TestRunStatefulAssumeRejectionRetries(t *testing.T) {
 	t.Parallel()
 	totalGateRuns := 0
-	err := Run(func(tc *TestCase) {
+	err := Run(func(tc TestCase) {
 		m := &gatedMachine{}
 		RunStateful(tc, m)
 		totalGateRuns += m.gateCount
@@ -191,7 +191,7 @@ func TestRunStatefulAssumeRejectionRetries(t *testing.T) {
 
 func TestRunStatefulRulePanicPropagates(t *testing.T) {
 	t.Parallel()
-	err := Run(func(tc *TestCase) {
+	err := Run(func(tc TestCase) {
 		RunStateful(tc, &rulePanicker{})
 	})
 	assertErrorContains(t, "rule panic propagated", err)
@@ -211,7 +211,7 @@ func TestStatefulInitialInvariantConnectionError(t *testing.T) {
 	conn.streams[1] = st
 	s.Close()
 
-	state := &TestCase{stream: st}
+	state := &testCase{stream: st}
 	sm, err := newStateMachine(&goodCounter{})
 	if err != nil {
 		t.Fatalf("newStateMachine: %v", err)
@@ -229,7 +229,7 @@ func TestStatefulInitialInvariantConnectionError(t *testing.T) {
 
 func TestRunStatefulInvariantViolationFails(t *testing.T) {
 	t.Parallel()
-	err := Run(func(tc *TestCase) {
+	err := Run(func(tc TestCase) {
 		RunStateful(tc, &invariantViolator{})
 	}, WithTestCases(10))
 	assertErrorContains(t, "counter reached", err)

--- a/workload.go
+++ b/workload.go
@@ -21,7 +21,7 @@ var workloadExit = os.Exit
 // Runs for an unbounded amount of time unless overridden via an option or flag.
 //
 // opts are overridden by flags.
-func Workload(fn func(*TestCase), opts ...Option) {
+func Workload(fn func(TestCase), opts ...Option) {
 	err := workload(os.Args, os.Stderr, fn, opts)
 	if err == nil {
 		return
@@ -34,7 +34,7 @@ func Workload(fn func(*TestCase), opts ...Option) {
 // output (parse errors, usage, --help) to stderr and returns nil on success
 // (including --help) or a non-nil error for flag-parse problems and
 // property-test failures.
-func workload(args []string, stderr io.Writer, fn func(*TestCase), opts []Option) error {
+func workload(args []string, stderr io.Writer, fn func(TestCase), opts []Option) error {
 	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	fs.SetOutput(stderr)
 

--- a/workload_test.go
+++ b/workload_test.go
@@ -163,7 +163,7 @@ func TestParseHealthCheckRoundTrip(t *testing.T) {
 
 func TestWorkloadEmptyTestSucceeds(t *testing.T) {
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
-	err := workload([]string{"prog"}, io.Discard, func(*TestCase) {
+	err := workload([]string{"prog"}, io.Discard, func(TestCase) {
 		t.Fatal("body should not run under empty_test")
 	}, nil)
 	if err != nil {
@@ -182,7 +182,7 @@ func TestWorkloadParsesFlags(t *testing.T) {
 			"--suppress-health-check=filter_too_much",
 		},
 		io.Discard,
-		func(*TestCase) {}, nil,
+		func(TestCase) {}, nil,
 	)
 	if err != nil {
 		t.Fatalf("workload: %v", err)
@@ -192,7 +192,7 @@ func TestWorkloadParsesFlags(t *testing.T) {
 func TestWorkloadHelpReturnsNil(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	err := workload([]string{"myprog", "--help"}, &buf, func(*TestCase) {}, nil)
+	err := workload([]string{"myprog", "--help"}, &buf, func(TestCase) {}, nil)
 	if err != nil {
 		t.Errorf("expected nil error on --help, got %v", err)
 	}
@@ -207,7 +207,7 @@ func TestWorkloadHelpReturnsNil(t *testing.T) {
 func TestWorkloadBadFlagReturnsError(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	err := workload([]string{"prog", "--bogus"}, &buf, func(*TestCase) {}, nil)
+	err := workload([]string{"prog", "--bogus"}, &buf, func(TestCase) {}, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown flag")
 	}
@@ -222,7 +222,7 @@ func TestWorkloadBadHealthCheckReturnsError(t *testing.T) {
 	err := workload(
 		[]string{"prog", "--suppress-health-check=nonsense"},
 		io.Discard,
-		func(*TestCase) {}, nil,
+		func(TestCase) {}, nil,
 	)
 	if err == nil || !strings.Contains(err.Error(), "nonsense") {
 		t.Errorf("expected error mentioning %q, got %v", "nonsense", err)
@@ -273,7 +273,7 @@ func TestWorkloadPublicSuccess(t *testing.T) {
 	withArgs(t, []string{"prog"})
 	code := captureWorkloadExit(t)
 
-	Workload(func(*TestCase) {})
+	Workload(func(TestCase) {})
 	if *code != 0 {
 		t.Errorf("workloadExit should not be called on success (got %d)", *code)
 	}
@@ -283,7 +283,7 @@ func TestWorkloadPublicExitsOnFlagError(t *testing.T) {
 	withArgs(t, []string{"prog", "--bogus"})
 	code := captureWorkloadExit(t)
 
-	Workload(func(*TestCase) {})
+	Workload(func(TestCase) {})
 	if *code != 1 {
 		t.Errorf("expected exit code 1, got %d", *code)
 	}
@@ -300,7 +300,7 @@ func TestWorkloadPublicExitsOnRunError(t *testing.T) {
 	withArgs(t, []string{"prog"})
 	code := captureWorkloadExit(t)
 
-	Workload(func(*TestCase) {})
+	Workload(func(TestCase) {})
 	if *code != 1 {
 		t.Errorf("expected exit code 1, got %d", *code)
 	}


### PR DESCRIPTION
Split the test-case API into an interface and a struct: TestCase is now the exported interface that Run, MustRun, Composite, and RunStateful callbacks receive; the per-test-case state is the unexported testCase struct. *T continues to satisfy TestCase by embedding *testCase.

State-machine rules and invariants now have the signature func(TestCase); the reflection check and error message in newStateMachine were updated to match.

Composite generators and stateful testing still do not have access to hegel.T.

Fixes: https://github.com/hegeldev/hegel-go/issues/68