### PR TITLE
do not recover panics during final replay 

### DIFF
--- a/.github/coverage-ratchet.json
+++ b/.github/coverage-ratchet.json
@@ -1,3 +1,3 @@
 {
-  "coverage_ignore_count": 40
+  "coverage_ignore_count": 37
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Overhaul panic handling to improve the experience when debugging hegel tests.

--- a/database_test.go
+++ b/database_test.go
@@ -38,8 +38,8 @@ func TestDatabasePersistsFailingExamples(t *testing.T) {
 		t.Fatal("expected empty database directory before the run")
 	}
 
-	err = run(func(_ TestCase) {
-		panic("")
+	err = run(func(tc TestCase) {
+		tc.Fail()
 	},
 		WithDatabase(Database(dbDir)),
 		withDatabaseKey("test_database_persists"),
@@ -102,7 +102,7 @@ func TestReplay1(t *testing.T) {
 		n := hegel.Draw[int64](ht, hegel.Integers[int64](math.MinInt64, math.MaxInt64))
 		recordTestCase("TestReplay1", n)
 		if n >= 1_000_000 {
-			panic(fmt.Sprintf("n=%%d", n))
+			ht.Fatalf("n=%%d", n)
 		}
 	}, hegel.WithDatabase(hegel.Database(%q)))
 }
@@ -112,7 +112,7 @@ func TestReplay2(t *testing.T) {
 		n := hegel.Draw[int64](ht, hegel.Integers[int64](math.MinInt64, math.MaxInt64))
 		recordTestCase("TestReplay2", n)
 		if n >= 1_000_000 {
-			panic(fmt.Sprintf("n=%%d", n))
+			ht.Fatalf("n=%%d", n)
 		}
 	}, hegel.WithDatabase(hegel.Database(%q)))
 }

--- a/generators.go
+++ b/generators.go
@@ -56,6 +56,22 @@ type TestCase interface {
 	// under [WithSingleTestCase]).
 	Log(args ...any)
 
+	// Abort the current test case and update status.
+	//
+	// Passing nil for err is valid and aborts without changing state.
+	abort(err error)
+
+	// Recover from a previous call to abort.
+	//
+	// Must be a deferred call.
+	recoverAbort()
+
+	// Get the current status.
+	getStatus() libhegel.Status
+
+	// Set the current status.
+	setStatus(status libhegel.Status)
+
 	// generate requests a value from the engine for schema. The schema is a
 	// JSON-shaped map (CBOR-encoded on the wire to libhegel). Returns the
 	// decoded value or a sentinel error on abort.
@@ -98,7 +114,7 @@ func Draw[T any](tc TestCase, g Generator[T]) T {
 	}
 	v, err := g.draw(tc)
 	if err != nil {
-		panic(shortCircuit{err})
+		tc.abort(err)
 	}
 	// Nested draws are reported as part of the parent's value.
 	if !tc.inSpan() {

--- a/internal/libhegel/libhegel.go
+++ b/internal/libhegel/libhegel.go
@@ -375,7 +375,7 @@ func (s *Settings) TestCases(n uint64) {
 	s.lib.settingsTestCases(s.ptr, n)
 }
 
-func (s *Settings) Verbosity(v Verbosity) { // coverage-ignore (exposed for completeness; not yet wired into the runner)
+func (s *Settings) Verbosity(v Verbosity) {
 	s.lib.settingsVerbosity(s.ptr, v)
 }
 
@@ -387,7 +387,7 @@ func (s *Settings) Derandomize(on bool) {
 	s.lib.settingsDerandomize(s.ptr, on)
 }
 
-func (s *Settings) ReportMultipleFailures(yes bool) { // coverage-ignore (exposed for completeness; not yet wired into the runner)
+func (s *Settings) ReportMultipleFailures(yes bool) {
 	s.lib.settingsReportMultiFail(s.ptr, yes)
 }
 
@@ -399,7 +399,7 @@ func (s *Settings) DatabaseKey(key string) {
 	s.lib.settingsDatabaseKey(s.ptr, key)
 }
 
-func (s *Settings) Phases(p Phase) { // coverage-ignore (exposed for completeness; not yet wired into the runner)
+func (s *Settings) Phases(p Phase) {
 	s.lib.settingsPhases(s.ptr, p)
 }
 

--- a/internal/libhegel/stub.go
+++ b/internal/libhegel/stub.go
@@ -1,14 +1,20 @@
 package libhegel
 
+import "fmt"
+
 // Stub creates a Handle where libhegel return values are controlled by the caller.
 //
 // returns supplies one value per libhegel call, consumed in strict call order.
 // The caller is responsible to provide the correct number of values with the
 // correct dynamic types (e.g. uintptr for opaque handles, Error for op results).
 func Stub(returns ...any) *Handle {
+	var i int
 	retval := func() any {
-		v := returns[0]
-		returns = returns[1:]
+		if i >= len(returns) {
+			panic(fmt.Sprintf("libhegel stub: missing %d'th return value", i+1))
+		}
+		v := returns[i]
+		i++
 		return v
 	}
 

--- a/internal/libhegel/stub_test.go
+++ b/internal/libhegel/stub_test.go
@@ -1,0 +1,35 @@
+package libhegel
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStubMissingReturnPanics covers the underflow guard in Stub's retval
+// closure: popping more return values than were supplied panics with an
+// index-bearing message.
+func TestStubMissingReturnPanics(t *testing.T) {
+	lib := Stub() // no returns supplied
+	defer func() {
+		r := recover()
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %v", r)
+		}
+		if !strings.Contains(msg, "missing 1'th return value") {
+			t.Errorf("unexpected panic message: %q", msg)
+		}
+	}()
+	lib.SettingsNew() // pops the (absent) first return => panic
+}
+
+// TestStubUnwiredSetters exercises the settings setters that the runner does
+// not (yet) drive — Verbosity, ReportMultipleFailures and Phases — directly
+// against a Stub so their plumbing is covered.
+func TestStubUnwiredSetters(t *testing.T) {
+	lib := Stub(uintptr(1)) // settings_new handle
+	s := lib.SettingsNew()
+	s.Verbosity(VERBOSITY_VERBOSE)
+	s.ReportMultipleFailures(true)
+	s.Phases(PHASE_GENERATE)
+}

--- a/runner.go
+++ b/runner.go
@@ -18,8 +18,10 @@ import (
 // It is compatible with most popular TestingT interfaces from assert libraries.
 type testCase struct {
 	tc             *libhegel.TestCase
+	status         libhegel.Status
+	origin         string
 	singleTestCase bool      // set when this case runs under WithSingleTestCase
-	failed         bool      // for T.Error/T.Fail deferred INTERESTING
+	aborted        bool      // set if test case run was short circuited
 	out            io.Writer // nil for exploratory cases; set for final replay / single-case
 	depth          int       // current span nesting depth
 }
@@ -33,12 +35,10 @@ var errTestCaseAborted = errors.New("test case aborted")
 // driveOneCase wraps it for failing cases; runProperty collects across cases.
 var errPropTestFailed = errors.New("property test failed")
 
-// --- TestCase public-method implementations ---
-
 // Assume rejects the current test case if condition is false.
 func (s *testCase) Assume(condition bool) {
 	if !condition {
-		panic(shortCircuit{libhegel.E_ASSUME})
+		s.abort(libhegel.E_ASSUME)
 	}
 }
 
@@ -58,16 +58,15 @@ func (s *testCase) reportDraw(skip int, value any) {
 
 func (s *testCase) Errorf(format string, args ...any) {
 	s.Note(fmt.Sprintf(format, args...))
-	s.failed = true
+	s.Fail()
 }
 
 func (s *testCase) Fail() {
-	s.failed = true
+	s.setStatus(libhegel.STATUS_INTERESTING)
 }
 
 func (s *testCase) FailNow() {
-	s.failed = true
-	panic(shortCircuit{errTestCaseAborted})
+	s.abort(errTestCaseAborted)
 }
 
 func (s *testCase) Log(args ...any) {
@@ -78,6 +77,51 @@ func (s *testCase) Target(value float64, label string) {
 	err := s.tc.Target(value, label)
 	if err != nil {
 		panic(err)
+	}
+}
+
+func (s *testCase) setStatus(status libhegel.Status) {
+	s.status = status
+	s.origin = ""
+	if s.status == libhegel.STATUS_INTERESTING {
+		s.origin = findExternalCaller()
+	}
+}
+
+func (s *testCase) getStatus() libhegel.Status {
+	return s.status
+}
+
+func (s *testCase) abort(err error) {
+	var status libhegel.Status
+	switch {
+	case err == nil:
+		status = s.status
+	case errors.Is(err, libhegel.E_ASSUME):
+		status = libhegel.STATUS_INVALID
+	case errors.Is(err, libhegel.E_STOP_TEST):
+		status = libhegel.STATUS_OVERRUN
+	case errors.Is(err, errTestCaseAborted):
+		status = libhegel.STATUS_INTERESTING
+	default:
+		// Unrecognized error: we panic instead of aborting.
+		panic(err)
+	}
+
+	if status < s.status {
+		// Ensure we never override STATUS_INTERESTING during an abort.
+		return
+	}
+
+	s.setStatus(status)
+	s.aborted = true
+	panic(err)
+}
+
+func (s *testCase) recoverAbort() {
+	if s.aborted {
+		s.aborted = false
+		_ = recover()
 	}
 }
 
@@ -492,26 +536,21 @@ func buildSettings(lib *libhegel.Handle, opts runOptions) *libhegel.Settings {
 	return s
 }
 
-// shortCircuit is the panic payload used to transport an error inside [Run].
-type shortCircuit struct {
-	err error
-}
-
 // driveOneCase runs one test case received from libhegel: invokes fn against a
 // fresh [testCase], recovers panics into a status (VALID/INVALID/OVERRUN/
 // INTERESTING) and an optional origin, and calls hegel_mark_complete.
 // Failures themselves are surfaced via hegel_run_result; the caller doesn't
 // need to inspect anything per-case.
-//
-// panicByOrigin records the most recent panic value seen at each origin so
-// the caller can include the dynamic panic message in the returned error
-// without putting it in the origin string (which libhegel uses as a
-// shrink-grouping key, and which therefore MUST be stable across all
-// failing inputs from the same call site).
 func driveOneCase(tc *libhegel.TestCase, fn testBody, single bool, baseOutput io.Writer) {
 	var caseOut io.Writer
+	var skipUserPanic bool
 	if tc.IsFinalReplay() || single {
 		caseOut = baseOutput
+
+		// Do not recover any pending panics on the final replay or when in
+		// single testcase mode.
+		// This ensures that debuggers can see the panics.
+		skipUserPanic = true
 	}
 
 	state := &testCase{
@@ -520,45 +559,27 @@ func driveOneCase(tc *libhegel.TestCase, fn testBody, single bool, baseOutput io
 		out:            caseOut,
 	}
 
-	status := libhegel.STATUS_VALID
-	var origin string
-
 	func() {
 		defer func() {
-			r := recover()
-			if r == nil {
-				if state.failed {
-					status = libhegel.STATUS_INTERESTING
-					origin = "test failed (via t.Error/t.Fail)"
-				}
+			if skipUserPanic {
 				return
 			}
-			switch v := r.(type) {
-			case shortCircuit:
-				switch {
-				case errors.Is(v.err, libhegel.E_ASSUME):
-					status = libhegel.STATUS_INVALID
-				case errors.Is(v.err, libhegel.E_STOP_TEST):
-					status = libhegel.STATUS_OVERRUN
-				case errors.Is(v.err, errTestCaseAborted):
-					status = libhegel.STATUS_INTERESTING
-					origin = findExternalCaller()
-				default:
-					panic(fmt.Sprintf("unrecognized short circuit: %v", v))
-				}
 
-			default:
-				status = libhegel.STATUS_INTERESTING
-				origin = findExternalCaller()
-				if caseOut != nil {
-					fmt.Fprintf(caseOut, "panic: %v at %s\n", v, origin)
-				}
+			r := recover()
+			if r == nil {
+				return
 			}
+
+			// The panic is recovered into an INTERESTING status. On the final
+			// replay (or in single-case mode) we never get here: skipUserPanic
+			// lets the panic propagate so the Go runtime prints it for debuggers.
+			state.setStatus(libhegel.STATUS_INTERESTING)
 		}()
+		defer state.recoverAbort()
 		fn(state)
 	}()
 
-	tc.MarkComplete(status, origin)
+	tc.MarkComplete(state.status, state.origin)
 }
 
 // collectFailures walks the failure list from a finished run and joins the

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,9 +1,7 @@
 package hegel
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,23 +23,6 @@ func TestRunHegelTestPasses(t *testing.T) {
 	}, WithTestCases(5))
 	if !called {
 		t.Error("test function was never called")
-	}
-}
-
-func TestRunHegelTestFails(t *testing.T) {
-	t.Parallel()
-	var buf bytes.Buffer
-	err := run(func(tc TestCase) {
-		x := Draw[int](tc, Integers[int](0, 100))
-		if x >= 0 {
-			panic(fmt.Sprintf("assertion failed: %d >= 0", x))
-		}
-	}, WithTestCases(1), WithDatabase(DatabaseDisabled()), withOutput(&buf))
-	if err == nil {
-		t.Fatal("expected failure")
-	}
-	if out := buf.String(); !strings.Contains(out, "assertion failed") {
-		t.Errorf("expected output to mention assertion; got %q", out)
 	}
 }
 
@@ -124,7 +105,10 @@ func TestRunHegelTestSingleCase(t *testing.T) {
 
 // --- MustRun: panics on error ---
 
-func TestMustRunPanicsOnError(t *testing.T) {
+// TestMustRunPanicsOnUserPanic covers the exploratory-case recover path in
+// driveOneCase: a user panic on a non-final case is recovered into an
+// INTERESTING status (the final replay then re-panics, which MustRun surfaces).
+func TestMustRunPanicsOnUserPanic(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
@@ -133,6 +117,21 @@ func TestMustRunPanicsOnError(t *testing.T) {
 	}()
 	MustRun(func(tc TestCase) {
 		panic("nope")
+	}, WithTestCases(2), WithDatabase(DatabaseDisabled()))
+}
+
+// TestMustRunPanicsOnReturnedError covers MustRun's panic(err) branch: failing
+// via Fail (rather than panicking) makes the property surface as a returned
+// error from Run, which MustRun re-panics.
+func TestMustRunPanicsOnReturnedError(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected MustRun to panic on returned error")
+		}
+	}()
+	MustRun(func(tc TestCase) {
+		tc.Fail()
 	}, WithTestCases(2), WithDatabase(DatabaseDisabled()))
 }
 
@@ -264,26 +263,6 @@ func TestExtractPanicOriginStableAcrossValues(t *testing.T) {
 	b := findExternalCaller()
 	if a != b {
 		t.Errorf("origin must be stable; got %q vs %q", a, b)
-	}
-}
-
-// TestRunHegelTestFailsSurfacesPanicMessage verifies that a panicked test
-// surfaces the panic value back through Run's returned error. The value
-// flows via the panicByOrigin capture in runProperty, not through the
-// origin field (which has to stay stable for shrinker grouping).
-func TestRunHegelTestFailsSurfacesPanicMessage(t *testing.T) {
-	t.Parallel()
-	var buf bytes.Buffer
-	err := run(func(tc TestCase) {
-		x := Draw[int](tc, Integers[int](0, 100))
-		_ = x
-		panic("BOOM-marker")
-	}, WithTestCases(2), WithDatabase(DatabaseDisabled()), withOutput(&buf))
-	if err == nil {
-		t.Fatal("expected failure from panic")
-	}
-	if !strings.Contains(buf.String(), "BOOM-marker") {
-		t.Errorf("expected output to include panic value; got %q", err)
 	}
 }
 
@@ -496,29 +475,48 @@ func TestRunWithHandleFailureError(t *testing.T) {
 	}
 }
 
+// TestBuildSettingsExercisesAllSetters drives a clean (no-test-case) run with
+// rich options so buildSettings invokes every conditionally-applied settings
+// setter: Mode, TestCases, Seed, Database, DatabaseKey and SuppressHealthCheck.
+func TestBuildSettingsExercisesAllSetters(t *testing.T) {
+	t.Parallel()
+	lib := libhegel.Stub(
+		uintptr(1),     // settings_new
+		uintptr(1),     // run_start
+		uintptr(0), "", // next_test_case NULL => run finished
+		uintptr(1), // run_result
+		true,       // passed
+	)
+	seed := int64(7)
+	opts := runOptions{
+		testCases:           5,
+		seed:                &seed,
+		singleTestCase:      true,
+		database:            Database("/tmp/does-not-matter.db"),
+		databaseKey:         "TestBuildSettingsExercisesAllSetters",
+		suppressHealthCheck: []HealthCheck{FilterTooMuch},
+	}
+	if err := runWithHandle(lib, func(TestCase) {}, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunWithHandleTargetPanic(t *testing.T) {
 	t.Parallel()
-	var buf bytes.Buffer
 	lib := libhegel.Stub(
 		uintptr(1),
 		uintptr(1),
 		uintptr(1),         // one case
-		true,               // is_final_replay => output enabled
+		true,               // is_final_replay => user panics are not recovered
 		libhegel.E_BACKEND, // target fails
-		libhegel.OK,        // mark_complete
-		uintptr(0), "",     // run finished
-		uintptr(1),
-		true, // passed
 	)
-	err := runWithHandle(lib, func(tc TestCase) {
+	// On the final replay skipUserPanic lets the panic propagate out of
+	// runWithHandle (so the Go runtime prints it for debuggers); it is not
+	// recovered into a status or error. expectErrorPanic asserts it escapes.
+	defer expectErrorPanic(t, libhegel.E_BACKEND)
+	runWithHandle(lib, func(tc TestCase) {
 		tc.Target(1.0, "x")
-	}, runOptions{output: &buf})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(buf.String(), "panic:") {
-		t.Errorf("expected recovered panic to be reported, got %q", buf.String())
-	}
+	}, runOptions{})
 }
 
 // stubOpCase drives a single test case whose body calls fn against the
@@ -581,18 +579,29 @@ func TestRunWithHandleUnrecognizedShortCircuit(t *testing.T) {
 		uintptr(1),
 		uintptr(1),
 		uintptr(1),
-		false, // is_final_replay
+		true, // is_final_replay
 	)
-	defer func() {
-		r := recover()
-		s, ok := r.(string)
-		if !ok || !strings.Contains(s, "unrecognized short circuit") {
-			t.Fatalf("expected unrecognized-short-circuit re-panic, got %v", r)
-		}
-	}()
-	runWithHandle(lib, func(TestCase) {
-		panic(shortCircuit{errors.New("weird")})
+	var sentinel = errors.New("weird")
+	defer expectErrorPanic(t, sentinel)
+	runWithHandle(lib, func(tc TestCase) {
+		tc.abort(sentinel)
 	}, runOptions{})
+}
+
+// TestAbortDoesNotDowngradeInteresting covers the guard in abort that refuses
+// to lower an already-INTERESTING status: an Assume rejection (E_ASSUME =>
+// INVALID) on an interesting case is a no-op and does not panic.
+func TestAbortDoesNotDowngradeInteresting(t *testing.T) {
+	t.Parallel()
+	tc := newStubTestCase()
+	tc.setStatus(libhegel.STATUS_INTERESTING)
+	tc.abort(libhegel.E_ASSUME) // INVALID < INTERESTING => returns without aborting
+	if tc.getStatus() != libhegel.STATUS_INTERESTING {
+		t.Fatalf("status downgraded to %v", tc.getStatus())
+	}
+	if tc.aborted {
+		t.Fatal("expected case not to be marked aborted")
+	}
 }
 
 // --- Draw error injection (via newStubTestCase) ---
@@ -608,30 +617,30 @@ func (g errGen[T]) draw(TestCase) (T, error) { var z T; return z, g.err }
 //lint:ignore U1000 satisfies Generator interface; staticcheck misses generic dispatch
 func (g errGen[T]) asBasic() (*basicGenerator[T], bool, error) { return nil, false, nil }
 
-// expectShortCircuit is deferred to recover a Draw panic and assert its error.
-func expectShortCircuit(t *testing.T, want error) {
+// expectErrorPanic is deferred to recover a Draw panic and assert its error.
+func expectErrorPanic(t *testing.T, want error) {
 	t.Helper()
 	r := recover()
-	sc, ok := r.(shortCircuit)
+	err, ok := r.(error)
 	if !ok {
-		t.Fatalf("expected shortCircuit panic, got %v", r)
+		t.Fatalf("expected error panic, got %v", r)
 	}
-	if !errors.Is(sc.err, want) {
-		t.Errorf("shortCircuit err = %v, want %v", sc.err, want)
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want %v", err, want)
 	}
 }
 
 func TestDrawPanicsOnGenerateError(t *testing.T) {
 	t.Parallel()
 	tc := newStubTestCase(libhegel.E_BACKEND) // generate fails
-	defer expectShortCircuit(t, libhegel.E_BACKEND)
+	defer expectErrorPanic(t, libhegel.E_BACKEND)
 	Draw[int](tc, Integers[int](0, 10))
 }
 
 func TestDrawListStartSpanError(t *testing.T) {
 	t.Parallel()
 	tc := newStubTestCase(libhegel.E_BACKEND) // start_span fails
-	defer expectShortCircuit(t, libhegel.E_BACKEND)
+	defer expectErrorPanic(t, libhegel.E_BACKEND)
 	Draw[[]int](tc, Lists[int](errGen[int]{}))
 }
 
@@ -641,7 +650,7 @@ func TestDrawListNewCollectionError(t *testing.T) {
 		libhegel.OK,        // start_span
 		libhegel.E_BACKEND, // new_collection fails
 	)
-	defer expectShortCircuit(t, libhegel.E_BACKEND)
+	defer expectErrorPanic(t, libhegel.E_BACKEND)
 	Draw[[]int](tc, Lists[int](errGen[int]{}))
 }
 
@@ -652,7 +661,7 @@ func TestDrawListCollectionMoreError(t *testing.T) {
 		libhegel.OK,        // new_collection
 		libhegel.E_BACKEND, // collection_more fails => coll.Err()
 	)
-	defer expectShortCircuit(t, libhegel.E_BACKEND)
+	defer expectErrorPanic(t, libhegel.E_BACKEND)
 	Draw[[]int](tc, Lists[int](errGen[int]{}))
 }
 
@@ -662,7 +671,7 @@ func TestDrawMapNewCollectionError(t *testing.T) {
 		libhegel.OK,        // start_span (LABEL_MAP)
 		libhegel.E_BACKEND, // new_collection fails
 	)
-	defer expectShortCircuit(t, libhegel.E_BACKEND)
+	defer expectErrorPanic(t, libhegel.E_BACKEND)
 	Draw[map[int]int](tc, Maps[int, int](errGen[int]{}, errGen[int]{}))
 }
 
@@ -696,7 +705,7 @@ func TestDrawMapBasic(t *testing.T) {
 func TestDrawFilterStartSpanError(t *testing.T) {
 	t.Parallel()
 	tc := newStubTestCase(libhegel.E_BACKEND) // start_span(FILTER) fails
-	defer expectShortCircuit(t, libhegel.E_BACKEND)
+	defer expectErrorPanic(t, libhegel.E_BACKEND)
 	Draw[int](tc, &filteredGenerator[int]{
 		source:    Integers[int](0, 10),
 		predicate: func(int) bool { return true },

--- a/single_test_case_test.go
+++ b/single_test_case_test.go
@@ -1,10 +1,7 @@
 package hegel
 
 import (
-	"bytes"
-	"fmt"
 	"io"
-	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -89,29 +86,25 @@ func TestSingleTestCasePermissiveOptions(t *testing.T) {
 type unboundedMachine struct{ n int }
 
 func (m *unboundedMachine) RuleStep(_ TestCase) { m.n++ }
-func (m *unboundedMachine) InvariantBounded(_ TestCase) {
+func (m *unboundedMachine) InvariantBounded(tc TestCase) {
 	// Threshold well above statefulMaxSteps (50), so a successful failure
 	// proves the cap was lifted in single-test-case mode.
 	if m.n >= 200 {
-		panic(fmt.Sprintf("counter reached %d", m.n))
+		tc.FailNow()
 	}
 }
 
 func TestSingleTestCaseStatefulRunsBeyondDefaultCap(t *testing.T) {
 	t.Parallel()
-	var buf bytes.Buffer
 	m := &unboundedMachine{}
 	err := run(func(s TestCase) {
 		RunStateful(s, m)
-	}, WithSingleTestCase(), withOutput(&buf))
+	}, WithSingleTestCase())
 	if err == nil {
 		t.Fatalf("expected invariant to fail; counter reached %d", m.n)
 	}
 	if m.n <= statefulMaxSteps {
 		t.Errorf("expected >%d steps, got %d (cap not lifted?)", statefulMaxSteps, m.n)
-	}
-	if !strings.Contains(buf.String(), "counter reached") {
-		t.Errorf("expected invariant panic in output, got: %q", buf.String())
 	}
 }
 

--- a/state.go
+++ b/state.go
@@ -3,6 +3,8 @@ package hegel
 import (
 	"fmt"
 	"testing"
+
+	"hegel.dev/go/hegel/internal/libhegel"
 )
 
 // Compile-time check that T satisfies testing.TB.
@@ -50,7 +52,7 @@ func (t *T) Fatal(args ...any) {
 		t.Helper()
 		t.T.Log(msg)
 	}
-	panic(shortCircuit{errTestCaseAborted})
+	t.abort(errTestCaseAborted)
 }
 
 // Fatalf logs the formatted message via the embedded [*testing.T] and marks
@@ -61,7 +63,7 @@ func (t *T) Fatalf(format string, args ...any) {
 		t.Helper()
 		t.T.Log(msg)
 	}
-	panic(shortCircuit{errTestCaseAborted})
+	t.abort(errTestCaseAborted)
 }
 
 // Skip discards the current test case.
@@ -105,7 +107,7 @@ func (t *T) Errorf(format string, args ...any) {
 
 // Failed reports whether the test case has been marked as failed.
 func (t *T) Failed() bool {
-	return t.testCase.failed
+	return t.testCase.status == libhegel.STATUS_INTERESTING
 }
 
 // Log routes the message through the embedded [*testing.T].

--- a/state_test.go
+++ b/state_test.go
@@ -2,9 +2,10 @@ package hegel
 
 import (
 	"bytes"
-	"errors"
 	"strings"
 	"testing"
+
+	"hegel.dev/go/hegel/internal/libhegel"
 )
 
 // makeFakeT creates a *T with a zero testCase and a real *testing.T
@@ -35,19 +36,7 @@ func makeEmittingT(t *testing.T, buf *bytes.Buffer) *T {
 func TestTFatalPanicsWithSentinel(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected Fatal to panic")
-		}
-		fs, ok := r.(shortCircuit)
-		if !ok {
-			t.Fatalf("expected shortCircuit, got %T: %v", r, r)
-		}
-		if !errors.Is(fs.err, errTestCaseAborted) {
-			t.Errorf("expected errTestCaseAborted, got %q", fs.err)
-		}
-	}()
+	defer expectErrorPanic(t, errTestCaseAborted)
 	ht.Fatal("fatal message")
 }
 
@@ -92,64 +81,28 @@ func TestTFatalfPanicsWithSentinel(t *testing.T) {
 func TestTFailNowPanicsWithSentinel(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected FailNow to panic")
-		}
-		fs, ok := r.(shortCircuit)
-		if !ok {
-			t.Fatalf("expected fatalSentinel, got %T: %v", r, r)
-		}
-		if !errors.Is(fs.err, errTestCaseAborted) {
-			t.Errorf("expected errTestCaseAborted, got %s", fs.err)
-		}
-	}()
+	defer expectErrorPanic(t, errTestCaseAborted)
 	ht.FailNow()
 }
 
 func TestTSkipPanicsWithShortCircuit(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected Skip to panic")
-		}
-		if _, ok := r.(shortCircuit); !ok {
-			t.Fatalf("expected shortCircuit, got %T: %v", r, r)
-		}
-	}()
+	defer expectErrorPanic(t, libhegel.E_ASSUME)
 	ht.Skip("skipping")
 }
 
 func TestTSkipfPanicsWithShortCircuit(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected Skipf to panic")
-		}
-		if _, ok := r.(shortCircuit); !ok {
-			t.Fatalf("expected shortCircuit, got %T: %v", r, r)
-		}
-	}()
+	defer expectErrorPanic(t, libhegel.E_ASSUME)
 	ht.Skipf("skip: %d", 1)
 }
 
 func TestTSkipNowPanicsWithShortCircuit(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected SkipNow to panic")
-		}
-		if _, ok := r.(shortCircuit); !ok {
-			t.Fatalf("expected shortCircuit, got %T: %v", r, r)
-		}
-	}()
+	defer expectErrorPanic(t, libhegel.E_ASSUME)
 	ht.SkipNow()
 }
 
@@ -161,8 +114,8 @@ func TestTErrorSetsFailed(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
 	ht.Error("something went wrong")
-	if !ht.testCase.failed {
-		t.Error("expected failed to be true after Error()")
+	if ht.testCase.status != libhegel.STATUS_INTERESTING {
+		t.Error("expected status=INTERESTING after Error()")
 	}
 }
 
@@ -170,8 +123,8 @@ func TestTErrorfSetsFailed(t *testing.T) {
 	t.Parallel()
 	ht := makeFakeT(t)
 	ht.Errorf("error: %d", 99)
-	if !ht.testCase.failed {
-		t.Error("expected failed to be true after Errorf()")
+	if ht.testCase.status != libhegel.STATUS_INTERESTING {
+		t.Error("expected status=INTERESTING after Errorf()")
 	}
 }
 
@@ -180,8 +133,8 @@ func TestTErrorEmitsViaTestingT(t *testing.T) {
 	t.Parallel()
 	ht := makeEmittingT(t, &bytes.Buffer{})
 	ht.Error("something went wrong")
-	if !ht.testCase.failed {
-		t.Error("expected failed to be true after Error()")
+	if ht.testCase.status != libhegel.STATUS_INTERESTING {
+		t.Error("expected status=INTERESTING after Error()")
 	}
 }
 
@@ -190,8 +143,8 @@ func TestTErrorfEmitsViaTestingT(t *testing.T) {
 	t.Parallel()
 	ht := makeEmittingT(t, &bytes.Buffer{})
 	ht.Errorf("error: %d", 99)
-	if !ht.testCase.failed {
-		t.Error("expected failed to be true after Errorf()")
+	if ht.testCase.status != libhegel.STATUS_INTERESTING {
+		t.Error("expected status=INTERESTING after Errorf()")
 	}
 }
 
@@ -251,8 +204,8 @@ func TestTestCaseErrorfWritesAndFails(t *testing.T) {
 	var buf bytes.Buffer
 	s := &testCase{out: &buf}
 	s.Errorf("value=%d", 42)
-	if !s.failed {
-		t.Error("expected failed=true after Errorf")
+	if s.status != libhegel.STATUS_INTERESTING {
+		t.Error("expected status=INTERESTING after Errorf")
 	}
 	if got := strings.TrimSpace(buf.String()); got != "value=42" {
 		t.Errorf("expected %q, got %q", "value=42", got)

--- a/stateful.go
+++ b/stateful.go
@@ -1,7 +1,6 @@
 package hegel
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -96,7 +95,7 @@ func (sm *stateMachine) Run(tc TestCase) {
 	tc.Note("Initial invariant check.")
 	for _, inv := range sm.invariants {
 		if err := callInvariant(tc, inv.fn); err != nil {
-			panic(err)
+			tc.abort(err)
 		}
 	}
 
@@ -124,7 +123,7 @@ func (sm *stateMachine) Run(tc TestCase) {
 
 		ok, err := callRule(tc, rule.fn)
 		if err != nil { // coverage-ignore
-			panic(err)
+			tc.abort(err)
 		}
 		stepsAttempted++
 		if !ok {
@@ -133,7 +132,7 @@ func (sm *stateMachine) Run(tc TestCase) {
 		stepsSucceeded++
 		for _, inv := range sm.invariants {
 			if err := callInvariant(tc, inv.fn); err != nil { // coverage-ignore
-				panic(err)
+				tc.abort(err)
 			}
 		}
 	}
@@ -154,17 +153,17 @@ func callInvariant(tc TestCase, fn func(TestCase)) error {
 // It returns true if fn ran to completion, false if it rejected via
 // Assume. Other panics propagate to the caller.
 func callRule(tc TestCase, fn func(TestCase)) (bool, error) {
-	return withSpan(tc, libhegel.LABEL_STATEFUL, func() (ok bool, err error) {
+	return withSpan(tc, libhegel.LABEL_STATEFUL, func() (bool, error) {
 		defer func() {
-			r := recover()
-			if r == nil {
-				return
+			if tc.getStatus() == libhegel.STATUS_INVALID {
+				tc.setStatus(libhegel.STATUS_VALID)
 			}
-			if sc, ok := r.(shortCircuit); ok && errors.Is(sc.err, libhegel.E_ASSUME) {
-				return
+
+			if tc.getStatus() != libhegel.STATUS_VALID {
+				tc.abort(nil)
 			}
-			panic(r)
 		}()
+		defer tc.recoverAbort()
 		fn(tc)
 		return true, nil
 	})

--- a/stateful_test.go
+++ b/stateful_test.go
@@ -1,9 +1,6 @@
 package hegel
 
 import (
-	"bytes"
-	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -63,16 +60,19 @@ func (m *gatedMachine) RuleGated(tc TestCase) {
 	m.gateCount++
 }
 
-type rulePanicker struct{}
+// ruleFailer.RuleFail marks the case failed via Fail (which sets INTERESTING
+// without panicking), so callRule's deferred block observes a non-VALID status
+// after the rule returns and aborts via abort(nil).
+type ruleFailer struct{}
 
-func (rulePanicker) RuleBoom(_ TestCase) { panic("rule panic propagated") }
+func (ruleFailer) RuleFail(tc TestCase) { tc.Fail() }
 
 type invariantViolator struct{ n int }
 
 func (m *invariantViolator) RuleStep(_ TestCase) { m.n++ }
-func (m *invariantViolator) InvariantSmall(_ TestCase) {
+func (m *invariantViolator) InvariantSmall(tc TestCase) {
 	if m.n >= 3 {
-		panic(fmt.Sprintf("counter reached %d", m.n))
+		tc.FailNow()
 	}
 }
 
@@ -191,30 +191,24 @@ func TestRunStatefulAssumeRejectionRetries(t *testing.T) {
 	}
 }
 
-func TestRunStatefulRulePanicPropagates(t *testing.T) {
+func TestRunStatefulInvariantViolationFails(t *testing.T) {
 	t.Parallel()
-	var buf bytes.Buffer
 	err := run(func(tc TestCase) {
-		RunStateful(tc, &rulePanicker{})
-	}, withOutput(&buf))
+		RunStateful(tc, &invariantViolator{})
+	}, WithTestCases(10))
 	if err == nil {
 		t.Fatal("Expected error")
-	}
-	if !strings.Contains(buf.String(), "rule panic propagated") {
-		t.Fatalf("Expected rule panic propagated in output, got %q", buf.String())
 	}
 }
 
-func TestRunStatefulInvariantViolationFails(t *testing.T) {
+// TestRunStatefulRuleFailureAborts covers callRule's deferred abort(nil) when a
+// rule leaves the case in a non-VALID status (via Fail) rather than panicking.
+func TestRunStatefulRuleFailureAborts(t *testing.T) {
 	t.Parallel()
-	var buf bytes.Buffer
 	err := run(func(tc TestCase) {
-		RunStateful(tc, &invariantViolator{})
-	}, WithTestCases(10), withOutput(&buf))
+		RunStateful(tc, &ruleFailer{})
+	}, WithTestCases(10))
 	if err == nil {
 		t.Fatal("Expected error")
-	}
-	if !strings.Contains(buf.String(), "counter reached") {
-		t.Fatalf("Expected counter reached in output, got %q", buf.String())
 	}
 }


### PR DESCRIPTION
do not recover panics during final replay

    Debugging a hegel test is currently a frustrating experience because the
    harness recovers all panics unconditionally. This means that delve / GoLand,
    etc. do not automatically break on a panic at the correct location.

    Fix this by reworking how we handle / deal with panics. First, introduce
    testCase.abort() and testCase.recoverAbort() which provide a mechanism to
    short circuit a test case execution. The mechanism uses panics behind the
    scenes but ensures that the user never sees these.

    Second, we stop recovering non-short circuit panics during the final replay
    of a test case. This enables native panic output and debugger integration.

    Fixes: https://github.com/hegeldev/hegel-go/issues/79
