### PR TITLE
Fixes to stateful testing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+This release fixes two issues in stateful testing:
+
+- Calling `Assume()` inside an invariant now rejects only that invariant
+  invocation rather than the entire test case, matching the behaviour of
+  `Assume()` inside a rule.
+- The number of steps taken during a stateful run is now drawn with a
+  skewed distribution clamped to the maximum step count, aligning step
+  selection with the other Hegel libraries so that shrinking behaves
+  consistently.

--- a/stateful.go
+++ b/stateful.go
@@ -107,7 +107,9 @@ func (sm *stateMachine) Run(tc TestCase) {
 	if isSingle {
 		nSteps = math.MaxInt
 	} else {
-		nSteps = Draw(tc, Integers(1, statefulMaxSteps))
+		// NB: Draw(Integers(0, statefulMaxSteps)) is not equivalent here
+		// because the resulting distribution is different.
+		nSteps = min(Draw(tc, Integers(0, math.MaxInt)), statefulMaxSteps)
 	}
 	stepsSucceeded := 0
 	stepsAttempted := 0

--- a/stateful.go
+++ b/stateful.go
@@ -94,7 +94,7 @@ func newStateMachine[M any, T interface{ *M }](machine T) (*stateMachine, error)
 func (sm *stateMachine) Run(tc TestCase) {
 	tc.Note("Initial invariant check.")
 	for _, inv := range sm.invariants {
-		if err := callInvariant(tc, inv.fn); err != nil {
+		if _, err := callRule(tc, inv.fn); err != nil {
 			tc.abort(err)
 		}
 	}
@@ -131,21 +131,11 @@ func (sm *stateMachine) Run(tc TestCase) {
 		}
 		stepsSucceeded++
 		for _, inv := range sm.invariants {
-			if err := callInvariant(tc, inv.fn); err != nil { // coverage-ignore
+			if _, err := callRule(tc, inv.fn); err != nil { // coverage-ignore
 				tc.abort(err)
 			}
 		}
 	}
-}
-
-// callInvariant brackets fn(tc) in a labelStateful span. Panics propagate
-// to the caller; invariant failures must surface as test failures.
-func callInvariant(tc TestCase, fn func(TestCase)) error {
-	_, err := withSpan(tc, libhegel.LABEL_STATEFUL, func() (struct{}, error) {
-		fn(tc)
-		return struct{}{}, nil
-	})
-	return err
 }
 
 // callRule brackets fn(tc) in a labelStateful span and recovers from


### PR DESCRIPTION
stateful: treat invariants like rules

    Currently calling TestCase.Assume() inside an invariant will reject the
    entire stateful test case instead of just the invariant.

    Align the behaviour with the one for rules, where Assume() only rejects that
    function.

stateful: align number of steps with other hegel libraries

    The number of steps taken during a stateful run is meant to be 
    statefulMaxSteps most of the time, but sometimes a smaller amount
    (so that shrinking can work).

    The way to achieve this is to draw an unbounded integer (which has a skewed
    distribution) and then clamping that to statefulMaxSteps.
