### PR TITLE
allow hegel-release bot in claude action

### DIFF
--- a/.github/workflows/bump-hegel-rust.yml
+++ b/.github/workflows/bump-hegel-rust.yml
@@ -63,6 +63,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          # hegel-rust fires this workflow via repository_dispatch using the
+          # hegel-release[bot] app token, so the actor is a bot. The action
+          # blocks bot-initiated runs by default; allow this specific bot.
+          allowed_bots: hegel-release
           prompt: |
             The pinned libhegel version was just bumped to v${{ steps.bump.outputs.version }}
             (internal/libhegel/checksums.go) on this checkout. Use the align-libhegel skill


### PR DESCRIPTION
The `Bump hegel-rust` workflow is fired by hegel-rust's release automation via `repository_dispatch`, which uses the `hegel-release[bot]` app token. That makes the workflow's actor a bot, and `anthropics/claude-code-action` blocks bot-initiated runs by default.

https://github.com/hegeldev/hegel-go/actions/runs/27785206319