### PR TITLE
claude: factor tool install into a composite action

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -1,0 +1,31 @@
+name: Install tools
+inputs:
+  tools:
+    required: true
+runs:
+  using: composite
+  steps:
+    - id: parse
+      env:
+        TOOLS: ${{ inputs.tools }}
+      # The allowlist below doubles as input validation. Adding a new tool
+      # means extending the case-statement AND adding a matching install step.
+      run: |
+        for tool in $TOOLS; do
+          case "$tool" in
+            just|uv) echo "$tool=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Unknown tool: $tool"; exit 1 ;;
+          esac
+        done
+      shell: bash
+    - if: steps.parse.outputs.just == 'true' && runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y just
+      shell: bash
+    - if: steps.parse.outputs.just == 'true' && runner.os == 'Windows'
+      run: choco install just -y --no-progress
+      shell: pwsh
+    - if: steps.parse.outputs.just == 'true' && runner.os == 'macOS'
+      run: brew install just
+      shell: bash
+    - if: steps.parse.outputs.uv == 'true'
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
         with:
           go-version: stable
 
-      - name: Install just
-        run: sudo apt-get update && sudo apt-get install -y just
+      - uses: ./.github/actions/install-tools
+        with:
+          tools: just
 
       - name: Lint
         run: just lint
@@ -59,9 +60,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install just
-        run: sudo apt-get update && sudo apt-get install -y just
-      - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+      - uses: ./.github/actions/install-tools
+        with:
+          tools: just uv
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -118,8 +119,9 @@ jobs:
         with:
           go-version: stable
 
-      - name: Install just
-        run: sudo apt-get update && sudo apt-get install -y just
+      - uses: ./.github/actions/install-tools
+        with:
+          tools: just
 
       - name: Check docs
         run: just check-docs
@@ -134,9 +136,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install just
-        run: sudo apt-get update && sudo apt-get install -y just
-      - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+      - uses: ./.github/actions/install-tools
+        with:
+          tools: just uv
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Factors the per-job tool install into a composite action, mirroring the same `.github/actions/install-tools` setup hegel-rust uses. The four existing call sites in `ci.yml` (lint, test, docs, conformance) now consume the composite instead of repeating `sudo apt-get install -y just` and `astral-sh/setup-uv` inline.

The composite is a verbatim copy of hegel-rust's, including the per-OS branches (`apt-get` on Linux, `choco install` on Windows, `brew install` on macOS). Hegel-go only runs on `ubuntu-latest` today, so the non-Linux branches are dormant — they're there to keep the file aligned with hegel-rust so a future hoist into a shared action is a no-op rename.

One incidental version bump: `astral-sh/setup-uv` moves from `v6` to `v7.6.0`, matching hegel-rust's pin.

### Self-review findings the human reviewer should know about

The code-reviewer subagent raised one finding I did not act on:

> The test job carries `permissions: contents: write, pull-requests: write` for both matrix entries (`oldstable` and `stable`), even though only the `stable` + non-fork entry actually runs the ratchet auto-update step. zizmor's `excessive-permissions` audit may eventually flag the `oldstable` row.

This pre-exists the PR (it's unchanged from main); I'd rather not bundle a permissions split into this CI-refactor PR. Worth a follow-up.

</details>
