### PR TITLE
Draw: better reporting

### DIFF
--- a/.github/coverage-ratchet.json
+++ b/.github/coverage-ratchet.json
@@ -1,3 +1,3 @@
 {
-  "coverage_ignore_count": 39
+  "coverage_ignore_count": 41
 }

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ func TestMatchesBuiltin(t *testing.T) {
 This test will fail when run with `go test`! Hegel will produce a minimal failing test case for us:
 
 ```
-Draw 1: [0 0]
-    example_test.go:25: slices not equal: [0 0] != [0]
+example_test.go:46: slice1 := hegel.Draw(ht, hegel.Lists(hegel.Integers(math.MinInt, math.MaxInt))) = []int{0, 0}
+example_test.go:50: slices not equal: [0 0] != [0]
 ```
 
 Hegel reports the minimal example showing that our sort is incorrectly dropping duplicates. If we remove `result = slices.Compact(result)` from `mySort()`, this test will then pass (because it's just comparing the standard sort against itself).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: patch
+
+This patch improves the output of failing tests. When a test fails, Hegel now emits a line for every `hegel.Draw` call made during the final replay, echoing the call site, the source statement, and the drawn value:
+
+```
+    example_test.go:46: slice1 := hegel.Draw(...) = []int{0, 0}
+```
+
+If the source file isn't available, a synthesized statement is used instead:
+
+```
+    example_test.go:46: hegel.Draw[[]int](...) = []int{0, 0}
+```
+
+`hegel.T`'s methods, `hegel.Draw`, and other internal frames are also marked as test helpers, so `file:line` decoration from `t.Log`, `t.Fatal`, and friends now points at the user's test body rather than into Hegel's internals.

--- a/composite.go
+++ b/composite.go
@@ -19,6 +19,9 @@ type compositeGenerator[T any] struct {
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
 func (g *compositeGenerator[T]) draw(tc TestCase) (T, error) {
+	if h, ok := tc.(interface{ Helper() }); ok {
+		h.Helper()
+	}
 	return g.fn(tc), nil
 }
 

--- a/composite.go
+++ b/composite.go
@@ -7,22 +7,25 @@ type compositeGenerator[T any] struct {
 	fn func(TestCase) T
 }
 
-// draw invokes the composed function with the given test case.
+// draw invokes the composed function inside a labelComposite span so nested
+// [Draw] reports are suppressed.
 //
-// The user fn calls [Draw], which panics at the exported boundary with the
-// sentinel error types. Those panics propagate up to the runner's recover,
-// which handles them identically to errors returned via the Generator
-// contract — no wrapping generator branches on error type. Letting them
-// through preserves the original stack trace for non-sentinel panics
-// (fatalSentinel from T.Fatal, user panics) so [extractPanicOrigin] can
-// point at the user's code rather than this defer site.
+// Panics from [Draw] (sentinel errors, fatalSentinel, user panics) propagate
+// uncaught so the runner's recover sees the original stack — [extractPanicOrigin]
+// points at the user's code rather than a defer site here.
 //
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
 func (g *compositeGenerator[T]) draw(tc TestCase) (T, error) {
-	if h, ok := tc.(interface{ Helper() }); ok {
-		h.Helper()
+	helper, _ := tc.(interface{ Helper() })
+	if helper != nil {
+		helper.Helper()
 	}
-	return g.fn(tc), nil
+	return withSpan(tc, labelComposite, func() (T, error) {
+		if helper != nil {
+			helper.Helper()
+		}
+		return g.fn(tc), nil
+	})
 }
 
 // asBasic always returns not-basic — composite generators have no schema.

--- a/draw_report.go
+++ b/draw_report.go
@@ -1,0 +1,143 @@
+package hegel
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var drawReportSource = newSourceCache()
+
+type fileLine struct {
+	file string
+	line int
+}
+
+type cachedFile struct {
+	file *ast.File
+	err  error
+}
+
+// sourceCache resolves source positions to printed-statement text. Parse
+// results — both successes and errors — are cached, so a missing or
+// unparseable file is read at most once per process.
+type sourceCache struct {
+	mu         sync.RWMutex
+	fset       *token.FileSet
+	files      map[string]cachedFile
+	statements map[fileLine]string
+}
+
+func newSourceCache() *sourceCache {
+	return &sourceCache{
+		fset:       token.NewFileSet(),
+		files:      make(map[string]cachedFile),
+		statements: make(map[fileLine]string),
+	}
+}
+
+// statementAt returns the source text of the smallest AST statement whose
+// position range covers line in file. Returns "" with err == nil when the
+// file parsed but no statement matches; returns "" with err != nil when the
+// file could not be parsed.
+func (c *sourceCache) statementAt(file string, line int) (string, error) {
+	key := fileLine{file: file, line: line}
+
+	c.mu.RLock()
+	stmt, ok := c.statements[key]
+	c.mu.RUnlock()
+	if ok {
+		return stmt, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.extractLocked(key)
+}
+
+// extractLocked re-checks the cache (a racing goroutine may have populated it
+// between statementAt's RLock and Lock) and otherwise parses the source and
+// records the smallest statement covering the target line. Caller must hold
+// c.mu for writing.
+func (c *sourceCache) extractLocked(key fileLine) (string, error) {
+	if stmt, ok := c.statements[key]; ok {
+		return stmt, nil
+	}
+
+	f, err := c.loadLocked(key.file)
+	if err != nil {
+		return "", err
+	}
+
+	stmt := ""
+	var best ast.Node
+	ast.Inspect(f, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		pos := c.fset.Position(n.Pos()).Line
+		end := c.fset.Position(n.End()).Line
+		if pos > key.line || end < key.line {
+			return false
+		}
+		// Prefer the innermost enclosing statement, but stop at expression
+		// granularity so we report whole assignments, not sub-expressions.
+		if _, isStmt := n.(ast.Stmt); isStmt {
+			best = n
+		}
+		return true
+	})
+	if best != nil {
+		var buf strings.Builder
+		cfg := printer.Config{Mode: printer.UseSpaces, Tabwidth: 4}
+		if perr := cfg.Fprint(&buf, c.fset, best); perr == nil {
+			stmt = buf.String()
+		}
+	}
+	c.statements[key] = stmt
+	return stmt, nil
+}
+
+// loadLocked returns the parsed AST for file, parsing it on first request.
+//
+// Errors are cached. Caller must hold c.mu for writing.
+func (c *sourceCache) loadLocked(file string) (*ast.File, error) {
+	if f, ok := c.files[file]; ok {
+		return f.file, f.err
+	}
+	f, err := parser.ParseFile(c.fset, file, nil, parser.ParseComments)
+	c.files[file] = cachedFile{f, err}
+	return f, err
+}
+
+// formatDrawReport renders one line describing a successful Draw call.
+// Returns "" with a nil error when the caller is internal to the hegel
+// package (e.g. the stateful runner's bookkeeping draws). When omitLocation
+// is true the rendered line drops the leading "file:line: " — callers that
+// route the message through testing.T.Log get that decoration for free.
+func formatDrawReport(skip int, value any, omitLocation bool) (string, error) {
+	_, file, line, ok := runtime.Caller(skip + 1)
+	if !ok { // coverage-ignore
+		return "", fmt.Errorf("runtime.Caller(%d) failed", skip+1)
+	}
+	stmt, _ := drawReportSource.statementAt(file, line)
+	return formatDrawLine(file, line, stmt, value, omitLocation), nil
+}
+
+func formatDrawLine(file string, line int, stmt string, value any, omitLocation bool) string {
+	if stmt == "" {
+		stmt = fmt.Sprintf("hegel.Draw[%T](...) = %#v", value, value)
+	} else {
+		stmt = fmt.Sprintf("%s = %#v", stmt, value)
+	}
+	if omitLocation {
+		return stmt
+	}
+	return fmt.Sprintf("%s:%d: %s", filepath.Base(file), line, stmt)
+}

--- a/draw_report_test.go
+++ b/draw_report_test.go
@@ -1,0 +1,337 @@
+package hegel
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempSource(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "src.go")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil { // coverage-ignore
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
+}
+
+const happyPathSource = `package x
+
+func f() int {
+	return 42
+}
+`
+
+func TestSourceCacheStatementAt(t *testing.T) {
+	t.Parallel()
+	path := writeTempSource(t, happyPathSource)
+	c := newSourceCache()
+
+	got, err := c.statementAt(path, 4)
+	if err != nil {
+		t.Fatalf("statementAt: unexpected err %v", err)
+	}
+	if !strings.Contains(got, "return 42") {
+		t.Fatalf("statementAt: got %q, want substring %q", got, "return 42")
+	}
+}
+
+func TestSourceCacheMissingFile(t *testing.T) {
+	t.Parallel()
+	c := newSourceCache()
+	missing := filepath.Join(t.TempDir(), "nope.go")
+
+	got, err := c.statementAt(missing, 1)
+	if err == nil {
+		t.Fatalf("statementAt(missing): expected err, got nil")
+	}
+	if got != "" {
+		t.Fatalf("statementAt(missing): got %q, want empty", got)
+	}
+	// Failures are cached so we don't re-read a file we already know is
+	// broken. The file entry is recorded; no statement is recorded.
+	if len(c.files) != 1 || len(c.statements) != 0 {
+		t.Fatalf("unexpected cache after failure: files=%d statements=%d", len(c.files), len(c.statements))
+	}
+	// Repeat the lookup; the second call hits the file cache and returns
+	// the same error without re-parsing.
+	got2, err2 := c.statementAt(missing, 1)
+	if err2 == nil {
+		t.Fatal("statementAt(missing) repeat: expected err, got nil")
+	}
+	if got2 != "" {
+		t.Fatalf("statementAt(missing) repeat: got %q, want empty", got2)
+	}
+}
+
+func TestSourceCacheParseError(t *testing.T) {
+	t.Parallel()
+	path := writeTempSource(t, "this is not go\n")
+	c := newSourceCache()
+
+	got, err := c.statementAt(path, 1)
+	if err == nil {
+		t.Fatalf("statementAt(invalid): expected err, got nil")
+	}
+	if got != "" {
+		t.Fatalf("statementAt(invalid): got %q, want empty", got)
+	}
+}
+
+func TestSourceCacheLineOutOfRange(t *testing.T) {
+	t.Parallel()
+	path := writeTempSource(t, happyPathSource)
+	c := newSourceCache()
+
+	got, err := c.statementAt(path, 999)
+	if err != nil {
+		t.Fatalf("statementAt(line=999): unexpected err %v", err)
+	}
+	if got != "" {
+		t.Fatalf("statementAt(line=999): got %q, want empty", got)
+	}
+}
+
+func TestSourceCacheStatementHit(t *testing.T) {
+	t.Parallel()
+	path := writeTempSource(t, happyPathSource)
+	c := newSourceCache()
+
+	first, err := c.statementAt(path, 4)
+	if err != nil || first == "" {
+		t.Fatalf("first lookup: %q err=%v", first, err)
+	}
+
+	// Delete the file; the second call with the same key must hit the
+	// statement cache without touching disk.
+	if err := os.Remove(path); err != nil { // coverage-ignore
+		t.Fatalf("remove: %v", err)
+	}
+	second, err := c.statementAt(path, 4)
+	if err != nil {
+		t.Fatalf("second lookup: unexpected err %v", err)
+	}
+	if second != first {
+		t.Fatalf("cache miss after delete: got %q, want %q", second, first)
+	}
+}
+
+func TestSourceCacheExtractLockedRevalidates(t *testing.T) {
+	t.Parallel()
+	c := newSourceCache()
+	key := fileLine{file: "preempted.go", line: 1}
+	// Simulate another goroutine populating the statement cache between
+	// statementAt's read-lock miss and the write-lock acquisition. extractLocked
+	// must re-check and return the existing value instead of re-extracting.
+	c.mu.Lock()
+	c.statements[key] = "racing winner"
+	got, err := c.extractLocked(key)
+	c.mu.Unlock()
+
+	if err != nil {
+		t.Fatalf("extractLocked: unexpected err %v", err)
+	}
+	if got != "racing winner" {
+		t.Fatalf("extractLocked: got %q, want %q (lock-held re-check failed)", got, "racing winner")
+	}
+}
+
+func TestSourceCacheFileReuse(t *testing.T) {
+	t.Parallel()
+	path := writeTempSource(t, happyPathSource)
+	c := newSourceCache()
+
+	// Prime the file cache for path; the statement cache only holds (path, 4).
+	if got, err := c.statementAt(path, 4); err != nil || !strings.Contains(got, "return 42") {
+		t.Fatalf("first lookup: %q err=%v", got, err)
+	}
+	// Delete the source on disk. A second lookup at a different line must
+	// bypass the statement cache and reuse the parsed AST — proves load's
+	// cache-hit branch is reached.
+	if err := os.Remove(path); err != nil { // coverage-ignore
+		t.Fatalf("remove: %v", err)
+	}
+	got, err := c.statementAt(path, 3)
+	if err != nil {
+		t.Fatalf("second lookup: unexpected err %v", err)
+	}
+	if got == "" {
+		t.Fatalf("second lookup at different line returned empty; AST cache not reused")
+	}
+}
+
+const multiLineSource = `package x
+
+func f() int {
+	return 1 +
+		2 +
+		3
+}
+`
+
+func TestSourceCacheMultiLineStatement(t *testing.T) {
+	t.Parallel()
+	path := writeTempSource(t, multiLineSource)
+	c := newSourceCache()
+
+	// Asking for the middle line of a multi-line return should return
+	// the whole return statement — exercises the pos < line <= end branch.
+	got, err := c.statementAt(path, 5)
+	if err != nil {
+		t.Fatalf("statementAt: unexpected err %v", err)
+	}
+	for _, want := range []string{"return 1 +", "2 +", "3"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("statementAt: got %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestFormatDrawLineWithStatement(t *testing.T) {
+	t.Parallel()
+	got := formatDrawLine("/abs/path/example_test.go", 42, "x := hegel.Draw(...)", []int{0, 0}, false)
+	want := "example_test.go:42: x := hegel.Draw(...) = []int{0, 0}"
+	if got != want {
+		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
+	}
+}
+
+func TestFormatDrawLineWithoutStatement(t *testing.T) {
+	t.Parallel()
+	got := formatDrawLine("/abs/path/example_test.go", 42, "", 7, false)
+	want := "example_test.go:42: hegel.Draw[int](...) = 7"
+	if got != want {
+		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
+	}
+}
+
+func TestFormatDrawLineOmitLocationWithStatement(t *testing.T) {
+	t.Parallel()
+	got := formatDrawLine("/abs/path/example_test.go", 42, "x := hegel.Draw(...)", []int{0, 0}, true)
+	want := "x := hegel.Draw(...) = []int{0, 0}"
+	if got != want {
+		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
+	}
+}
+
+func TestFormatDrawLineOmitLocationWithoutStatement(t *testing.T) {
+	t.Parallel()
+	got := formatDrawLine("/abs/path/example_test.go", 42, "", 7, true)
+	want := "hegel.Draw[int](...) = 7"
+	if got != want {
+		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
+	}
+}
+
+func TestDrawReportInProcess(t *testing.T) {
+	captured := captureStdout(t, func() {
+		if err := Run(func(tc TestCase) {
+			_ = Draw(tc, Integers(0, 100))
+		}, WithSingleTestCase()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+	if !strings.Contains(captured, "draw_report_test.go:") {
+		t.Fatalf("expected draw report in output, got:\n%s", captured)
+	}
+	if !strings.Contains(captured, "Draw(tc, Integers(0, 100))") {
+		t.Fatalf("expected statement text in output, got:\n%s", captured)
+	}
+}
+
+// Inner Draws inside the Composite element fire at depth > 0 under the Lists
+// span and must be suppressed.
+func TestDrawReportSuppressedInsideSpan(t *testing.T) {
+	gen := Lists(Composite(func(tc TestCase) int {
+		return Draw(tc, Integers(0, 100))
+	})).MinSize(2).MaxSize(2)
+
+	captured := captureStdout(t, func() {
+		if err := Run(func(tc TestCase) {
+			_ = Draw(tc, gen)
+		}, WithSingleTestCase()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	got := strings.Count(captured, "draw_report_test.go:")
+	if got != 1 {
+		t.Fatalf("expected exactly 1 draw line in output, got %d:\n%s", got, captured)
+	}
+	if !strings.Contains(captured, "Draw(tc, gen)") {
+		t.Fatalf("expected outer Draw statement text in output, got:\n%s", captured)
+	}
+}
+
+// Isolates labelComposite from labelList: a top-level Composite must
+// suppress its own inner Draws even without an enclosing Lists span.
+func TestDrawReportSuppressedInsideComposite(t *testing.T) {
+	gen := Composite(func(tc TestCase) int {
+		a := Draw(tc, Integers(0, 100))
+		b := Draw(tc, Integers(0, 100))
+		return a + b
+	})
+
+	captured := captureStdout(t, func() {
+		if err := Run(func(tc TestCase) {
+			_ = Draw(tc, gen)
+		}, WithSingleTestCase()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	got := strings.Count(captured, "draw_report_test.go:")
+	if got != 1 {
+		t.Fatalf("expected exactly 1 draw line in output, got %d:\n%s", got, captured)
+	}
+	if !strings.Contains(captured, "Draw(tc, gen)") {
+		t.Fatalf("expected outer Draw statement text in output, got:\n%s", captured)
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn. Not safe for
+// concurrent test execution — caller must not use t.Parallel.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	saved := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		done <- string(buf)
+	}()
+
+	fn()
+	w.Close()
+	os.Stdout = saved
+	return <-done
+}
+
+func TestIsHegelFrameExternalTestPackage(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		fn   string
+		want bool
+	}{
+		{"hegel.dev/go/hegel.Draw[...]", true},
+		{"hegel.dev/go/hegel", true},
+		{"hegel.dev/go/hegel/internal/foo.Bar", true},
+		{"hegel.dev/go/hegel_test.TestSomething", false},
+		{"hegel.dev/go/hegelfoo.Bar", false},
+		{"testing.tRunner", false},
+		{"short", false},
+	}
+	for _, tc := range cases {
+		if got := isHegelFrame(tc.fn); got != tc.want {
+			t.Errorf("isHegelFrame(%q) = %v, want %v", tc.fn, got, tc.want)
+		}
+	}
+}

--- a/generators.go
+++ b/generators.go
@@ -113,6 +113,15 @@ type TestCase interface {
 
 // Draw produces a value from a Generator using the given State context.
 func Draw[T any](tc TestCase, g Generator[T]) T {
+	// Mark Draw as a t.Helper so the noteFn-driven t.Log decoration points
+	// at the user's call site rather than this function. The interface
+	// check avoids referring to *T by name (which would collide with the
+	// type parameter) and gracefully skips the *testCase branch, where
+	// notes route through stdout without file:line decoration.
+	if h, ok := tc.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+
 	v, err := g.draw(tc)
 	if err != nil {
 		panic(err)

--- a/generators.go
+++ b/generators.go
@@ -40,6 +40,11 @@ const (
 	// labelStateful marks a single rule or invariant call inside a stateful
 	// test, letting the shrinker treat each step as an atomic unit.
 	labelStateful spanLabel = 16
+	// labelComposite marks a composite generator's body, so draws inside
+	// the body are bracketed in a span. This lets [Draw] suppress nested
+	// draw reports the same way it does for element generators inside
+	// Lists/Maps/OneOf.
+	labelComposite spanLabel = 17
 )
 
 // --- Generator interface ---
@@ -109,22 +114,42 @@ type TestCase interface {
 	// isSingleTestCase reports whether this case is running under
 	// [WithSingleTestCase]. Unexported to seal the interface to this package.
 	isSingleTestCase() bool
+
+	// maybeNoteFn returns the note function for this test case, or nil if
+	// notes are suppressed (the exploratory phase).
+	maybeNoteFn() func(string)
+
+	// startSpan notifies the server that a new generation span has started.
+	startSpan(label spanLabel) error
+
+	// stopSpan notifies the server that the current generation span has ended.
+	stopSpan(discard bool) error
+
+	// inSpan reports whether the test case is inside one or more
+	// generation spans.
+	inSpan() bool
 }
 
 // Draw produces a value from a Generator using the given State context.
 func Draw[T any](tc TestCase, g Generator[T]) T {
-	// Mark Draw as a t.Helper so the noteFn-driven t.Log decoration points
-	// at the user's call site rather than this function. The interface
-	// check avoids referring to *T by name (which would collide with the
-	// type parameter) and gracefully skips the *testCase branch, where
-	// notes route through stdout without file:line decoration.
-	if h, ok := tc.(interface{ Helper() }); ok {
+	h, hasTestingT := tc.(interface{ Helper() })
+	if hasTestingT {
 		h.Helper()
 	}
 
 	v, err := g.draw(tc)
 	if err != nil {
 		panic(err)
+	}
+	// Nested draws are reported as part of the parent's value.
+	if fn := tc.maybeNoteFn(); fn != nil && !tc.inSpan() {
+		msg, err := formatDrawReport(1, v, hasTestingT)
+		if err != nil { // coverage-ignore
+			panic(err)
+		}
+		if msg != "" {
+			fn(msg)
+		}
 	}
 	return v
 }
@@ -206,7 +231,7 @@ const maxFilterAttempts = 3
 func (g *filteredGenerator[T]) draw(tc TestCase) (T, error) {
 	var zero T
 	for range maxFilterAttempts {
-		if err := startSpan(tc, labelFilter); err != nil {
+		if err := tc.startSpan(labelFilter); err != nil {
 			return zero, err
 		}
 		value, err := g.source.draw(tc)
@@ -214,12 +239,12 @@ func (g *filteredGenerator[T]) draw(tc TestCase) (T, error) {
 			return zero, err
 		}
 		if g.predicate(value) {
-			if err := stopSpan(tc, false); err != nil { // coverage-ignore
+			if err := tc.stopSpan(false); err != nil { // coverage-ignore
 				return zero, err
 			}
 			return value, nil
 		}
-		if err := stopSpan(tc, true); err != nil { // coverage-ignore
+		if err := tc.stopSpan(true); err != nil { // coverage-ignore
 			return zero, err
 		}
 	}
@@ -296,42 +321,27 @@ func Filter[T any](g Generator[T], pred func(T) bool) Generator[T] {
 
 // --- Span helpers ---
 
-// startSpan notifies the server that a new generation span has started.
-func startSpan(tc TestCase, label spanLabel) error {
-	_, err := tc.doRequest(map[string]any{
-		"command": "start_span",
-		"label":   int64(label),
-	})
-	return err
-}
-
-// stopSpan notifies the server that the current generation span has ended.
-func stopSpan(tc TestCase, discard bool) error {
-	_, err := tc.doRequest(map[string]any{
-		"command": "stop_span",
-		"discard": discard,
-	})
-	return err
-}
-
 // withSpan brackets body in a span that always commits (discard=false).
 //
 // On body error the span is left open: every error path here is a sentinel
 // that aborts the test case (dataExhausted, flakyAbort, connectionError,
 // assumeRejected), and the runner tears down server-side state regardless.
 //
-// Use the inline startSpan/stopSpan pair when the discard decision depends
-// on the body's outcome (see filteredGenerator.draw).
+// Use the inline (*testCase).startSpan/stopSpan pair when the discard
+// decision depends on the body's outcome (see filteredGenerator.draw).
 func withSpan[T any](tc TestCase, label spanLabel, body func() (T, error)) (T, error) {
+	if h, ok := tc.(interface{ Helper() }); ok {
+		h.Helper()
+	}
 	var zero T
-	if err := startSpan(tc, label); err != nil {
+	if err := tc.startSpan(label); err != nil {
 		return zero, err
 	}
 	v, err := body()
 	if err != nil {
 		return zero, err
 	}
-	if err := stopSpan(tc, false); err != nil { // coverage-ignore
+	if err := tc.stopSpan(false); err != nil { // coverage-ignore
 		return zero, err
 	}
 	return v, nil

--- a/generators_test.go
+++ b/generators_test.go
@@ -137,6 +137,7 @@ func TestLabelConstants(t *testing.T) {
 		{"Mapped", labelMapped, 13},
 		{"SampledFrom", labelSampledFrom, 14},
 		{"EnumVariant", labelEnumVariant, 15},
+		{"Composite", labelComposite, 17},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1117,13 +1118,13 @@ func TestExtractFloatAsFloat64(t *testing.T) {
 }
 
 // =============================================================================
-// startSpan/stopSpan: aborted path returns errTestCaseAborted
+// (*testCase).startSpan / (*testCase).stopSpan: aborted path returns errTestCaseAborted
 // =============================================================================
 
 func TestStartSpanAborted(t *testing.T) {
 	t.Parallel()
 	s := &testCase{aborted: true}
-	if err := startSpan(s, labelOneOf); !errors.Is(err, errTestCaseAborted) {
+	if err := s.startSpan(labelOneOf); !errors.Is(err, errTestCaseAborted) {
 		t.Fatalf("startSpan on aborted: got %v, want errTestCaseAborted", err)
 	}
 }
@@ -1131,8 +1132,21 @@ func TestStartSpanAborted(t *testing.T) {
 func TestStopSpanAborted(t *testing.T) {
 	t.Parallel()
 	s := &testCase{aborted: true}
-	if err := stopSpan(s, false); !errors.Is(err, errTestCaseAborted) {
+	if err := s.stopSpan(false); !errors.Is(err, errTestCaseAborted) {
 		t.Fatalf("stopSpan on aborted: got %v, want errTestCaseAborted", err)
+	}
+}
+
+// TestInSpan verifies that (*testCase).inSpan reflects the depth counter.
+func TestInSpan(t *testing.T) {
+	t.Parallel()
+	s := &testCase{}
+	if s.inSpan() {
+		t.Fatalf("inSpan at depth 0: got true, want false")
+	}
+	s.depth = 1
+	if !s.inSpan() {
+		t.Fatalf("inSpan at depth 1: got false, want true")
 	}
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -45,14 +45,15 @@ panic("force final replay")`, "hegel.WithTestCases(1)").
 }
 
 // TestDrawDecoratesWithUserFileLine verifies the helper marking on Draw lets
-// the noteFn-driven t.Log decoration point at the user's file, in addition to
-// the file:line baked into the draw-report message text itself.
+// the noteFn-driven t.Log decoration point at the user's file. When Draw runs
+// under *T the formatter omits its own file:line prefix so the t.Log
+// decoration is the only one present.
 func TestDrawDecoratesWithUserFileLine(t *testing.T) {
 	t.Parallel()
 	newTempGoProject(t).
 		testBody(`_ = hegel.Draw(ht, hegel.Integers(0, 100))
 panic("force final replay")`, "hegel.WithTestCases(1)").
-		expectFailure(`hegel_test\.go:\d+: hegel_test\.go:\d+: _ = hegel\.Draw\(ht, hegel\.Integers\(0, 100\)\)`).
+		expectFailure(`(?m)^\s+hegel_test\.go:\d+: _ = hegel\.Draw\(ht, hegel\.Integers\(0, 100\)\)`).
 		goTest()
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,80 @@
+package hegel
+
+import "testing"
+
+// These tests verify that the t.Helper() calls inside T.Fatal, T.Fatalf, and
+// T.Logf cause t.Log to decorate output with the user's test file:line, not
+// the hegel-go source location. The output flows:
+//
+//   user test → ht.Fatal/Fatalf/Logf → noteFn closure → t.Log
+//
+// All intermediate frames between t.Log and the user's test body need to be
+// marked as helpers; otherwise t.Log reports the first non-helper frame.
+
+func TestTFatalDecoratesWithUserFileLine(t *testing.T) {
+	t.Parallel()
+	newTempGoProject(t).
+		testBody(`ht.Fatal("BOOM-fatal")`, "hegel.WithTestCases(1)").
+		expectFailure(`hegel_test\.go:\d+: BOOM-fatal`).
+		goTest()
+}
+
+func TestTFatalfDecoratesWithUserFileLine(t *testing.T) {
+	t.Parallel()
+	newTempGoProject(t).
+		testBody(`ht.Fatalf("BOOM-fatalf %d", 7)`, "hegel.WithTestCases(1)").
+		expectFailure(`hegel_test\.go:\d+: BOOM-fatalf 7`).
+		goTest()
+}
+
+func TestTErrorDecoratesWithUserFileLine(t *testing.T) {
+	t.Parallel()
+	newTempGoProject(t).
+		testBody(`ht.Error("BOOM-error")`, "hegel.WithTestCases(1)").
+		expectFailure(`hegel_test\.go:\d+: BOOM-error`).
+		goTest()
+}
+
+func TestTLogfDecoratesWithUserFileLine(t *testing.T) {
+	t.Parallel()
+	newTempGoProject(t).
+		testBody(`ht.Logf("BOOM-logf %d", 9)
+panic("force final replay")`, "hegel.WithTestCases(1)").
+		expectFailure(`hegel_test\.go:\d+: BOOM-logf 9`).
+		goTest()
+}
+
+// TestDrawDecoratesWithUserFileLine verifies the helper marking on Draw lets
+// the noteFn-driven t.Log decoration point at the user's file, in addition to
+// the file:line baked into the draw-report message text itself.
+func TestDrawDecoratesWithUserFileLine(t *testing.T) {
+	t.Parallel()
+	newTempGoProject(t).
+		testBody(`_ = hegel.Draw(ht, hegel.Integers(0, 100))
+panic("force final replay")`, "hegel.WithTestCases(1)").
+		expectFailure(`hegel_test\.go:\d+: hegel_test\.go:\d+: _ = hegel\.Draw\(ht, hegel\.Integers\(0, 100\)\)`).
+		goTest()
+}
+
+// TestNoteInsideCompositeDecoratesWithUserFileLine verifies that tc.Note()
+// called from within a Composite generator's callback decorates with the
+// user's test file, not an internal hegel source location.
+//
+// The path is: user's Composite callback → testCase.Note → noteFn closure →
+// t.Log. Every frame between t.Log and the user's body needs to be marked as
+// a helper; testCase.Note and compositeGenerator.draw are the two non-helper
+// frames that this case exposes.
+func TestNoteInsideCompositeDecoratesWithUserFileLine(t *testing.T) {
+	t.Parallel()
+	newTempGoProject(t).
+		testBody(`c := hegel.Composite(func(tc hegel.TestCase) int {
+	tc.(*hegel.T).Helper()
+	tc.Note("BOOM-composite-note")
+	return 0
+})
+_ = hegel.Draw(ht, c)
+ht.Fail()
+`, "hegel.WithSingleTestCase()").
+		expectFailure(`(?m)^\s+hegel_test\.go:\d+: BOOM-composite-note`).
+		goTest()
+}

--- a/runner.go
+++ b/runner.go
@@ -24,6 +24,7 @@ type testCase struct {
 	aborted        bool
 	failed         bool         // for T.Error/Fail deferred INTERESTING
 	noteFn         func(string) // nil for exploratory cases; t.Log/stdout for final replay / single-case
+	depth          int          // current span nesting depth; >0 inside a generation span
 }
 
 // --- Sentinel errors ---
@@ -162,6 +163,36 @@ func (s *testCase) generateFromSchema(schema map[string]any) (any, error) {
 
 func (s *testCase) isSingleTestCase() bool {
 	return s.singleTestCase
+}
+
+func (s *testCase) maybeNoteFn() func(string) {
+	return s.noteFn
+}
+
+func (s *testCase) startSpan(label spanLabel) error {
+	if _, err := s.doRequest(map[string]any{
+		"command": "start_span",
+		"label":   int64(label),
+	}); err != nil {
+		return err
+	}
+	s.depth++
+	return nil
+}
+
+func (s *testCase) stopSpan(discard bool) error {
+	if _, err := s.doRequest(map[string]any{
+		"command": "stop_span",
+		"discard": discard,
+	}); err != nil {
+		return err
+	}
+	s.depth--
+	return nil
+}
+
+func (s *testCase) inSpan() bool {
+	return s.depth > 0
 }
 
 // fatalSentinel is panic'd by T.Fatal/Fatalf/FailNow to mark a test case as INTERESTING.
@@ -453,7 +484,17 @@ func extractPanicOrigin(v any) string {
 }
 
 func isHegelFrame(fn string) bool {
-	return strings.HasPrefix(fn, "hegel.dev/go/hegel")
+	const pkg = "hegel.dev/go/hegel"
+	if !strings.HasPrefix(fn, pkg) {
+		return false
+	}
+	if len(fn) == len(pkg) {
+		return true
+	}
+	// "hegel.dev/go/hegel.Func" or "hegel.dev/go/hegel/sub.Func" → internal.
+	// "hegel.dev/go/hegel_test.Func" → external (test package), not internal.
+	next := fn[len(pkg)]
+	return next == '.' || next == '/'
 }
 
 // --- Client: manages a single connection's test lifecycle ---

--- a/runner.go
+++ b/runner.go
@@ -382,8 +382,8 @@ func Test(t *testing.T, fn func(*T), opts ...Option) {
 		fn(ht)
 	}
 	allOpts := append(opts, withDatabaseKey([]byte(t.Name())))
-	err := runHegel(body, func(msg string) { t.Log(msg) }, allOpts) // coverage-ignore
-	if err != nil {                                                 // coverage-ignore
+	err := runHegel(body, func(msg string) { t.Helper(); t.Log(msg) }, allOpts) // coverage-ignore
+	if err != nil {                                                             // coverage-ignore
 		t.Fatal(err)
 	}
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -931,6 +931,16 @@ panic("always fail for final replay")`, "hegel.WithTestCases(1)").
 		goTest()
 }
 
+func TestDrawReportOnFinal(t *testing.T) {
+	t.Parallel()
+
+	newTempGoProject(t).
+		testBody(`n := hegel.Draw(ht, hegel.Integers(0, 100))
+ht.Fatalf("got %d", n)`, "hegel.WithTestCases(1)").
+		expectFailure(`hegel_test\.go:\d+: n := hegel\.Draw\(ht, hegel\.Integers\(0, 100\)\) = \d+`).
+		goTest()
+}
+
 // --- hegelCommand: covered in installer_test.go ---
 
 // --- runTest: SendControlRequest error (closed connection) ---

--- a/state.go
+++ b/state.go
@@ -45,26 +45,30 @@ type T struct {
 // Fatal logs the message via [TestCase.Note] and marks the test case as failed.
 func (t *T) Fatal(args ...any) {
 	msg := fmt.Sprint(args...)
-	t.Note(msg)
+	if t.noteFn != nil {
+		t.Helper()
+		t.noteFn(msg)
+	}
 	panic(fatalSentinel{msg: msg})
 }
 
 // Fatalf logs the formatted message via [TestCase.Note] and marks the test case as failed.
 func (t *T) Fatalf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	t.Note(msg)
+	if t.noteFn != nil {
+		t.Helper()
+		t.noteFn(msg)
+	}
 	panic(fatalSentinel{msg: msg})
 }
 
 // Skip discards the current test case.
-func (t *T) Skip(args ...any) {
-	_ = args
+func (t *T) Skip(_ ...any) {
 	t.Assume(false)
 }
 
 // Skipf discards the current test case.
-func (t *T) Skipf(format string, args ...any) {
-	_, _ = format, args
+func (t *T) Skipf(_ string, _ ...any) {
 	t.Assume(false)
 }
 
@@ -78,7 +82,10 @@ func (t *T) SkipNow() {
 // The test case continues running but will be treated as a failure after return.
 func (t *T) Error(args ...any) {
 	msg := fmt.Sprint(args...)
-	t.Note(msg)
+	if t.noteFn != nil {
+		t.Helper()
+		t.noteFn(msg)
+	}
 	t.testCase.Fail()
 }
 
@@ -89,7 +96,19 @@ func (t *T) Failed() bool {
 
 // Logf routes the formatted message through [TestCase.Note].
 func (t *T) Logf(format string, args ...any) {
-	t.Note(fmt.Sprintf(format, args...))
+	if t.noteFn != nil {
+		t.Helper()
+		t.noteFn(fmt.Sprintf(format, args...))
+	}
+}
+
+// Note routes the message through [TestCase.Note], marking this frame as a
+// helper so the noteFn-driven t.Log decoration walks past it to user code.
+func (t *T) Note(message string) {
+	if t.noteFn != nil {
+		t.Helper()
+		t.noteFn(message)
+	}
 }
 
 // Run aborts the test — nested sub-tests inside a Hegel property test are not supported.

--- a/state_test.go
+++ b/state_test.go
@@ -36,6 +36,20 @@ func TestTFatalPanicsWithSentinel(t *testing.T) {
 	ht.Fatal("fatal message")
 }
 
+func TestTFatalCallsNoteFn(t *testing.T) {
+	t.Parallel()
+	ht := makeFakeT(t)
+	var gotMsg string
+	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
+	defer func() {
+		_ = recover()
+		if gotMsg != "fatal message" {
+			t.Errorf("expected note %q, got %q", "fatal message", gotMsg)
+		}
+	}()
+	ht.Fatal("fatal message")
+}
+
 func TestTFatalfPanicsWithSentinel(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
@@ -53,6 +67,20 @@ func TestTFatalfPanicsWithSentinel(t *testing.T) {
 		}
 	}()
 	ht.Fatalf("fatal: %d", 42)
+}
+
+func TestTFatalfCallsNoteFn(t *testing.T) {
+	t.Parallel()
+	ht := makeFakeT(t)
+	var gotMsg string
+	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
+	defer func() {
+		_ = recover()
+		if gotMsg != "fatal: 99" {
+			t.Errorf("expected note %q, got %q", "fatal: 99", gotMsg)
+		}
+	}()
+	ht.Fatalf("fatal: %d", 99)
 }
 
 func TestTFailNowPanicsWithSentinel(t *testing.T) {
@@ -194,6 +222,17 @@ func TestTLogfCallsNote(t *testing.T) {
 	ht.Logf("value=%d", 42)
 	if gotMsg != "value=42" {
 		t.Errorf("expected %q, got %q", "value=42", gotMsg)
+	}
+}
+
+func TestTNoteCallsNoteFn(t *testing.T) {
+	t.Parallel()
+	ht := makeFakeT(t)
+	var gotMsg string
+	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
+	ht.Note("a note")
+	if gotMsg != "a note" {
+		t.Errorf("expected %q, got %q", "a note", gotMsg)
 	}
 }
 

--- a/temp_project_test.go
+++ b/temp_project_test.go
@@ -116,6 +116,7 @@ func (p *tempGoProject) expectFailure(pattern string) *tempGoProject {
 // output is flushed regardless of pass/fail, so callers can grep for
 // note/log sentinels emitted by the test body.
 func (p *tempGoProject) goTest(args ...string) runOutput {
+	p.t.Helper()
 	return p.run(append([]string{"test", "-v", "./..."}, args...))
 }
 


### PR DESCRIPTION
report source-line context on each Draw during final replay

    Hegel's failing-test output previously surfaced only user notes plus the
    body's own error message. We now emit a line for every Draw call whose
    s.noteFn is active (final replay, or WithSingleTestCase), echoing the call
    site, source statement, and drawn value:

        example_test.go:46: slice1 := hegel.Draw(...) = []int{0, 0}

    draw_report.go provides a process-wide sourceCache that parses Go files
    lazily and uses go/ast + go/printer to extract the smallest statement
    covering the caller's line. We synthesis an source statement if the source
    code isn't available:

        example_test.go:46: hegel.Draw[[]int](...) = []int{0, 0}

    Caller resolution skips frames inside hegel.dev/go/hegel so internal draws
    (e.g. the stateful runner's scheduling) don't pollute output; the 
    isHegelFrame check was tightened to require a "." or "/" boundary so the 
    external hegel_test package is not mistaken for an internal frame.
