### PR TITLE
add WithSingleTestCase for non-replayable workloads

### DIFF
--- a/.github/coverage-ratchet.json
+++ b/.github/coverage-ratchet.json
@@ -1,3 +1,3 @@
 {
-  "coverage_ignore_count": 40
+  "coverage_ignore_count": 39
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release adds `hegel.WithSingleTestCase` (and a matching `--single-test-case` flag on `hegel.Workload`) for long-running workloads or tests whose body is not safely re-runnable on the same inputs — code with external side effects, time-dependent behavior, or execution under Antithesis. Shrinking, replay, and the example database are disabled, and `hegel.RunStateful` loops indefinitely instead of capping at the usual step count.

--- a/generators.go
+++ b/generators.go
@@ -75,7 +75,9 @@ type TestCase interface {
 	// Assume rejects the current test case if condition is false.
 	Assume(condition bool)
 
-	// Note prints message during the final (replay) test case only.
+	// Note prints message during the final (replay) test case or under
+	// [WithSingleTestCase]. Output is routed to t.Log for [Test], or stdout
+	// for [Run].
 	Note(message string)
 
 	// Target sends a target value to guide test generation.
@@ -92,7 +94,8 @@ type TestCase interface {
 	// FailNow marks the test case as failed and stops the test body.
 	FailNow()
 
-	// Log routes the message through Note (only emitted on final replay).
+	// Log routes the message through Note (only emitted on final replay or
+	// under [WithSingleTestCase]).
 	Log(args ...any)
 
 	// doRequest sends a CBOR-encoded request to the server and returns the
@@ -102,6 +105,10 @@ type TestCase interface {
 	// generateFromSchema sends a generate command for schema and returns the
 	// decoded value. Unexported to seal the interface to this package.
 	generateFromSchema(schema map[string]any) (any, error)
+
+	// isSingleTestCase reports whether this case is running under
+	// [WithSingleTestCase]. Unexported to seal the interface to this package.
+	isSingleTestCase() bool
 }
 
 // Draw produces a value from a Generator using the given State context.

--- a/hegel.go
+++ b/hegel.go
@@ -165,6 +165,15 @@
 // CLI flags (--test-cases, --derandomize, --database,
 // --suppress-health-check) and runs the body unbounded by default.
 //
+// # Long-running workloads
+//
+// For workloads whose body is not safely re-runnable on the same inputs —
+// code with external side effects, time-dependent behavior, or execution
+// under Antithesis where the surrounding state evolves between iterations —
+// pass [WithSingleTestCase] (or --single-test-case to [Workload]). Shrinking,
+// replay, and the example database are disabled, and [RunStateful] loops
+// indefinitely instead of capping at the usual step count.
+//
 // # Learning more
 //
 //   - Browse the function documentation for the full list of available

--- a/runner.go
+++ b/runner.go
@@ -19,11 +19,11 @@ import (
 //
 // It is compatible with most popular TestingT interfaces from assert libraries.
 type testCase struct {
-	stream  *stream
-	isFinal bool
-	aborted bool
-	failed  bool         // for T.Error/Fail deferred INTERESTING
-	noteFn  func(string) // injected: t.Log for Test, stdout for Run
+	stream         *stream
+	singleTestCase bool // set when this case runs under WithSingleTestCase
+	aborted        bool
+	failed         bool         // for T.Error/Fail deferred INTERESTING
+	noteFn         func(string) // nil for exploratory cases; t.Log/stdout for final replay / single-case
 }
 
 // --- Sentinel errors ---
@@ -64,7 +64,7 @@ func (s *testCase) Assume(condition bool) {
 }
 
 func (s *testCase) Note(message string) {
-	if s.isFinal && s.noteFn != nil {
+	if s.noteFn != nil {
 		s.noteFn(message)
 	}
 }
@@ -158,6 +158,10 @@ func (s *testCase) doRequest(msg map[string]any) (any, error) {
 // decoded value.
 func (s *testCase) generateFromSchema(schema map[string]any) (any, error) {
 	return s.doRequest(map[string]any{"command": "generate", "schema": schema})
+}
+
+func (s *testCase) isSingleTestCase() bool {
+	return s.singleTestCase
 }
 
 // fatalSentinel is panic'd by T.Fatal/Fatalf/FailNow to mark a test case as INTERESTING.
@@ -254,6 +258,7 @@ type runOptions struct {
 	database            DatabaseSetting
 	derandomize         bool
 	seed                *int64
+	singleTestCase      bool
 	// databaseKey identifies the test for example-database lookups. Set by
 	// [Test] from t.Name(); nil for [Run]/[MustRun] (no test name available).
 	databaseKey []byte
@@ -293,6 +298,20 @@ func WithDerandomize(derandomize bool) Option {
 // WithSeed sets a fixed random seed for the test, making it deterministic.
 func WithSeed(seed int64) Option {
 	return func(o *runOptions) { o.seed = &seed }
+}
+
+// WithSingleTestCase runs exactly one test case with no shrinking, replay, or
+// example database. Use it for long-running workloads or tests whose body is
+// not safely re-runnable on the same inputs — for example, code with external
+// side effects, time-dependent behavior, or execution under Antithesis where
+// the surrounding state evolves between iterations.
+//
+// In this mode [WithTestCases], [WithDatabase], [WithDerandomize], and
+// [SuppressHealthCheck] are ignored. [RunStateful] loops indefinitely (until
+// a rule or invariant fails, or the process is terminated externally) rather
+// than capping at the usual step count.
+func WithSingleTestCase() Option {
+	return func(o *runOptions) { o.singleTestCase = true }
 }
 
 // withDatabaseKey sets the example-database key. Unexported: only [Test]
@@ -450,6 +469,13 @@ func newClient(conn *connection) *client {
 	return &client{conn: conn}
 }
 
+func buildSingleTestCaseMessage(streamID uint32) map[string]any {
+	return map[string]any{
+		"command":   "single_test_case",
+		"stream_id": int64(streamID),
+	}
+}
+
 func buildRunTestMessage(streamID uint32, opts runOptions) map[string]any {
 	msg := map[string]any{
 		"command":     "run_test",
@@ -482,21 +508,35 @@ func buildRunTestMessage(streamID uint32, opts runOptions) map[string]any {
 }
 
 // runTest executes one property test against the server.
+//
+// In single-test-case mode (opts.singleTestCase) the server runs exactly one
+// case via the single_test_case command — no shrinking, replay, or example
+// database. Otherwise it sends run_test and replays any interesting failures
+// after the exploratory phase.
 func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) error {
 	testSt := c.conn.NewStream("Test")
 
-	runTestMsg := buildRunTestMessage(testSt.StreamID(), opts)
-	payload, err := encodeCBOR(runTestMsg)
+	cmdName := "run_test"
+	var cmdMsg map[string]any
+	if opts.singleTestCase {
+		cmdName = "single_test_case"
+		cmdMsg = buildSingleTestCaseMessage(testSt.StreamID())
+	} else {
+		cmdMsg = buildRunTestMessage(testSt.StreamID(), opts)
+	}
+	payload, err := encodeCBOR(cmdMsg)
 	if err != nil { // coverage-ignore
 		panic(fmt.Sprintf("runTest encode: %v", err))
 	}
 
 	if _, err := c.conn.SendControlRequest(payload); err != nil {
-		return fmt.Errorf("run_test send: %w", err)
+		return fmt.Errorf("%s send: %w", cmdName, err)
 	}
 
 	// Event loop.
 	var resultData map[any]any
+	var lastErr error
+testCase:
 	for {
 		msgID, raw, err := testSt.RecvRequestRaw(30 * time.Second)
 		// covered by TempGoProject
@@ -525,22 +565,28 @@ func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) erro
 			if err != nil { // coverage-ignore
 				return fmt.Errorf("connect test case stream: %w", err)
 			}
-			if err := c.runTestCase(caseSt, fn, false, noteFn); err != nil {
-				return err
+
+			var caseNoteFn func(string)
+			if opts.singleTestCase {
+				caseNoteFn = noteFn
+			}
+
+			lastErr = c.runTestCase(caseSt, fn, opts.singleTestCase, caseNoteFn)
+			if lastErr != nil && !errors.Is(lastErr, errPropTestFailed) {
+				return lastErr
 			}
 
 		case "test_done":
 			testSt.SendReplyValue(msgID, true) //nolint:errcheck
 			resultsVal := msg[any("results")]
 			resultData, _ = resultsVal.(map[any]any)
-			goto doneLoop
+			break testCase
 
 		default: // coverage-ignore
 			return fmt.Errorf("unrecognised event %q", event)
 		}
 	}
 
-doneLoop:
 	if resultData == nil { // coverage-ignore
 		panic("resultData is nil after test_done")
 	}
@@ -561,15 +607,15 @@ doneLoop:
 		return fmt.Errorf("flaky test detected: %s", flakyMsg)
 	}
 
-	nInterestingVal := resultData[any("interesting_test_cases")]
-	nInteresting, _ := toInt64(nInterestingVal)
-	if nInteresting == 0 {
-		return nil
+	if opts.singleTestCase {
+		return lastErr
 	}
 
 	// Replay interesting (failing) test cases.
+	nInterestingVal := resultData[any("interesting_test_cases")]
+	nInteresting, _ := toInt64(nInterestingVal)
 	var errs []error
-	for i := int64(0); i < nInteresting; i++ {
+	for i := range nInteresting {
 		msgID, raw, err := testSt.RecvRequestRaw(30 * time.Second)
 		if err != nil { // coverage-ignore
 			return fmt.Errorf("final case recv: %w", err)
@@ -583,34 +629,32 @@ doneLoop:
 		if err != nil { // coverage-ignore
 			return fmt.Errorf("connect final case stream: %w", err)
 		}
-		caseErr := c.runTestCase(caseSt, fn, true, noteFn)
+		caseErr := c.runTestCase(caseSt, fn, false, noteFn)
 		if caseErr != nil {
 			errs = append(errs, caseErr)
 		}
 	}
-	if len(errs) == 0 { // coverage-ignore
-		return nil
-	}
-	if len(errs) == 1 {
-		return errs[0]
-	}
-	return fmt.Errorf("multiple failures: %v", errs) // coverage-ignore
+	return errors.Join(errs...) // coverage-ignore
 }
 
+var errPropTestFailed = errors.New("property test failed")
+
 // runTestCase executes one test case and sends mark_complete to the server.
-func (c *client) runTestCase(st *stream, fn testBody, isFinal bool, noteFn func(string)) (finalErr error) {
+//
+// Returns errPropTestFailed if the test case caused an abort.
+func (c *client) runTestCase(st *stream, fn testBody, singleTestCase bool, noteFn func(string)) error {
 	state := &testCase{
-		stream:  st,
-		isFinal: isFinal,
-		aborted: false,
-		noteFn:  noteFn,
+		stream:         st,
+		singleTestCase: singleTestCase,
+		aborted:        false,
+		noteFn:         noteFn,
 	}
 
-	alreadyComplete := false
+	sendComplete := true
 	status := "VALID"
 	origin := ""
 
-	func() {
+	err := func() (finalErr error) {
 		defer func() {
 			r := recover()
 			if r == nil {
@@ -618,9 +662,7 @@ func (c *client) runTestCase(st *stream, fn testBody, isFinal bool, noteFn func(
 				if state.failed {
 					status = "INTERESTING"
 					origin = "test failed (via t.Error/t.Fail)"
-					if isFinal {
-						finalErr = fmt.Errorf("property test failed: test failed")
-					}
+					finalErr = fmt.Errorf("%w: test failed", errPropTestFailed)
 				}
 				return
 			}
@@ -628,35 +670,28 @@ func (c *client) runTestCase(st *stream, fn testBody, isFinal bool, noteFn func(
 			case assumeRejected:
 				status = "INVALID"
 			case *dataExhausted:
-				alreadyComplete = true
+				sendComplete = false
 			case flakyAbort:
-				alreadyComplete = true
+				sendComplete = false
 			case *connectionError:
-				finalErr = fmt.Errorf("%s", v.msg)
+				// Connection is dead — sending mark_complete would just error.
+				sendComplete = false
+				finalErr = v
 			case fatalSentinel:
 				status = "INTERESTING"
 				origin = extractPanicOrigin(v)
-				if isFinal {
-					finalErr = fmt.Errorf("property test failed: %s", v.msg)
-				}
+				finalErr = fmt.Errorf("%w: %s", errPropTestFailed, v.msg)
 			default:
 				status = "INTERESTING"
 				origin = extractPanicOrigin(v)
-				if isFinal {
-					finalErr = fmt.Errorf("property test failed: %v", v)
-				}
+				finalErr = fmt.Errorf("%w: %v", errPropTestFailed, v)
 			}
 		}()
 		fn(state)
+		return
 	}()
 
-	if finalErr != nil {
-		// connection error or re-raised final failure: close stream and return.
-		st.Close()
-		return finalErr
-	}
-
-	if !alreadyComplete {
+	if sendComplete {
 		var originVal any
 		if origin != "" {
 			originVal = origin
@@ -668,7 +703,7 @@ func (c *client) runTestCase(st *stream, fn testBody, isFinal bool, noteFn func(
 		})
 	}
 	st.Close()
-	return nil
+	return err
 }
 
 // --- Session: manages the hegel subprocess ---

--- a/runner_test.go
+++ b/runner_test.go
@@ -180,11 +180,11 @@ func TestAssumeOutsideContext(t *testing.T) {
 	s.Assume(false)
 }
 
-// --- Note outside context is no-op (isFinal defaults false) ---
+// --- Note outside context is no-op (noteFn nil) ---
 
 func TestNoteOutsideContext(t *testing.T) {
 	t.Parallel()
-	// Note() on a zero-value *testCase should not panic (isFinal=false).
+	// Note() on a zero-value *testCase should not panic (noteFn=nil).
 	s := &testCase{}
 	s.Note("outside context -- safe")
 }
@@ -538,11 +538,11 @@ func TestExtractPanicOriginError(t *testing.T) {
 	}
 }
 
-// --- Note: isFinal=true prints to stderr ---
+// --- Note: non-nil noteFn prints ---
 
-func TestNoteIsFinalTrue(t *testing.T) {
+func TestNoteWithNoteFn(t *testing.T) {
 	t.Parallel()
-	state := &testCase{isFinal: true, noteFn: stdoutNoteFn}
+	state := &testCase{noteFn: stdoutNoteFn}
 	// Should not panic.
 	state.Note("test note on final")
 }

--- a/single_test_case_test.go
+++ b/single_test_case_test.go
@@ -1,0 +1,180 @@
+package hegel
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// --- Unit tests: --single-test-case flag wiring ---
+
+func TestSingleTestCaseFlagSetOption(t *testing.T) {
+	t.Parallel()
+	f := &singleTestCaseFlag{}
+	if !f.IsBoolFlag() {
+		t.Error("IsBoolFlag should be true")
+	}
+	if err := f.Set("true"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if f.String() != "true" {
+		t.Errorf("String=%q want %q", f.String(), "true")
+	}
+	o := applyOpts([]Option{f.Option()})
+	if !o.singleTestCase {
+		t.Error("expected singleTestCase=true")
+	}
+}
+
+func TestSingleTestCaseFlagBadValue(t *testing.T) {
+	t.Parallel()
+	f := &singleTestCaseFlag{}
+	if err := f.Set("maybe"); err == nil {
+		t.Fatal("expected error for non-bool value")
+	}
+}
+
+func TestSingleTestCaseFlagFalseIsNoop(t *testing.T) {
+	t.Parallel()
+	f := &singleTestCaseFlag{}
+	if err := f.Set("false"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	o := applyOpts([]Option{f.Option()})
+	if o.singleTestCase {
+		t.Error("expected singleTestCase=false")
+	}
+}
+
+// --- Integration tests: real hegel binary ---
+
+func TestSingleTestCaseRunsExactlyOnce(t *testing.T) {
+	var count int32
+	err := Run(func(s TestCase) {
+		atomic.AddInt32(&count, 1)
+		_ = Draw[bool](s, Booleans())
+	}, WithSingleTestCase())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("expected exactly 1 test case, got %d", got)
+	}
+}
+
+func TestSingleTestCaseFailureSurfaces(t *testing.T) {
+	err := Run(func(TestCase) {
+		panic("intentional failure")
+	}, WithSingleTestCase())
+	if err == nil {
+		t.Fatal("expected error from failing single test case")
+	}
+	if !strings.Contains(err.Error(), "intentional failure") {
+		t.Errorf("expected error to mention panic message, got: %v", err)
+	}
+}
+
+func TestSingleTestCaseNoteIsVisible(t *testing.T) {
+	const marker = "hello from single test case"
+	var notes []string
+	err := runHegel(func(s TestCase) {
+		s.Note(marker)
+	}, func(msg string) { notes = append(notes, msg) }, []Option{WithSingleTestCase()})
+	if err != nil {
+		t.Fatalf("runHegel: %v", err)
+	}
+	found := false
+	for _, n := range notes {
+		if strings.Contains(n, marker) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected note %q in output, got %v", marker, notes)
+	}
+}
+
+func TestSingleTestCasePermissiveOptions(t *testing.T) {
+	// Combining WithSingleTestCase with other options is permissive — the
+	// extra options simply don't go on the wire.
+	err := Run(func(s TestCase) {
+		_ = Draw[bool](s, Booleans())
+	},
+		WithSingleTestCase(),
+		WithTestCases(50),
+		WithDerandomize(true),
+		WithDatabase(DatabaseDisabled()),
+		SuppressHealthCheck(FilterTooMuch),
+	)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+// --- Stateful unbounded steps ---
+
+type unboundedMachine struct{ n int }
+
+func (m *unboundedMachine) RuleStep(_ TestCase) { m.n++ }
+func (m *unboundedMachine) InvariantBounded(_ TestCase) {
+	// Threshold well above statefulMaxSteps (50), so a successful failure
+	// proves the cap was lifted in single-test-case mode.
+	if m.n >= 200 {
+		panic(fmt.Sprintf("counter reached %d", m.n))
+	}
+}
+
+func TestSingleTestCaseStatefulRunsBeyondDefaultCap(t *testing.T) {
+	m := &unboundedMachine{}
+	err := Run(func(s TestCase) {
+		RunStateful(s, m)
+	}, WithSingleTestCase())
+	if err == nil {
+		t.Fatalf("expected invariant to fail; counter reached %d", m.n)
+	}
+	if m.n <= statefulMaxSteps {
+		t.Errorf("expected >%d steps, got %d (cap not lifted?)", statefulMaxSteps, m.n)
+	}
+	if !strings.Contains(err.Error(), "counter reached") {
+		t.Errorf("expected invariant panic in error, got: %v", err)
+	}
+}
+
+// --- runTest in single-test-case mode: SendControlRequest error (closed connection) ---
+
+func TestRunSingleTestCaseSendControlRequestError(t *testing.T) {
+	t.Parallel()
+	conn, remote := clientConnPair(t)
+	remote.Close()
+
+	cl := newClient(conn)
+	err := cl.runTest(func(_ TestCase) {}, runOptions{singleTestCase: true}, stdoutNoteFn)
+	if err == nil {
+		t.Fatal("expected error from single_test_case send on closed conn")
+	}
+	mustContainStr(t, err.Error(), "single_test_case send")
+}
+
+// --- Workload --single-test-case ---
+
+func TestWorkloadSingleTestCaseFlag(t *testing.T) {
+	var count int32
+	err := workload(
+		[]string{"prog", "--single-test-case"},
+		io.Discard,
+		func(s TestCase) {
+			atomic.AddInt32(&count, 1)
+			_ = Draw[bool](s, Booleans())
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("workload: %v", err)
+	}
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("expected exactly 1 test case, got %d", got)
+	}
+}

--- a/state_test.go
+++ b/state_test.go
@@ -130,8 +130,6 @@ func TestTSkipNowPanicsWithAssumeRejected(t *testing.T) {
 func TestTErrorSetsFailedAndCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	// Make state final so Note actually fires (verify no panic).
-	ht.testCase.isFinal = true
 	noted := false
 	ht.testCase.noteFn = func(msg string) { noted = true }
 	ht.Error("something went wrong")
@@ -146,7 +144,6 @@ func TestTErrorSetsFailedAndCallsNote(t *testing.T) {
 func TestTErrorfSetsFailedAndCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	ht.testCase.isFinal = true
 	noted := false
 	ht.testCase.noteFn = func(msg string) { noted = true }
 	ht.Errorf("error: %d", 99)
@@ -181,7 +178,6 @@ func TestTFailSetsFailed(t *testing.T) {
 func TestTLogCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	ht.testCase.isFinal = true
 	var gotMsg string
 	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
 	ht.Log("hello", " world")
@@ -193,7 +189,6 @@ func TestTLogCallsNote(t *testing.T) {
 func TestTLogfCallsNote(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	ht.testCase.isFinal = true
 	var gotMsg string
 	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
 	ht.Logf("value=%d", 42)

--- a/stateful.go
+++ b/stateful.go
@@ -2,6 +2,7 @@ package hegel
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 )
@@ -96,11 +97,20 @@ func (sm *stateMachine) Run(tc TestCase) {
 		}
 	}
 
-	nSteps := Draw(tc, Integers(1, statefulMaxSteps))
+	// Under WithSingleTestCase the loop runs until a rule or invariant fails
+	// or the process is terminated externally; the retry budget is dropped so
+	// repeated Assume rejections don't cap the run.
+	isSingle := tc.isSingleTestCase()
+	var nSteps int
+	if isSingle {
+		nSteps = math.MaxInt
+	} else {
+		nSteps = Draw(tc, Integers(1, statefulMaxSteps))
+	}
 	stepsSucceeded := 0
 	stepsAttempted := 0
 	step := 0
-	for stepsSucceeded < nSteps && (stepsAttempted < 10*nSteps || (stepsSucceeded == 0 && stepsAttempted < 1000)) {
+	for stepsSucceeded < nSteps && (isSingle || stepsAttempted < 10*nSteps || (stepsSucceeded == 0 && stepsAttempted < 1000)) {
 		step++
 		idx := 0
 		if len(sm.rules) > 1 {

--- a/workload.go
+++ b/workload.go
@@ -42,6 +42,7 @@ func workload(args []string, stderr io.Writer, fn func(TestCase), opts []Option)
 	fs.Var(&derandomizeFlag{}, "derandomize", "use a fixed seed for reproducible runs")
 	fs.Var(&databaseFlag{}, "database", "example database `path`; empty string disables persistence")
 	fs.Var(&suppressHealthCheckFlag{}, "suppress-health-check", "`name` of health check to suppress (repeatable)")
+	fs.Var(&singleTestCaseFlag{}, "single-test-case", "run exactly one test case with no shrinking, replay, or example database")
 
 	if err := fs.Parse(args[1:]); errors.Is(err, flag.ErrHelp) {
 		return nil
@@ -113,6 +114,35 @@ func (f *derandomizeFlag) IsBoolFlag() bool { return true }
 // Option returns the option corresponding to this flag.
 func (f *derandomizeFlag) Option() Option {
 	return WithDerandomize(f.derandomize)
+}
+
+// singleTestCaseFlag wires --single-test-case to [WithSingleTestCase].
+type singleTestCaseFlag struct {
+	singleTestCase bool
+}
+
+func (f *singleTestCaseFlag) String() string {
+	return strconv.FormatBool(f.singleTestCase)
+}
+
+func (f *singleTestCaseFlag) Set(s string) error {
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	f.singleTestCase = b
+	return nil
+}
+
+// IsBoolFlag tells the flag package that --single-test-case parses without a value.
+func (f *singleTestCaseFlag) IsBoolFlag() bool { return true }
+
+// Option returns the option corresponding to this flag.
+func (f *singleTestCaseFlag) Option() Option {
+	if !f.singleTestCase {
+		return func(*runOptions) {}
+	}
+	return WithSingleTestCase()
 }
 
 // databaseFlag wires --database to [WithDatabase]. A non-empty value selects


### PR DESCRIPTION
WithSingleTestCase (and the matching --single-test-case Workload flag) disables shrinking, replay, and the example database. Use it for long-running workloads or tests whose body is not safely re-runnable on the same inputs — code with external side effects, time-dependent behavior, or execution under Antithesis where surrounding state evolves between iterations. RunStateful also loops indefinitely instead of capping at the usual step count.

runTest handles both modes: in single-test-case mode it sends the server's single_test_case command and runs exactly one case as "final" (notes print, body failures surface); otherwise it sends run_test as before. The isFinal flag on TestCase is gone — Note now keys off a non-nil noteFn, and body failures surface as errPropTestFailed which the exploratory caller filters out.