### PR TITLE
add Workload for running property tests as standalone binaries

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release adds `hegel.Workload`, for running a property test as a standalone CLI binary outside of `go test` — for example as a workload in a soak run or fuzzing harness.

--- a/example_test.go
+++ b/example_test.go
@@ -233,3 +233,9 @@ func ExampleComposite_recursive() {
 		_ = hegel.Draw(ht, nodeGen)
 	})
 }
+
+func ExampleWorkload() {
+	hegel.Workload(func(tc *hegel.TestCase) {
+		_ = hegel.Draw(tc, hegel.Integers(0, 100))
+	})
+}

--- a/hegel.go
+++ b/hegel.go
@@ -158,12 +158,21 @@
 //		}, hegel.WithTestCases(500))
 //	}
 //
+// # Run as a standalone binary
+//
+// To run a property test outside of go test — for example as a workload
+// in a soak run or fuzzing harness — use [Workload]. It parses the usual
+// CLI flags (--test-cases, --derandomize, --database,
+// --suppress-health-check) and runs the body unbounded by default.
+//
 // # Learning more
 //
 //   - Browse the function documentation for the full list of available
 //     generators.
 //   - See [WithTestCases] and other [Option] functions for more
 //     configuration settings to customize how your test runs.
+//   - See [Workload] for running a property test as a standalone CLI
+//     binary outside of go test.
 //
 // [Hypothesis]: https://github.com/hypothesisworks/hypothesis
 // [Hegel]: https://hegel.dev/

--- a/workload.go
+++ b/workload.go
@@ -1,0 +1,179 @@
+package hegel
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// workloadExit is a seam so tests can observe the exit code from [Workload]
+// without terminating the test process.
+var workloadExit = os.Exit
+
+// Workload runs a property test as a standalone CLI binary, parsing flags
+// from [os.Args].
+//
+// Runs for an unbounded amount of time unless overridden via an option or flag.
+//
+// opts are overridden by flags.
+func Workload(fn func(*TestCase), opts ...Option) {
+	err := workload(os.Args, os.Stderr, fn, opts)
+	if err == nil {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Error:", err)
+	workloadExit(1)
+}
+
+// workload is the testable core of [Workload]. It writes flag-package
+// output (parse errors, usage, --help) to stderr and returns nil on success
+// (including --help) or a non-nil error for flag-parse problems and
+// property-test failures.
+func workload(args []string, stderr io.Writer, fn func(*TestCase), opts []Option) error {
+	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	fs.Var(&testCasesFlag{}, "test-cases", "maximum `number` of test cases to run")
+	fs.Var(&derandomizeFlag{}, "derandomize", "use a fixed seed for reproducible runs")
+	fs.Var(&databaseFlag{}, "database", "example database `path`; empty string disables persistence")
+	fs.Var(&suppressHealthCheckFlag{}, "suppress-health-check", "`name` of health check to suppress (repeatable)")
+
+	if err := fs.Parse(args[1:]); errors.Is(err, flag.ErrHelp) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	allOpts := []Option{
+		WithTestCases(math.MaxInt),
+	}
+	allOpts = append(allOpts, opts...)
+	fs.Visit(func(f *flag.Flag) {
+		if ov, ok := f.Value.(optionValue); ok {
+			allOpts = append(allOpts, ov.Option())
+		}
+	})
+	return Run(fn, allOpts...)
+}
+
+type optionValue interface {
+	flag.Value
+	Option() Option
+}
+
+// testCasesFlag wires --test-cases to [WithTestCases].
+type testCasesFlag struct {
+	n int
+}
+
+func (f *testCasesFlag) String() string {
+	return strconv.Itoa(f.n)
+}
+
+func (f *testCasesFlag) Set(s string) error {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+	f.n = n
+	return nil
+}
+
+// Option returns the option corresponding to this flag.
+func (f *testCasesFlag) Option() Option {
+	return WithTestCases(f.n)
+}
+
+// derandomizeFlag wires --derandomize to [WithDerandomize].
+type derandomizeFlag struct {
+	derandomize bool
+}
+
+func (f *derandomizeFlag) String() string {
+	return strconv.FormatBool(f.derandomize)
+}
+
+func (f *derandomizeFlag) Set(s string) error {
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	f.derandomize = b
+	return nil
+}
+
+// IsBoolFlag tells the flag package that --derandomize parses without a value.
+func (f *derandomizeFlag) IsBoolFlag() bool { return true }
+
+// Option returns the option corresponding to this flag.
+func (f *derandomizeFlag) Option() Option {
+	return WithDerandomize(f.derandomize)
+}
+
+// databaseFlag wires --database to [WithDatabase]. A non-empty value selects
+// [Database]; an empty value (--database=) selects [DatabaseDisabled].
+type databaseFlag struct {
+	path string
+}
+
+func (f *databaseFlag) String() string {
+	return f.path
+}
+
+func (f *databaseFlag) Set(s string) error {
+	f.path = s
+	return nil
+}
+
+// Option returns the option corresponding to this flag.
+func (f *databaseFlag) Option() Option {
+	if f.path == "" {
+		return WithDatabase(DatabaseDisabled())
+	}
+	return WithDatabase(Database(f.path))
+}
+
+// suppressHealthCheckFlag wires --suppress-health-check to
+// [SuppressHealthCheck]. The flag is repeatable; each occurrence accumulates a
+// single [HealthCheck] value.
+type suppressHealthCheckFlag struct {
+	checks []HealthCheck
+}
+
+func (f *suppressHealthCheckFlag) String() string {
+	names := make([]string, len(f.checks))
+	for i, hc := range f.checks {
+		names[i] = hc.String()
+	}
+	return strings.Join(names, ",")
+}
+
+func (f *suppressHealthCheckFlag) Set(s string) error {
+	hc, err := parseHealthCheck(s)
+	if err != nil {
+		return err
+	}
+	f.checks = append(f.checks, hc)
+	return nil
+}
+
+// Option returns the option corresponding to this flag.
+func (f *suppressHealthCheckFlag) Option() Option {
+	return SuppressHealthCheck(f.checks...)
+}
+
+// parseHealthCheck is the inverse of [HealthCheck.String]. Unknown names
+// return an error naming the bad value.
+func parseHealthCheck(name string) (HealthCheck, error) {
+	for _, hc := range AllHealthChecks() {
+		if hc.String() == name {
+			return hc, nil
+		}
+	}
+	return 0, fmt.Errorf("unknown health check %q", name)
+}

--- a/workload_test.go
+++ b/workload_test.go
@@ -1,0 +1,307 @@
+package hegel
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// applyOpts builds a runOptions by applying all opts in order.
+func applyOpts(opts []Option) runOptions {
+	var o runOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// captureWorkloadExit replaces workloadExit with one that records the exit
+// code into the returned pointer, and registers a t.Cleanup to restore it.
+func captureWorkloadExit(t *testing.T) *int {
+	t.Helper()
+	var code int
+	orig := workloadExit
+	workloadExit = func(c int) { code = c }
+	t.Cleanup(func() { workloadExit = orig })
+	return &code
+}
+
+// withArgs replaces os.Args for the duration of the test.
+func withArgs(t *testing.T, args []string) {
+	t.Helper()
+	orig := os.Args
+	os.Args = args
+	t.Cleanup(func() { os.Args = orig })
+}
+
+// --- Per-flag round-trip tests ---
+
+func TestTestCasesFlagSetOption(t *testing.T) {
+	t.Parallel()
+	f := &testCasesFlag{}
+	if err := f.Set("7"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if f.String() != "7" {
+		t.Errorf("String=%q want %q", f.String(), "7")
+	}
+	o := applyOpts([]Option{f.Option()})
+	if o.testCases != 7 {
+		t.Errorf("testCases=%d want 7", o.testCases)
+	}
+}
+
+func TestTestCasesFlagBadValue(t *testing.T) {
+	t.Parallel()
+	f := &testCasesFlag{}
+	if err := f.Set("not-an-int"); err == nil {
+		t.Fatal("expected error for non-int value")
+	}
+}
+
+func TestDerandomizeFlagSetOption(t *testing.T) {
+	t.Parallel()
+	f := &derandomizeFlag{}
+	if !f.IsBoolFlag() {
+		t.Error("IsBoolFlag should be true")
+	}
+	if err := f.Set("true"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if f.String() != "true" {
+		t.Errorf("String=%q want %q", f.String(), "true")
+	}
+	o := applyOpts([]Option{f.Option()})
+	if !o.derandomize {
+		t.Error("expected derandomize=true")
+	}
+}
+
+func TestDerandomizeFlagBadValue(t *testing.T) {
+	t.Parallel()
+	f := &derandomizeFlag{}
+	if err := f.Set("maybe"); err == nil {
+		t.Fatal("expected error for non-bool value")
+	}
+}
+
+func TestDatabaseFlagPath(t *testing.T) {
+	t.Parallel()
+	f := &databaseFlag{}
+	if err := f.Set("/tmp/db"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if f.String() != "/tmp/db" {
+		t.Errorf("String=%q want %q", f.String(), "/tmp/db")
+	}
+	o := applyOpts([]Option{f.Option()})
+	want := Database("/tmp/db")
+	if o.database != want {
+		t.Errorf("database=%+v want %+v", o.database, want)
+	}
+}
+
+func TestDatabaseFlagDisabledViaEmpty(t *testing.T) {
+	t.Parallel()
+	f := &databaseFlag{}
+	if err := f.Set(""); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	o := applyOpts([]Option{f.Option()})
+	if o.database != DatabaseDisabled() {
+		t.Errorf("database=%+v want DatabaseDisabled()", o.database)
+	}
+}
+
+func TestSuppressHealthCheckFlagRepeated(t *testing.T) {
+	t.Parallel()
+	f := &suppressHealthCheckFlag{}
+	if err := f.Set("filter_too_much"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := f.Set("too_slow"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if f.String() != "filter_too_much,too_slow" {
+		t.Errorf("String=%q", f.String())
+	}
+	o := applyOpts([]Option{f.Option()})
+	want := []HealthCheck{FilterTooMuch, TooSlow}
+	if !reflect.DeepEqual(o.suppressHealthCheck, want) {
+		t.Errorf("suppressHealthCheck=%v want %v", o.suppressHealthCheck, want)
+	}
+}
+
+func TestSuppressHealthCheckFlagUnknown(t *testing.T) {
+	t.Parallel()
+	f := &suppressHealthCheckFlag{}
+	err := f.Set("bogus")
+	if err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("expected error mentioning %q, got %v", "bogus", err)
+	}
+}
+
+func TestParseHealthCheckRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, hc := range AllHealthChecks() {
+		got, err := parseHealthCheck(hc.String())
+		if err != nil {
+			t.Errorf("parseHealthCheck(%q): %v", hc.String(), err)
+			continue
+		}
+		if got != hc {
+			t.Errorf("parseHealthCheck(%q)=%v want %v", hc.String(), got, hc)
+		}
+	}
+}
+
+// --- workload() (lowercase) ---
+
+func TestWorkloadEmptyTestSucceeds(t *testing.T) {
+	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
+	err := workload([]string{"prog"}, io.Discard, func(*TestCase) {
+		t.Fatal("body should not run under empty_test")
+	}, nil)
+	if err != nil {
+		t.Fatalf("workload: %v", err)
+	}
+}
+
+func TestWorkloadParsesFlags(t *testing.T) {
+	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
+	err := workload(
+		[]string{
+			"prog",
+			"--test-cases=3",
+			"--derandomize",
+			"--database=/tmp/x",
+			"--suppress-health-check=filter_too_much",
+		},
+		io.Discard,
+		func(*TestCase) {}, nil,
+	)
+	if err != nil {
+		t.Fatalf("workload: %v", err)
+	}
+}
+
+func TestWorkloadHelpReturnsNil(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := workload([]string{"myprog", "--help"}, &buf, func(*TestCase) {}, nil)
+	if err != nil {
+		t.Errorf("expected nil error on --help, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "Usage of myprog") {
+		t.Errorf("expected help to mention %q, got %q", "Usage of myprog", buf.String())
+	}
+	if !strings.Contains(buf.String(), "test-cases") {
+		t.Errorf("expected help to list --test-cases, got %q", buf.String())
+	}
+}
+
+func TestWorkloadBadFlagReturnsError(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := workload([]string{"prog", "--bogus"}, &buf, func(*TestCase) {}, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+	// flag.ContinueOnError prints the error and usage to fs.Output().
+	if !strings.Contains(buf.String(), "bogus") {
+		t.Errorf("expected stderr to mention %q, got %q", "bogus", buf.String())
+	}
+}
+
+func TestWorkloadBadHealthCheckReturnsError(t *testing.T) {
+	t.Parallel()
+	err := workload(
+		[]string{"prog", "--suppress-health-check=nonsense"},
+		io.Discard,
+		func(*TestCase) {}, nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "nonsense") {
+		t.Errorf("expected error mentioning %q, got %v", "nonsense", err)
+	}
+}
+
+// --- Layering: Workload default < opts < CLI ---
+
+func TestWorkloadLayeringCLIOverrides(t *testing.T) {
+	t.Parallel()
+	tcFlag := &testCasesFlag{}
+	if err := tcFlag.Set("7"); err != nil {
+		t.Fatal(err)
+	}
+	userOpts := []Option{WithTestCases(99)}
+	all := []Option{WithTestCases(math.MaxInt)}
+	all = append(all, userOpts...)
+	all = append(all, tcFlag.Option())
+	o := applyOpts(all)
+	if o.testCases != 7 {
+		t.Errorf("CLI should win: testCases=%d want 7", o.testCases)
+	}
+}
+
+func TestWorkloadLayeringOptsOverridesDefault(t *testing.T) {
+	t.Parallel()
+	userOpts := []Option{WithTestCases(13)}
+	all := append([]Option{WithTestCases(math.MaxInt)}, userOpts...)
+	o := applyOpts(all)
+	if o.testCases != 13 {
+		t.Errorf("opts should beat default: testCases=%d want 13", o.testCases)
+	}
+}
+
+func TestWorkloadLayeringDefaultAlone(t *testing.T) {
+	t.Parallel()
+	all := []Option{WithTestCases(math.MaxInt)}
+	o := applyOpts(all)
+	if o.testCases != math.MaxInt {
+		t.Errorf("default: testCases=%d want MaxInt", o.testCases)
+	}
+}
+
+// --- Workload() (uppercase): success and exit-on-error paths ---
+
+func TestWorkloadPublicSuccess(t *testing.T) {
+	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
+	withArgs(t, []string{"prog"})
+	code := captureWorkloadExit(t)
+
+	Workload(func(*TestCase) {})
+	if *code != 0 {
+		t.Errorf("workloadExit should not be called on success (got %d)", *code)
+	}
+}
+
+func TestWorkloadPublicExitsOnFlagError(t *testing.T) {
+	withArgs(t, []string{"prog", "--bogus"})
+	code := captureWorkloadExit(t)
+
+	Workload(func(*TestCase) {})
+	if *code != 1 {
+		t.Errorf("expected exit code 1, got %d", *code)
+	}
+}
+
+// TestWorkloadPublicExitsOnRunError exercises the path where Run returns an
+// error (the flag package did not pre-print).
+func TestWorkloadPublicExitsOnRunError(t *testing.T) {
+	old := globalSession
+	defer func() { globalSession = old }()
+	globalSession = newHegelSession()
+	globalSession.hegelCmd = "/nonexistent"
+
+	withArgs(t, []string{"prog"})
+	code := captureWorkloadExit(t)
+
+	Workload(func(*TestCase) {})
+	if *code != 1 {
+		t.Errorf("expected exit code 1, got %d", *code)
+	}
+}


### PR DESCRIPTION
Workload runs a property test as a CLI binary outside go test, parsing the usual flags from os.Args: --test-cases, --derandomize, --database (empty disables persistence), and the repeatable --suppress-health-check. Defaults to an unbounded test-case budget so it can be used as a soak or fuzzing workload; flags override Option arguments.