### PR TITLE
Clean up test output

### DIFF
--- a/.github/coverage-ratchet.json
+++ b/.github/coverage-ratchet.json
@@ -1,3 +1,3 @@
 {
-  "coverage_ignore_count": 41
+  "coverage_ignore_count": 39
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -221,7 +221,6 @@ func TestCompositeRecursiveE2E(t *testing.T) {
 // value triggers a failure, the engine shrinks toward a minimal failing input.
 func TestCompositeShrinksToFailingCase(t *testing.T) {
 	t.Parallel()
-
 	// Generator: a struct with two ints. Property under test: a + b < 100.
 	// Smallest counterexample: a=0, b=100 (or a=100, b=0).
 	type pair struct{ a, b int }
@@ -233,7 +232,7 @@ func TestCompositeShrinksToFailingCase(t *testing.T) {
 	})
 
 	var minimalA, minimalB int
-	err := Run(func(s TestCase) {
+	err := run(func(s TestCase) {
 		p := Draw(s, pairGen)
 		if p.a+p.b >= 100 {
 			minimalA, minimalB = p.a, p.b

--- a/database_test.go
+++ b/database_test.go
@@ -38,12 +38,12 @@ func TestDatabasePersistsFailingExamples(t *testing.T) {
 		t.Fatal("expected empty database directory before the run")
 	}
 
-	err = runHegel(func(_ TestCase) {
+	err = run(func(_ TestCase) {
 		panic("")
-	}, stdoutNoteFn, []Option{
+	},
 		WithDatabase(Database(dbDir)),
 		withDatabaseKey([]byte("test_database_persists")),
-	})
+	)
 	if err == nil {
 		t.Fatal("expected property test failure")
 	}

--- a/draw_report.go
+++ b/draw_report.go
@@ -121,14 +121,14 @@ func (c *sourceCache) loadLocked(file string) (*ast.File, error) {
 // and returns the file:line location and a printed "statement = value" line
 // for the originating Draw call. skip is the number of frames above this one
 // to skip (Draw passes 1 to point at the user's call site).
-func formatDrawReport(skip int, value any) (location, statement string, _ error) {
+func formatDrawReport(skip int, value any) (location, statement string) {
 	_, file, line, ok := runtime.Caller(skip + 1)
 	if !ok { // coverage-ignore
-		return "", "", fmt.Errorf("runtime.Caller(%d) failed", skip+1)
+		panic(fmt.Errorf("runtime.Caller(%d) failed", skip+1))
 	}
 	stmt, _ := drawReportSource.statementAt(file, line)
 	location, stmt = formatDrawLine(file, line, stmt, value)
-	return location, stmt, nil
+	return location, stmt
 }
 
 func formatDrawLine(file string, line int, stmt string, value any) (location, statement string) {

--- a/draw_report.go
+++ b/draw_report.go
@@ -77,12 +77,13 @@ func (c *sourceCache) extractLocked(key fileLine) (string, error) {
 
 	stmt := ""
 	var best ast.Node
+	tokFile := c.fset.File(f.FileStart)
 	ast.Inspect(f, func(n ast.Node) bool {
 		if n == nil {
 			return false
 		}
-		pos := c.fset.Position(n.Pos()).Line
-		end := c.fset.Position(n.End()).Line
+		pos := tokFile.Line(n.Pos())
+		end := tokFile.Line(n.End())
 		if pos > key.line || end < key.line {
 			return false
 		}
@@ -111,33 +112,30 @@ func (c *sourceCache) loadLocked(file string) (*ast.File, error) {
 	if f, ok := c.files[file]; ok {
 		return f.file, f.err
 	}
-	f, err := parser.ParseFile(c.fset, file, nil, parser.ParseComments)
+	f, err := parser.ParseFile(c.fset, file, nil, parser.SkipObjectResolution)
 	c.files[file] = cachedFile{f, err}
 	return f, err
 }
 
-// formatDrawReport renders one line describing a successful Draw call.
-// Returns "" with a nil error when the caller is internal to the hegel
-// package (e.g. the stateful runner's bookkeeping draws). When omitLocation
-// is true the rendered line drops the leading "file:line: " — callers that
-// route the message through testing.T.Log get that decoration for free.
-func formatDrawReport(skip int, value any, omitLocation bool) (string, error) {
+// formatDrawReport resolves the caller's source position via runtime.Caller
+// and returns the file:line location and a printed "statement = value" line
+// for the originating Draw call. skip is the number of frames above this one
+// to skip (Draw passes 1 to point at the user's call site).
+func formatDrawReport(skip int, value any) (location, statement string, _ error) {
 	_, file, line, ok := runtime.Caller(skip + 1)
 	if !ok { // coverage-ignore
-		return "", fmt.Errorf("runtime.Caller(%d) failed", skip+1)
+		return "", "", fmt.Errorf("runtime.Caller(%d) failed", skip+1)
 	}
 	stmt, _ := drawReportSource.statementAt(file, line)
-	return formatDrawLine(file, line, stmt, value, omitLocation), nil
+	location, stmt = formatDrawLine(file, line, stmt, value)
+	return location, stmt, nil
 }
 
-func formatDrawLine(file string, line int, stmt string, value any, omitLocation bool) string {
+func formatDrawLine(file string, line int, stmt string, value any) (location, statement string) {
 	if stmt == "" {
 		stmt = fmt.Sprintf("hegel.Draw[%T](...) = %#v", value, value)
 	} else {
 		stmt = fmt.Sprintf("%s = %#v", stmt, value)
 	}
-	if omitLocation {
-		return stmt
-	}
-	return fmt.Sprintf("%s:%d: %s", filepath.Base(file), line, stmt)
+	return fmt.Sprintf("%s:%d", filepath.Base(file), line), stmt
 }

--- a/draw_report_test.go
+++ b/draw_report_test.go
@@ -1,7 +1,7 @@
 package hegel
 
 import (
-	"io"
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -217,13 +217,14 @@ func TestFormatDrawLineWithoutStatement(t *testing.T) {
 }
 
 func TestDrawReportInProcess(t *testing.T) {
-	captured := captureStdout(t, func() {
-		if err := Run(func(tc TestCase) {
-			_ = Draw(tc, Integers(0, 100))
-		}, WithSingleTestCase()); err != nil {
-			t.Fatalf("Run: %v", err)
-		}
-	})
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := run(func(tc TestCase) {
+		_ = Draw(tc, Integers(0, 100))
+	}, WithSingleTestCase(), withOutput(&buf)); err != nil {
+		t.Fatalf("runHegel: %v", err)
+	}
+	captured := buf.String()
 	if !strings.Contains(captured, "draw_report_test.go:") {
 		t.Fatalf("expected draw report in output, got:\n%s", captured)
 	}
@@ -235,18 +236,18 @@ func TestDrawReportInProcess(t *testing.T) {
 // Inner Draws inside the Composite element fire at depth > 0 under the Lists
 // span and must be suppressed.
 func TestDrawReportSuppressedInsideSpan(t *testing.T) {
+	t.Parallel()
 	gen := Lists(Composite(func(tc TestCase) int {
 		return Draw(tc, Integers(0, 100))
 	})).MinSize(2).MaxSize(2)
 
-	captured := captureStdout(t, func() {
-		if err := Run(func(tc TestCase) {
-			_ = Draw(tc, gen)
-		}, WithSingleTestCase()); err != nil {
-			t.Fatalf("Run: %v", err)
-		}
-	})
-
+	var buf bytes.Buffer
+	if err := run(func(tc TestCase) {
+		_ = Draw(tc, gen)
+	}, WithSingleTestCase(), withOutput(&buf)); err != nil {
+		t.Fatalf("runHegel: %v", err)
+	}
+	captured := buf.String()
 	got := strings.Count(captured, "draw_report_test.go:")
 	if got != 1 {
 		t.Fatalf("expected exactly 1 draw line in output, got %d:\n%s", got, captured)
@@ -259,20 +260,20 @@ func TestDrawReportSuppressedInsideSpan(t *testing.T) {
 // Isolates labelComposite from labelList: a top-level Composite must
 // suppress its own inner Draws even without an enclosing Lists span.
 func TestDrawReportSuppressedInsideComposite(t *testing.T) {
+	t.Parallel()
 	gen := Composite(func(tc TestCase) int {
 		a := Draw(tc, Integers(0, 100))
 		b := Draw(tc, Integers(0, 100))
 		return a + b
 	})
 
-	captured := captureStdout(t, func() {
-		if err := Run(func(tc TestCase) {
-			_ = Draw(tc, gen)
-		}, WithSingleTestCase()); err != nil {
-			t.Fatalf("Run: %v", err)
-		}
-	})
-
+	var buf bytes.Buffer
+	if err := run(func(tc TestCase) {
+		_ = Draw(tc, gen)
+	}, WithSingleTestCase(), withOutput(&buf)); err != nil {
+		t.Fatalf("runHegel: %v", err)
+	}
+	captured := buf.String()
 	got := strings.Count(captured, "draw_report_test.go:")
 	if got != 1 {
 		t.Fatalf("expected exactly 1 draw line in output, got %d:\n%s", got, captured)
@@ -280,29 +281,6 @@ func TestDrawReportSuppressedInsideComposite(t *testing.T) {
 	if !strings.Contains(captured, "Draw(tc, gen)") {
 		t.Fatalf("expected outer Draw statement text in output, got:\n%s", captured)
 	}
-}
-
-// captureStdout redirects os.Stdout for the duration of fn. Not safe for
-// concurrent test execution — caller must not use t.Parallel.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	saved := os.Stdout
-	os.Stdout = w
-
-	done := make(chan string, 1)
-	go func() {
-		buf, _ := io.ReadAll(r)
-		done <- string(buf)
-	}()
-
-	fn()
-	w.Close()
-	os.Stdout = saved
-	return <-done
 }
 
 func TestIsHegelFrameExternalTestPackage(t *testing.T) {

--- a/draw_report_test.go
+++ b/draw_report_test.go
@@ -192,37 +192,27 @@ func TestSourceCacheMultiLineStatement(t *testing.T) {
 
 func TestFormatDrawLineWithStatement(t *testing.T) {
 	t.Parallel()
-	got := formatDrawLine("/abs/path/example_test.go", 42, "x := hegel.Draw(...)", []int{0, 0}, false)
-	want := "example_test.go:42: x := hegel.Draw(...) = []int{0, 0}"
-	if got != want {
-		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
+	loc, stmt := formatDrawLine("/abs/path/example_test.go", 42, "x := hegel.Draw(...)", []int{0, 0})
+	wantLoc := "example_test.go:42"
+	wantStmt := "x := hegel.Draw(...) = []int{0, 0}"
+	if loc != wantLoc {
+		t.Fatalf("formatDrawLine location: got %q, want %q", loc, wantLoc)
+	}
+	if stmt != wantStmt {
+		t.Fatalf("formatDrawLine statement: got %q, want %q", stmt, wantStmt)
 	}
 }
 
 func TestFormatDrawLineWithoutStatement(t *testing.T) {
 	t.Parallel()
-	got := formatDrawLine("/abs/path/example_test.go", 42, "", 7, false)
-	want := "example_test.go:42: hegel.Draw[int](...) = 7"
-	if got != want {
-		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
+	loc, stmt := formatDrawLine("/abs/path/example_test.go", 42, "", 7)
+	wantLoc := "example_test.go:42"
+	wantStmt := "hegel.Draw[int](...) = 7"
+	if loc != wantLoc {
+		t.Fatalf("formatDrawLine location: got %q, want %q", loc, wantLoc)
 	}
-}
-
-func TestFormatDrawLineOmitLocationWithStatement(t *testing.T) {
-	t.Parallel()
-	got := formatDrawLine("/abs/path/example_test.go", 42, "x := hegel.Draw(...)", []int{0, 0}, true)
-	want := "x := hegel.Draw(...) = []int{0, 0}"
-	if got != want {
-		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
-	}
-}
-
-func TestFormatDrawLineOmitLocationWithoutStatement(t *testing.T) {
-	t.Parallel()
-	got := formatDrawLine("/abs/path/example_test.go", 42, "", 7, true)
-	want := "hegel.Draw[int](...) = 7"
-	if got != want {
-		t.Fatalf("formatDrawLine: got %q, want %q", got, want)
+	if stmt != wantStmt {
+		t.Fatalf("formatDrawLine statement: got %q, want %q", stmt, wantStmt)
 	}
 }
 

--- a/generators.go
+++ b/generators.go
@@ -115,9 +115,11 @@ type TestCase interface {
 	// [WithSingleTestCase]. Unexported to seal the interface to this package.
 	isSingleTestCase() bool
 
-	// maybeNoteFn returns the note function for this test case, or nil if
-	// notes are suppressed (the exploratory phase).
-	maybeNoteFn() func(string)
+	// reportDraw emits one draw-report line for value through the
+	// implementation's note channel, or no-ops when notes are suppressed.
+	// skip is the number of stack frames to skip when resolving the source
+	// position of the originating [Draw] call.
+	reportDraw(skip int, value any)
 
 	// startSpan notifies the server that a new generation span has started.
 	startSpan(label spanLabel) error
@@ -130,26 +132,21 @@ type TestCase interface {
 	inSpan() bool
 }
 
-// Draw produces a value from a Generator using the given State context.
+// Draw produces a value from a Generator using the given TestCase context.
 func Draw[T any](tc TestCase, g Generator[T]) T {
-	h, hasTestingT := tc.(interface{ Helper() })
-	if hasTestingT {
+	// Mark this frame as a helper so t.Log file:line decoration walks past
+	// it to the user's call site. testCase has no-op Helper; *T inherits
+	// from *testing.T.
+	if h, ok := tc.(interface{ Helper() }); ok {
 		h.Helper()
 	}
-
 	v, err := g.draw(tc)
 	if err != nil {
 		panic(err)
 	}
 	// Nested draws are reported as part of the parent's value.
-	if fn := tc.maybeNoteFn(); fn != nil && !tc.inSpan() {
-		msg, err := formatDrawReport(1, v, hasTestingT)
-		if err != nil { // coverage-ignore
-			panic(err)
-		}
-		if msg != "" {
-			fn(msg)
-		}
+	if !tc.inSpan() {
+		tc.reportDraw(1, v)
 	}
 	return v
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,6 +1,8 @@
 package hegel
 
-import "testing"
+import (
+	"testing"
+)
 
 // These tests verify that the t.Helper() calls inside T.Fatal, T.Fatalf, and
 // T.Logf cause t.Log to decorate output with the user's test file:line, not

--- a/runner.go
+++ b/runner.go
@@ -22,9 +22,9 @@ type testCase struct {
 	stream         *stream
 	singleTestCase bool // set when this case runs under WithSingleTestCase
 	aborted        bool
-	failed         bool         // for T.Error/Fail deferred INTERESTING
-	noteFn         func(string) // nil for exploratory cases; t.Log/stdout for final replay / single-case
-	depth          int          // current span nesting depth; >0 inside a generation span
+	failed         bool      // for T.Error/Fail deferred INTERESTING
+	out            io.Writer // nil for exploratory cases; set for final replay / single-case
+	depth          int       // current span nesting depth; >0 inside a generation span
 }
 
 // --- Sentinel errors ---
@@ -65,9 +65,17 @@ func (s *testCase) Assume(condition bool) {
 }
 
 func (s *testCase) Note(message string) {
-	if s.noteFn != nil {
-		s.noteFn(message)
+	if s.out != nil {
+		fmt.Fprintln(s.out, message)
 	}
+}
+
+func (s *testCase) reportDraw(skip int, value any) {
+	if s.out == nil {
+		return
+	}
+	loc, msg := formatDrawReport(skip+1, value)
+	fmt.Fprintf(s.out, "%s: %s\n", loc, msg)
 }
 
 func (s *testCase) Errorf(format string, args ...any) {
@@ -163,10 +171,6 @@ func (s *testCase) generateFromSchema(schema map[string]any) (any, error) {
 
 func (s *testCase) isSingleTestCase() bool {
 	return s.singleTestCase
-}
-
-func (s *testCase) maybeNoteFn() func(string) {
-	return s.noteFn
 }
 
 func (s *testCase) startSpan(label spanLabel) error {
@@ -293,6 +297,9 @@ type runOptions struct {
 	// databaseKey identifies the test for example-database lookups. Set by
 	// [Test] from t.Name(); nil for [Run]/[MustRun] (no test name available).
 	databaseKey []byte
+	// output receives note/draw-report output during single-test-case mode and
+	// during the final replay of interesting cases. nil means no output.
+	output io.Writer
 }
 
 // Option is a functional option for Test and Run.
@@ -352,6 +359,14 @@ func withDatabaseKey(key []byte) Option {
 	return func(o *runOptions) { o.databaseKey = key }
 }
 
+// withOutput sets the writer that receives note and draw-report output during
+// single-test-case mode and during the final replay of interesting cases.
+// Unexported: [Run] sets it to [os.Stdout], [Test] to t.Output(), [Workload]
+// to its stdout. Tests use it to inspect output.
+func withOutput(w io.Writer) Option {
+	return func(o *runOptions) { o.output = w }
+}
+
 // ciEnvVar describes a single CI-detection env var. If matchAny is true, the
 // var counts as a CI signal whenever it is present in the environment, even
 // with an empty value. Otherwise it must equal expected exactly.
@@ -394,7 +409,7 @@ func isCI() bool {
 //
 // Note output goes to stdout. For use in standalone binaries and conformance tests.
 func Run(fn func(TestCase), opts ...Option) error {
-	return runHegel(fn, stdoutNoteFn, opts)
+	return run(fn, append(opts, withOutput(os.Stdout))...)
 }
 
 // MustRun runs a property test and panics if it fails.
@@ -412,23 +427,19 @@ func Test(t *testing.T, fn func(*T), opts ...Option) {
 		ht := &T{testCase: tc.(*testCase), T: t}
 		fn(ht)
 	}
-	allOpts := append(opts, withDatabaseKey([]byte(t.Name())))
-	err := runHegel(body, func(msg string) { t.Helper(); t.Log(msg) }, allOpts) // coverage-ignore
-	if err != nil {                                                             // coverage-ignore
+	allOpts := append(opts, withDatabaseKey([]byte(t.Name())), withOutput(t.Output()))
+	err := run(body, allOpts...)
+	if err != nil { // coverage-ignore
 		t.Fatal(err)
 	}
 }
 
-// stdoutNoteFn is the noteFn for Run/MustRun: writes to stdout.
-func stdoutNoteFn(msg string) {
-	fmt.Println(msg)
-}
-
-// runHegel is the shared implementation for Run, MustRun, and Test.
+// run is the shared implementation for Run, MustRun, and Test.
 //
-// The example-database key is supplied (when applicable) by [Test];
-// non-test entry points leave it nil.
-func runHegel(fn testBody, noteFn func(string), opts []Option) error {
+// The example-database key is supplied (when applicable) by [Test]; non-test
+// entry points leave it nil. Note/draw-report output is routed via
+// [withOutput]; absent that option no output is produced.
+func run(fn testBody, opts ...Option) error {
 	inCI := isCI()
 	o := runOptions{
 		testCases:   100,
@@ -451,13 +462,13 @@ func runHegel(fn testBody, noteFn func(string), opts []Option) error {
 		if err := s.start(); err != nil {
 			return fmt.Errorf("session start: %w", err)
 		}
-		return s.runTest(fn, o, noteFn)
+		return s.runTest(fn, o)
 	}
 
 	if err := globalSession.start(); err != nil {
 		return fmt.Errorf("session start: %w", err)
 	}
-	return globalSession.runTest(fn, o, noteFn)
+	return globalSession.runTest(fn, o)
 }
 
 // extractPanicOrigin extracts file/line from a recovered panic using runtime.Callers,
@@ -554,7 +565,10 @@ func buildRunTestMessage(streamID uint32, opts runOptions) map[string]any {
 // case via the single_test_case command — no shrinking, replay, or example
 // database. Otherwise it sends run_test and replays any interesting failures
 // after the exploratory phase.
-func (c *client) runTest(fn testBody, opts runOptions, noteFn func(string)) error {
+//
+// Note/draw-report output during single-test-case mode and during the final
+// replay of interesting cases is written to opts.output (see [withOutput]).
+func (c *client) runTest(fn testBody, opts runOptions) error {
 	testSt := c.conn.NewStream("Test")
 
 	cmdName := "run_test"
@@ -607,12 +621,12 @@ testCase:
 				return fmt.Errorf("connect test case stream: %w", err)
 			}
 
-			var caseNoteFn func(string)
+			var caseOut io.Writer
 			if opts.singleTestCase {
-				caseNoteFn = noteFn
+				caseOut = opts.output
 			}
 
-			lastErr = c.runTestCase(caseSt, fn, opts.singleTestCase, caseNoteFn)
+			lastErr = c.runTestCase(caseSt, fn, opts.singleTestCase, caseOut)
 			if lastErr != nil && !errors.Is(lastErr, errPropTestFailed) {
 				return lastErr
 			}
@@ -670,7 +684,7 @@ testCase:
 		if err != nil { // coverage-ignore
 			return fmt.Errorf("connect final case stream: %w", err)
 		}
-		caseErr := c.runTestCase(caseSt, fn, false, noteFn)
+		caseErr := c.runTestCase(caseSt, fn, false, opts.output)
 		if caseErr != nil {
 			errs = append(errs, caseErr)
 		}
@@ -683,12 +697,12 @@ var errPropTestFailed = errors.New("property test failed")
 // runTestCase executes one test case and sends mark_complete to the server.
 //
 // Returns errPropTestFailed if the test case caused an abort.
-func (c *client) runTestCase(st *stream, fn testBody, singleTestCase bool, noteFn func(string)) error {
+func (c *client) runTestCase(st *stream, fn testBody, singleTestCase bool, out io.Writer) error {
 	state := &testCase{
 		stream:         st,
 		singleTestCase: singleTestCase,
 		aborted:        false,
-		noteFn:         noteFn,
+		out:            out,
 	}
 
 	sendComplete := true
@@ -944,8 +958,8 @@ func (s *hegelSession) cleanupLocked() {
 }
 
 // runTest runs a test via the session's client.
-func (s *hegelSession) runTest(fn testBody, opts runOptions, noteFn func(string)) error {
-	return s.cli.runTest(fn, opts, noteFn)
+func (s *hegelSession) runTest(fn testBody, opts runOptions) error {
+	return s.cli.runTest(fn, opts)
 }
 
 // globalSession is the package-level session, lazily started.

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,6 +1,7 @@
 package hegel
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -142,9 +143,9 @@ func TestErrorResponse(t *testing.T) {
 				gotErr = fmt.Errorf("%v", r)
 			}
 		}()
-		gotErr = runHegel(func(s TestCase) {
+		gotErr = run(func(s TestCase) {
 			Draw[bool](s, Booleans()) // server sends error_response here
-		}, stdoutNoteFn, []Option{WithTestCases(3)})
+		}, WithTestCases(3))
 	}()
 	// The error from the server causes INTERESTING status -> re-raised on final run.
 	// Either a panic or a non-nil error is acceptable.
@@ -180,11 +181,11 @@ func TestAssumeOutsideContext(t *testing.T) {
 	s.Assume(false)
 }
 
-// --- Note outside context is no-op (noteFn nil) ---
+// --- Note outside context is no-op (out nil) ---
 
 func TestNoteOutsideContext(t *testing.T) {
 	t.Parallel()
-	// Note() on a zero-value *testCase should not panic (noteFn=nil).
+	// Note() on a zero-value *testCase should not panic (out=nil).
 	s := &testCase{}
 	s.Note("outside context -- safe")
 }
@@ -340,7 +341,7 @@ func TestWithTestCasesOption(t *testing.T) {
 func TestStopTestOnCollectionMore(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_collection_more")
-	err := runHegel(func(tc TestCase) {
+	err := run(func(tc TestCase) {
 		max := 10
 		coll, err := newCollection(tc, 0, &max)
 		if err != nil {
@@ -350,7 +351,7 @@ func TestStopTestOnCollectionMore(t *testing.T) {
 		if err := coll.Err(); err != nil {
 			panic(err)
 		}
-	}, stdoutNoteFn, nil)
+	})
 	_ = err // StopTest causes abort, not necessarily an error return
 }
 
@@ -359,7 +360,7 @@ func TestStopTestOnCollectionMore(t *testing.T) {
 func TestStopTestOnNewCollection(t *testing.T) {
 
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "stop_test_on_new_collection")
-	err := runHegel(func(tc TestCase) {
+	err := run(func(tc TestCase) {
 		max := 10
 		coll, err := newCollection(tc, 0, &max)
 		if err != nil {
@@ -369,7 +370,7 @@ func TestStopTestOnNewCollection(t *testing.T) {
 		if err := coll.Err(); err != nil {
 			panic(err)
 		}
-	}, stdoutNoteFn, nil)
+	})
 	_ = err // StopTest causes abort, not necessarily an error return
 }
 
@@ -378,9 +379,9 @@ func TestStopTestOnNewCollection(t *testing.T) {
 func TestConnectionErrorInTestFunction(t *testing.T) {
 	t.Parallel()
 
-	err := runHegel(func(_ TestCase) {
+	err := run(func(_ TestCase) {
 		panic(&connectionError{msg: "test connection lost"})
-	}, stdoutNoteFn, []Option{WithTestCases(1)})
+	}, WithTestCases(1))
 	if err == nil {
 		t.Fatal("expected error to be raised for connection error")
 	}
@@ -538,13 +539,16 @@ func TestExtractPanicOriginError(t *testing.T) {
 	}
 }
 
-// --- Note: non-nil noteFn prints ---
+// --- Note: non-nil out writes ---
 
-func TestNoteWithNoteFn(t *testing.T) {
+func TestNoteWithOut(t *testing.T) {
 	t.Parallel()
-	state := &testCase{noteFn: stdoutNoteFn}
-	// Should not panic.
+	var buf bytes.Buffer
+	state := &testCase{out: &buf}
 	state.Note("test note on final")
+	if got := strings.TrimSpace(buf.String()); got != "test note on final" {
+		t.Errorf("Note output: got %q, want %q", got, "test note on final")
+	}
 }
 
 // --- hegelSession: start with spawn error ---
@@ -610,7 +614,7 @@ func TestRunHegelTestESessionError(t *testing.T) {
 	globalSession = newHegelSession()
 	globalSession.hegelCmd = "/nonexistent/hegel"
 
-	err := runHegel(func(_ TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
+	err := run(func(_ TestCase) {}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when session cannot start")
 	}
@@ -636,7 +640,7 @@ func TestRunHegelTestPanicsOnFailure(t *testing.T) {
 	fake.hegelCmd = "/nonexistent/hegel"
 	globalSession = fake
 
-	if _err := runHegel(func(_ TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)}); _err != nil {
+	if _err := run(func(_ TestCase) {}, WithTestCases(1)); _err != nil {
 		panic(_err)
 	}
 }
@@ -667,7 +671,7 @@ func TestHegelSessionRunTest(t *testing.T) {
 	}
 	err := s.runTest(func(st TestCase) {
 		Draw[bool](st, Booleans())
-	}, runOptions{testCases: 2}, stdoutNoteFn)
+	}, runOptions{testCases: 2})
 	if err != nil {
 		t.Errorf("session.runTest: %v", err)
 	}
@@ -756,7 +760,7 @@ func TestRunHegelTestEProtocolModeStartError(t *testing.T) {
 	t.Setenv("HOME", "/nonexistent")
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
 
-	err := runHegel(func(_ TestCase) {}, stdoutNoteFn, []Option{WithTestCases(1)})
+	err := run(func(_ TestCase) {}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when session cannot start in protocol test mode")
 	}
@@ -888,10 +892,10 @@ func TestTestSuccess(t *testing.T) {
 
 func TestStateFailedPath(t *testing.T) {
 
-	err := runHegel(func(tc TestCase) {
+	err := run(func(tc TestCase) {
 		_ = Draw[bool](tc, Booleans())
 		tc.Fail()
-	}, stdoutNoteFn, []Option{WithTestCases(1)})
+	}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when state.failed is true")
 	}
@@ -903,10 +907,10 @@ func TestStateFailedPath(t *testing.T) {
 
 func TestFatalSentinelPath(t *testing.T) {
 
-	err := runHegel(func(s TestCase) {
+	err := run(func(s TestCase) {
 		_ = Draw[bool](s, Booleans())
 		panic(fatalSentinel{msg: "test fatal"})
-	}, stdoutNoteFn, []Option{WithTestCases(1)})
+	}, WithTestCases(1))
 	if err == nil {
 		t.Error("expected error when fatalSentinel is raised")
 	}
@@ -951,7 +955,7 @@ func TestRunTestSendControlRequestError(t *testing.T) {
 	remote.Close()
 
 	cl := newClient(conn)
-	err := cl.runTest(func(_ TestCase) {}, runOptions{testCases: 1}, stdoutNoteFn)
+	err := cl.runTest(func(_ TestCase) {}, runOptions{testCases: 1})
 	if err == nil {
 		t.Fatal("expected error from runTest on closed conn")
 	}
@@ -1102,11 +1106,11 @@ var flakyCounter atomic.Int64
 func TestFlakyGlobalState(t *testing.T) {
 
 	flakyCounter.Store(0)
-	err := runHegel(func(s TestCase) {
+	err := run(func(s TestCase) {
 		min := int(flakyCounter.Load())
 		_ = Draw[int](s, Integers[int](min, min+100))
 		flakyCounter.Add(1)
-	}, stdoutNoteFn, nil)
+	})
 	if err == nil {
 		t.Fatal("expected error for flaky test")
 	}
@@ -1319,7 +1323,7 @@ func TestRunHegelDisablesDatabaseInCI(t *testing.T) {
 	clearCIEnv(t)
 	t.Setenv("CI", "true")
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
-	err := runHegel(func(_ TestCase) {}, stdoutNoteFn, nil)
+	err := run(func(_ TestCase) {})
 	if err != nil {
 		t.Fatalf("runHegel: %v", err)
 	}

--- a/server_crash_test.go
+++ b/server_crash_test.go
@@ -228,7 +228,7 @@ func TestServerCrashIncludesLogContent(t *testing.T) {
 
 	err := s.runTest(func(tc TestCase) {
 		Draw[bool](tc, Booleans())
-	}, runOptions{testCases: 1}, stdoutNoteFn)
+	}, runOptions{testCases: 1})
 	if err == nil {
 		t.Fatal("expected error from fake crash server")
 	}
@@ -247,7 +247,7 @@ func TestServerCrashEmptyLog(t *testing.T) {
 
 	err := s.runTest(func(tc TestCase) {
 		Draw[bool](tc, Booleans())
-	}, runOptions{testCases: 1}, stdoutNoteFn)
+	}, runOptions{testCases: 1})
 	if err == nil {
 		t.Fatal("expected error from fake crash server")
 	}

--- a/single_test_case_test.go
+++ b/single_test_case_test.go
@@ -1,6 +1,7 @@
 package hegel
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -51,13 +52,14 @@ func TestSingleTestCaseFlagFalseIsNoop(t *testing.T) {
 // --- Integration tests: real hegel binary ---
 
 func TestSingleTestCaseRunsExactlyOnce(t *testing.T) {
+	t.Parallel()
 	var count int32
-	err := Run(func(s TestCase) {
+	err := run(func(s TestCase) {
 		atomic.AddInt32(&count, 1)
 		_ = Draw[bool](s, Booleans())
 	}, WithSingleTestCase())
 	if err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("runHegel: %v", err)
 	}
 	if got := atomic.LoadInt32(&count); got != 1 {
 		t.Errorf("expected exactly 1 test case, got %d", got)
@@ -65,7 +67,8 @@ func TestSingleTestCaseRunsExactlyOnce(t *testing.T) {
 }
 
 func TestSingleTestCaseFailureSurfaces(t *testing.T) {
-	err := Run(func(TestCase) {
+	t.Parallel()
+	err := run(func(TestCase) {
 		panic("intentional failure")
 	}, WithSingleTestCase())
 	if err == nil {
@@ -77,30 +80,25 @@ func TestSingleTestCaseFailureSurfaces(t *testing.T) {
 }
 
 func TestSingleTestCaseNoteIsVisible(t *testing.T) {
+	t.Parallel()
 	const marker = "hello from single test case"
-	var notes []string
-	err := runHegel(func(s TestCase) {
+	var buf bytes.Buffer
+	err := run(func(s TestCase) {
 		s.Note(marker)
-	}, func(msg string) { notes = append(notes, msg) }, []Option{WithSingleTestCase()})
+	}, WithSingleTestCase(), withOutput(&buf))
 	if err != nil {
 		t.Fatalf("runHegel: %v", err)
 	}
-	found := false
-	for _, n := range notes {
-		if strings.Contains(n, marker) {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected note %q in output, got %v", marker, notes)
+	if !strings.Contains(buf.String(), marker) {
+		t.Errorf("expected note %q in output, got %q", marker, buf.String())
 	}
 }
 
 func TestSingleTestCasePermissiveOptions(t *testing.T) {
+	t.Parallel()
 	// Combining WithSingleTestCase with other options is permissive — the
 	// extra options simply don't go on the wire.
-	err := Run(func(s TestCase) {
+	err := run(func(s TestCase) {
 		_ = Draw[bool](s, Booleans())
 	},
 		WithSingleTestCase(),
@@ -110,7 +108,7 @@ func TestSingleTestCasePermissiveOptions(t *testing.T) {
 		SuppressHealthCheck(FilterTooMuch),
 	)
 	if err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("runHegel: %v", err)
 	}
 }
 
@@ -128,8 +126,9 @@ func (m *unboundedMachine) InvariantBounded(_ TestCase) {
 }
 
 func TestSingleTestCaseStatefulRunsBeyondDefaultCap(t *testing.T) {
+	t.Parallel()
 	m := &unboundedMachine{}
-	err := Run(func(s TestCase) {
+	err := run(func(s TestCase) {
 		RunStateful(s, m)
 	}, WithSingleTestCase())
 	if err == nil {
@@ -151,7 +150,7 @@ func TestRunSingleTestCaseSendControlRequestError(t *testing.T) {
 	remote.Close()
 
 	cl := newClient(conn)
-	err := cl.runTest(func(_ TestCase) {}, runOptions{singleTestCase: true}, stdoutNoteFn)
+	err := cl.runTest(func(_ TestCase) {}, runOptions{singleTestCase: true})
 	if err == nil {
 		t.Fatal("expected error from single_test_case send on closed conn")
 	}
@@ -161,9 +160,11 @@ func TestRunSingleTestCaseSendControlRequestError(t *testing.T) {
 // --- Workload --single-test-case ---
 
 func TestWorkloadSingleTestCaseFlag(t *testing.T) {
+	t.Parallel()
 	var count int32
 	err := workload(
 		[]string{"prog", "--single-test-case"},
+		io.Discard,
 		io.Discard,
 		func(s TestCase) {
 			atomic.AddInt32(&count, 1)

--- a/state.go
+++ b/state.go
@@ -42,22 +42,24 @@ type T struct {
 
 // Shadowed methods — override testing.T behavior for Hegel compatibility.
 
-// Fatal logs the message via [TestCase.Note] and marks the test case as failed.
+// Fatal logs the message via the embedded [*testing.T] and marks the test
+// case as failed.
 func (t *T) Fatal(args ...any) {
 	msg := fmt.Sprint(args...)
-	if t.noteFn != nil {
+	if t.out != nil {
 		t.Helper()
-		t.noteFn(msg)
+		t.T.Log(msg)
 	}
 	panic(fatalSentinel{msg: msg})
 }
 
-// Fatalf logs the formatted message via [TestCase.Note] and marks the test case as failed.
+// Fatalf logs the formatted message via the embedded [*testing.T] and marks
+// the test case as failed.
 func (t *T) Fatalf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	if t.noteFn != nil {
+	if t.out != nil {
 		t.Helper()
-		t.noteFn(msg)
+		t.T.Log(msg)
 	}
 	panic(fatalSentinel{msg: msg})
 }
@@ -77,14 +79,26 @@ func (t *T) SkipNow() {
 	t.Assume(false)
 }
 
-// Error logs the message via [TestCase.Note] and sets the failed flag.
+// Error logs the message via the embedded [*testing.T] and sets the failed flag.
 //
 // The test case continues running but will be treated as a failure after return.
 func (t *T) Error(args ...any) {
 	msg := fmt.Sprint(args...)
-	if t.noteFn != nil {
+	if t.out != nil {
 		t.Helper()
-		t.noteFn(msg)
+		t.T.Log(msg)
+	}
+	t.testCase.Fail()
+}
+
+// Errorf logs the formatted message via the embedded [*testing.T] and sets
+// the failed flag.
+//
+// The test case continues running but will be treated as a failure after return.
+func (t *T) Errorf(format string, args ...any) {
+	if t.out != nil {
+		t.Helper()
+		t.T.Logf(format, args...)
 	}
 	t.testCase.Fail()
 }
@@ -94,24 +108,40 @@ func (t *T) Failed() bool {
 	return t.testCase.failed
 }
 
-// Logf routes the formatted message through [TestCase.Note].
-func (t *T) Logf(format string, args ...any) {
-	if t.noteFn != nil {
+// Log routes the message through the embedded [*testing.T].
+func (t *T) Log(args ...any) {
+	if t.out != nil {
 		t.Helper()
-		t.noteFn(fmt.Sprintf(format, args...))
+		t.T.Log(fmt.Sprint(args...))
 	}
 }
 
-// Note routes the message through [TestCase.Note], marking this frame as a
-// helper so the noteFn-driven t.Log decoration walks past it to user code.
-func (t *T) Note(message string) {
-	if t.noteFn != nil {
+// Logf routes the formatted message through the embedded [*testing.T].
+func (t *T) Logf(format string, args ...any) {
+	if t.out != nil {
 		t.Helper()
-		t.noteFn(message)
+		t.T.Logf(format, args...)
+	}
+}
+
+// Note routes the message through the embedded [*testing.T].
+func (t *T) Note(message string) {
+	if t.out != nil {
+		t.Helper()
+		t.T.Log(message)
 	}
 }
 
 // Run aborts the test — nested sub-tests inside a Hegel property test are not supported.
 func (t *T) Run(_ string, _ func(*testing.T)) bool {
 	panic("nested t.Run is not supported inside a property test")
+}
+
+func (t *T) reportDraw(skip int, value any) {
+	if t.out == nil {
+		return
+	}
+	_, msg := formatDrawReport(skip+1, value)
+	t.Helper()
+	t.T.Log(msg)
 }

--- a/state_test.go
+++ b/state_test.go
@@ -1,14 +1,28 @@
 package hegel
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
 // makeFakeT creates a *T with a zero testCase and a real *testing.T
 // for unit testing T methods in state.go.
+//
+// emit defaults to false so the embedded *testing.T isn't exercised.
 func makeFakeT(t *testing.T) *T {
 	return &T{
 		testCase: &testCase{},
+		T:        t,
+	}
+}
+
+// makeEmittingT creates a *T with a testCase.out set to buf.
+// Use when the test wants to assert routing through the embedded *testing.T
+// (which we can't capture directly) and/or testCase.out.
+func makeEmittingT(t *testing.T, buf *bytes.Buffer) *T {
+	return &T{
+		testCase: &testCase{out: buf},
 		T:        t,
 	}
 }
@@ -36,15 +50,19 @@ func TestTFatalPanicsWithSentinel(t *testing.T) {
 	ht.Fatal("fatal message")
 }
 
-func TestTFatalCallsNoteFn(t *testing.T) {
+// TestTFatalEmitsViaTestingT exercises the emit=true branch of Fatal: the
+// message routes through t.T.Log so file:line decoration walks back to user
+// code. We can't capture t.T.Log output from here, so this test merely
+// proves the path runs without panic from t.Log and that the fatalSentinel
+// still unwinds.
+func TestTFatalEmitsViaTestingT(t *testing.T) {
 	t.Parallel()
-	ht := makeFakeT(t)
-	var gotMsg string
-	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
+	ht := makeEmittingT(t, &bytes.Buffer{})
 	defer func() {
-		_ = recover()
-		if gotMsg != "fatal message" {
-			t.Errorf("expected note %q, got %q", "fatal message", gotMsg)
+		r := recover()
+		fs, ok := r.(fatalSentinel)
+		if !ok || fs.msg != "fatal message" {
+			t.Errorf("expected fatalSentinel %q, got %T:%v", "fatal message", r, r)
 		}
 	}()
 	ht.Fatal("fatal message")
@@ -69,15 +87,14 @@ func TestTFatalfPanicsWithSentinel(t *testing.T) {
 	ht.Fatalf("fatal: %d", 42)
 }
 
-func TestTFatalfCallsNoteFn(t *testing.T) {
+func TestTFatalfEmitsViaTestingT(t *testing.T) {
 	t.Parallel()
-	ht := makeFakeT(t)
-	var gotMsg string
-	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
+	ht := makeEmittingT(t, &bytes.Buffer{})
 	defer func() {
-		_ = recover()
-		if gotMsg != "fatal: 99" {
-			t.Errorf("expected note %q, got %q", "fatal: 99", gotMsg)
+		r := recover()
+		fs, ok := r.(fatalSentinel)
+		if !ok || fs.msg != "fatal: 99" {
+			t.Errorf("expected fatalSentinel %q, got %T:%v", "fatal: 99", r, r)
 		}
 	}()
 	ht.Fatalf("fatal: %d", 99)
@@ -155,31 +172,41 @@ func TestTSkipNowPanicsWithAssumeRejected(t *testing.T) {
 // T.Error / T.Errorf — set failed flag, call Note
 // =============================================================================
 
-func TestTErrorSetsFailedAndCallsNote(t *testing.T) {
+func TestTErrorSetsFailed(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	noted := false
-	ht.testCase.noteFn = func(msg string) { noted = true }
 	ht.Error("something went wrong")
 	if !ht.testCase.failed {
 		t.Error("expected failed to be true after Error()")
 	}
-	if !noted {
-		t.Error("expected Note to be called by Error()")
-	}
 }
 
-func TestTErrorfSetsFailedAndCallsNote(t *testing.T) {
+func TestTErrorfSetsFailed(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	noted := false
-	ht.testCase.noteFn = func(msg string) { noted = true }
 	ht.Errorf("error: %d", 99)
 	if !ht.testCase.failed {
 		t.Error("expected failed to be true after Errorf()")
 	}
-	if !noted {
-		t.Error("expected Note to be called by Errorf()")
+}
+
+// TestTErrorEmitsViaTestingT exercises the emit=true branch of Error.
+func TestTErrorEmitsViaTestingT(t *testing.T) {
+	t.Parallel()
+	ht := makeEmittingT(t, &bytes.Buffer{})
+	ht.Error("something went wrong")
+	if !ht.testCase.failed {
+		t.Error("expected failed to be true after Error()")
+	}
+}
+
+// TestTErrorfEmitsViaTestingT exercises the emit=true branch of Errorf.
+func TestTErrorfEmitsViaTestingT(t *testing.T) {
+	t.Parallel()
+	ht := makeEmittingT(t, &bytes.Buffer{})
+	ht.Errorf("error: %d", 99)
+	if !ht.testCase.failed {
+		t.Error("expected failed to be true after Errorf()")
 	}
 }
 
@@ -200,40 +227,72 @@ func TestTFailSetsFailed(t *testing.T) {
 }
 
 // =============================================================================
-// T.Log / T.Logf — route through Note
+// T.Log / T.Logf / T.Note — route through t.T.Log when emit=true, no-op otherwise
 // =============================================================================
 
-func TestTLogCallsNote(t *testing.T) {
+// When emit=false, Log/Logf/Note are silent.
+func TestTLogSilentWhenNotEmitting(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	var gotMsg string
-	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
 	ht.Log("hello", " world")
-	if gotMsg != "hello world" {
-		t.Errorf("expected %q, got %q", "hello world", gotMsg)
-	}
-}
-
-func TestTLogfCallsNote(t *testing.T) {
-	t.Parallel()
-	ht := makeFakeT(t)
-	var gotMsg string
-	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
 	ht.Logf("value=%d", 42)
-	if gotMsg != "value=42" {
-		t.Errorf("expected %q, got %q", "value=42", gotMsg)
+	ht.Note("a note")
+}
+
+// When emit=true, Log/Logf/Note route through t.T.Log. We can't capture
+// t.T.Log output directly; this test just exercises the branch.
+func TestTLogEmitsWhenEmitting(t *testing.T) {
+	t.Parallel()
+	ht := makeEmittingT(t, &bytes.Buffer{})
+	ht.Log("hello", " world")
+	ht.Logf("value=%d", 42)
+	ht.Note("a note")
+}
+
+// testCase.Note writes to s.out when set.
+func TestTestCaseNoteWritesToOut(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := &testCase{out: &buf}
+	s.Note("hello world")
+	if got := strings.TrimSpace(buf.String()); got != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", got)
 	}
 }
 
-func TestTNoteCallsNoteFn(t *testing.T) {
+// testCase.Errorf writes to s.out and sets the failed flag.
+func TestTestCaseErrorfWritesAndFails(t *testing.T) {
 	t.Parallel()
-	ht := makeFakeT(t)
-	var gotMsg string
-	ht.testCase.noteFn = func(msg string) { gotMsg = msg }
-	ht.Note("a note")
-	if gotMsg != "a note" {
-		t.Errorf("expected %q, got %q", "a note", gotMsg)
+	var buf bytes.Buffer
+	s := &testCase{out: &buf}
+	s.Errorf("value=%d", 42)
+	if !s.failed {
+		t.Error("expected failed=true after Errorf")
 	}
+	if got := strings.TrimSpace(buf.String()); got != "value=42" {
+		t.Errorf("expected %q, got %q", "value=42", got)
+	}
+}
+
+// testCase.Log routes through Note.
+func TestTestCaseLogWritesToOut(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := &testCase{out: &buf}
+	s.Log("hello", " world")
+	if got := strings.TrimSpace(buf.String()); got != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", got)
+	}
+}
+
+// *T.reportDraw with emit=true and a captured Draw site routes through
+// t.T.Log. We can't capture t.T.Log output from here, but we can exercise
+// the code path. The call site doesn't matter — formatDrawReport just
+// needs a non-zero skip frame.
+func TestTReportDrawEmits(t *testing.T) {
+	t.Parallel()
+	ht := makeEmittingT(t, &bytes.Buffer{})
+	ht.reportDraw(0, 42)
 }
 
 // =============================================================================

--- a/stateful_test.go
+++ b/stateful_test.go
@@ -191,7 +191,7 @@ func TestRunStatefulAssumeRejectionRetries(t *testing.T) {
 
 func TestRunStatefulRulePanicPropagates(t *testing.T) {
 	t.Parallel()
-	err := Run(func(tc TestCase) {
+	err := run(func(tc TestCase) {
 		RunStateful(tc, &rulePanicker{})
 	})
 	assertErrorContains(t, "rule panic propagated", err)
@@ -229,7 +229,7 @@ func TestStatefulInitialInvariantConnectionError(t *testing.T) {
 
 func TestRunStatefulInvariantViolationFails(t *testing.T) {
 	t.Parallel()
-	err := Run(func(tc TestCase) {
+	err := run(func(tc TestCase) {
 		RunStateful(tc, &invariantViolator{})
 	}, WithTestCases(10))
 	assertErrorContains(t, "counter reached", err)

--- a/workload.go
+++ b/workload.go
@@ -11,9 +11,13 @@ import (
 	"strings"
 )
 
-// workloadExit is a seam so tests can observe the exit code from [Workload]
-// without terminating the test process.
-var workloadExit = os.Exit
+// Seams so tests can observe the exit code from [Workload] and redirect its
+// output without terminating the test process or polluting the test log.
+var (
+	workloadExit             = os.Exit
+	workloadStdout io.Writer = os.Stdout
+	workloadStderr io.Writer = os.Stderr
+)
 
 // Workload runs a property test as a standalone CLI binary, parsing flags
 // from [os.Args].
@@ -22,19 +26,19 @@ var workloadExit = os.Exit
 //
 // opts are overridden by flags.
 func Workload(fn func(TestCase), opts ...Option) {
-	err := workload(os.Args, os.Stderr, fn, opts)
+	err := workload(os.Args, workloadStdout, workloadStderr, fn, opts)
 	if err == nil {
 		return
 	}
-	fmt.Fprintln(os.Stderr, "Error:", err)
+	fmt.Fprintln(workloadStderr, "Error:", err)
 	workloadExit(1)
 }
 
-// workload is the testable core of [Workload]. It writes flag-package
-// output (parse errors, usage, --help) to stderr and returns nil on success
-// (including --help) or a non-nil error for flag-parse problems and
-// property-test failures.
-func workload(args []string, stderr io.Writer, fn func(TestCase), opts []Option) error {
+// workload is the testable core of [Workload]. Note output (interesting cases,
+// single-test-case mode) goes to stdout; flag-package output (parse errors,
+// usage, --help) goes to stderr. Returns nil on success (including --help) or
+// a non-nil error for flag-parse problems and property-test failures.
+func workload(args []string, stdout io.Writer, stderr io.Writer, fn func(TestCase), opts []Option) error {
 	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	fs.SetOutput(stderr)
 
@@ -59,7 +63,8 @@ func workload(args []string, stderr io.Writer, fn func(TestCase), opts []Option)
 			allOpts = append(allOpts, ov.Option())
 		}
 	})
-	return Run(fn, allOpts...)
+	allOpts = append(allOpts, withOutput(stdout))
+	return run(fn, allOpts...)
 }
 
 type optionValue interface {

--- a/workload_test.go
+++ b/workload_test.go
@@ -20,13 +20,22 @@ func applyOpts(opts []Option) runOptions {
 }
 
 // captureWorkloadExit replaces workloadExit with one that records the exit
-// code into the returned pointer, and registers a t.Cleanup to restore it.
+// code into the returned pointer, redirects workloadStdout/workloadStderr to
+// the test's output, and registers a t.Cleanup to restore them.
 func captureWorkloadExit(t *testing.T) *int {
 	t.Helper()
 	var code int
-	orig := workloadExit
+	origExit := workloadExit
+	origStdout := workloadStdout
+	origStderr := workloadStderr
 	workloadExit = func(c int) { code = c }
-	t.Cleanup(func() { workloadExit = orig })
+	workloadStdout = t.Output()
+	workloadStderr = t.Output()
+	t.Cleanup(func() {
+		workloadExit = origExit
+		workloadStdout = origStdout
+		workloadStderr = origStderr
+	})
 	return &code
 }
 
@@ -163,7 +172,7 @@ func TestParseHealthCheckRoundTrip(t *testing.T) {
 
 func TestWorkloadEmptyTestSucceeds(t *testing.T) {
 	t.Setenv("HEGEL_PROTOCOL_TEST_MODE", "empty_test")
-	err := workload([]string{"prog"}, io.Discard, func(TestCase) {
+	err := workload([]string{"prog"}, io.Discard, io.Discard, func(TestCase) {
 		t.Fatal("body should not run under empty_test")
 	}, nil)
 	if err != nil {
@@ -182,6 +191,7 @@ func TestWorkloadParsesFlags(t *testing.T) {
 			"--suppress-health-check=filter_too_much",
 		},
 		io.Discard,
+		io.Discard,
 		func(TestCase) {}, nil,
 	)
 	if err != nil {
@@ -192,7 +202,7 @@ func TestWorkloadParsesFlags(t *testing.T) {
 func TestWorkloadHelpReturnsNil(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	err := workload([]string{"myprog", "--help"}, &buf, func(TestCase) {}, nil)
+	err := workload([]string{"myprog", "--help"}, io.Discard, &buf, func(TestCase) {}, nil)
 	if err != nil {
 		t.Errorf("expected nil error on --help, got %v", err)
 	}
@@ -207,7 +217,7 @@ func TestWorkloadHelpReturnsNil(t *testing.T) {
 func TestWorkloadBadFlagReturnsError(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	err := workload([]string{"prog", "--bogus"}, &buf, func(TestCase) {}, nil)
+	err := workload([]string{"prog", "--bogus"}, io.Discard, &buf, func(TestCase) {}, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown flag")
 	}
@@ -221,6 +231,7 @@ func TestWorkloadBadHealthCheckReturnsError(t *testing.T) {
 	t.Parallel()
 	err := workload(
 		[]string{"prog", "--suppress-health-check=nonsense"},
+		io.Discard,
 		io.Discard,
 		func(TestCase) {}, nil,
 	)


### PR DESCRIPTION
`go test` currently writes a bunch of junk to stdout because we don't properly redirect test output during tests. Fix this by passing around an io.Writer that receives output.