### PR TITLE
Expose engine settings knobs and let libhegel own CI detection

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,9 +53,7 @@ The user-facing surface lives in `hegel.go` (canonical package doc). Entry point
 - `hegel.Draw(ht, gen)` — draws a value inside a test body
 - `hegel.T` — passed to the [Test] body; methods include `Note`, `Fatal`, `Fatalf`
 - Generators: `Integers`, `Floats`, `Text`, `Booleans`, `Lists`, `Maps`, ...
-- Options: `WithTestCases(n)`, `WithDatabase(Database(path))`,
-  `WithDatabase(DatabaseDisabled())`, `WithDerandomize(bool)`, `WithSeed(n)`,
-  `SuppressHealthCheck(...)`, `WithSingleTestCase()`
+- Options: `WithTestCases(n)`, `WithDatabase(path)`, ...
 
 ## Testing Philosophy
 

--- a/.github/coverage-ratchet.json
+++ b/.github/coverage-ratchet.json
@@ -1,3 +1,3 @@
 {
-  "coverage_ignore_count": 30
+  "coverage_ignore_count": 29
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+RELEASE_TYPE: patch
+
+This release changes `WithDatabase` to take a plain `string` path instead of a `DatabaseSetting` value. The `DatabaseSetting` type and its `Database` and `DatabaseDisabled` constructors have been removed. A non-empty path persists failing examples to that directory; an empty path disables persistence.
+
+```go
+// before
+hegel.Test(t, body, hegel.WithDatabase(hegel.Database("examples")))
+hegel.Test(t, body, hegel.WithDatabase(hegel.DatabaseDisabled()))
+
+// after
+hegel.Test(t, body, hegel.WithDatabase("examples"))
+hegel.Test(t, body, hegel.WithDatabase("")) // empty path disables persistence
+```
+
+This release also exposes four libhegel engine settings that previously had no public option:
+
+- `WithBackend` selects the randomness backend (`BackendAuto`, `BackendDefault`, `BackendURandom`) — for example to read fresh entropy on every draw when running under Antithesis.
+- `WithVerbosity` sets how much the engine logs (`VerbosityQuiet` through `VerbosityDebug`).
+- `WithReportMultipleFailures` asks the engine to report every distinct counterexample it finds rather than stopping at the first.
+- `WithPhases` restricts a run to specific phases (`PhaseExplicit`, `PhaseReuse`, `PhaseGenerate`, `PhaseTarget`, `PhaseShrink`); `AllPhases` returns them all.
+
+Passing `SuppressHealthCheck` more than once now keeps the last call's set of checks rather than accumulating across calls — pass every check to suppress in a single call.

--- a/database_test.go
+++ b/database_test.go
@@ -27,7 +27,6 @@ func readValues(t *testing.T, dir, label string) []int64 {
 }
 
 func TestDatabasePersistsFailingExamples(t *testing.T) {
-	clearCIEnv(t)
 	dbDir := t.TempDir()
 
 	entries, err := os.ReadDir(dbDir)
@@ -41,7 +40,7 @@ func TestDatabasePersistsFailingExamples(t *testing.T) {
 	err = run(func(tc TestCase) {
 		tc.Fail()
 	},
-		WithDatabase(Database(dbDir)),
+		WithDatabase(dbDir),
 		withDatabaseKey("test_database_persists"),
 	)
 	if err == nil {
@@ -72,7 +71,6 @@ func TestDatabaseKeyReplaysFailure(t *testing.T) {
 	}
 	dbStr := strings.ReplaceAll(dbPath, "\\", "/")
 
-	clearCIEnv(t)
 	t.Setenv("VALUES_DIR", valuesPath)
 
 	testCode := fmt.Sprintf(`package temptest
@@ -104,7 +102,7 @@ func TestReplay1(t *testing.T) {
 		if n >= 1_000_000 {
 			ht.Fatalf("n=%%d", n)
 		}
-	}, hegel.WithDatabase(hegel.Database(%q)))
+	}, hegel.WithDatabase(%q))
 }
 
 func TestReplay2(t *testing.T) {
@@ -114,7 +112,7 @@ func TestReplay2(t *testing.T) {
 		if n >= 1_000_000 {
 			ht.Fatalf("n=%%d", n)
 		}
-	}, hegel.WithDatabase(hegel.Database(%q)))
+	}, hegel.WithDatabase(%q))
 }
 `, dbStr, dbStr)
 

--- a/example_test.go
+++ b/example_test.go
@@ -36,14 +36,14 @@ func ExampleTest_withDatabase() {
 		if n < 0 {
 			ht.Fatal("negative integer should not be generated")
 		}
-	}, hegel.WithDatabase(hegel.Database("my_hegel_database")))
+	}, hegel.WithDatabase("my_hegel_database"))
 }
 
 func ExampleTest_disableDatabase() {
 	t := &testing.T{}
 	hegel.Test(t, func(ht *hegel.T) {
 		_ = hegel.Draw(ht, hegel.Booleans())
-	}, hegel.WithDatabase(hegel.DatabaseDisabled()))
+	}, hegel.WithDatabase("")) // empty path disables persistence
 }
 
 func ExampleTest_withDerandomize() {

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,26 +1,8 @@
 package hegel
 
 import (
-	"os"
 	"testing"
 )
-
-// clearCIEnv unsets every CI-detection env var for the duration of the test so
-// isCI() returns false even on a CI runner. Used by tests that need to assert
-// non-CI default behavior (e.g. the example database being enabled).
-//
-// It must genuinely unset the vars rather than set them to "": the matchAny
-// vars (e.g. CI) count as a CI signal whenever they are present, even empty, so
-// t.Setenv(name, "") would leave isCI() returning true on a CI runner.
-func clearCIEnv(t *testing.T) {
-	t.Helper()
-	for _, v := range ciEnvVars {
-		if old, ok := os.LookupEnv(v.name); ok {
-			os.Unsetenv(v.name)
-			t.Cleanup(func() { os.Setenv(v.name, old) })
-		}
-	}
-}
 
 // These tests verify that the t.Helper() calls inside T.Fatal, T.Fatalf, and
 // T.Logf cause t.Log to decorate output with the user's test file:line, not

--- a/runner.go
+++ b/runner.go
@@ -264,55 +264,88 @@ func AllHealthChecks() []HealthCheck {
 	return []HealthCheck{FilterTooMuch, TooSlow, TestCasesTooLarge, LargeInitialTestCase}
 }
 
-// --- Test runner options ---
+// --- Engine knobs ---
 
-// databaseState distinguishes "user has not set the database" (engine
-// default), "user disabled the database", and "user supplied a path".
-type databaseState int
+// Backend selects the engine's source of randomness. Pass one to [WithBackend].
+type Backend = libhegel.Backend
 
 const (
-	databaseUnset databaseState = iota
-	databaseDisabled
-	databasePath
+	// BackendAuto chooses automatically (the default): urandom under
+	// Antithesis, otherwise the default seeded PRNG.
+	BackendAuto = libhegel.BACKEND_AUTO
+	// BackendDefault expands a single seeded PRNG; runs are reproducible from
+	// the seed and shrinking / replay work as usual.
+	BackendDefault = libhegel.BACKEND_DEFAULT
+	// BackendURandom reads fresh entropy from /dev/urandom on every draw.
+	// Intended for running under Antithesis; you almost certainly don't want it
+	// otherwise.
+	BackendURandom = libhegel.BACKEND_URANDOM
 )
 
-// DatabaseSetting configures example-database persistence for a test run.
-// Construct one with [Database] (a path) or [DatabaseDisabled] (no
-// persistence) and pass it to [WithDatabase].
-type DatabaseSetting struct {
-	state databaseState
-	path  string
+// Verbosity controls how much the engine logs during a run. Pass one to
+// [WithVerbosity].
+type Verbosity = libhegel.Verbosity
+
+const (
+	// VerbosityQuiet suppresses engine logging.
+	VerbosityQuiet = libhegel.VERBOSITY_QUIET
+	// VerbosityNormal is the default logging level.
+	VerbosityNormal = libhegel.VERBOSITY_NORMAL
+	// VerbosityVerbose enables verbose logging.
+	VerbosityVerbose = libhegel.VERBOSITY_VERBOSE
+	// VerbosityDebug enables debug logging.
+	VerbosityDebug = libhegel.VERBOSITY_DEBUG
+)
+
+// Phase identifies one phase of a property-test run. Phases can be combined and
+// passed to [WithPhases] to restrict which phases the engine runs.
+type Phase = libhegel.Phase
+
+const (
+	// PhaseExplicit runs explicitly-provided examples.
+	PhaseExplicit = libhegel.PHASE_EXPLICIT
+	// PhaseReuse replays examples from the example database.
+	PhaseReuse = libhegel.PHASE_REUSE
+	// PhaseGenerate generates new examples.
+	PhaseGenerate = libhegel.PHASE_GENERATE
+	// PhaseTarget runs targeted-property search.
+	PhaseTarget = libhegel.PHASE_TARGET
+	// PhaseShrink shrinks failing examples.
+	PhaseShrink = libhegel.PHASE_SHRINK
+)
+
+// AllPhases returns all phase variants.
+func AllPhases() []Phase {
+	return []Phase{PhaseExplicit, PhaseReuse, PhaseGenerate, PhaseTarget, PhaseShrink}
 }
 
-// Database returns a [DatabaseSetting] that persists failing examples to the
-// given directory.
-func Database(path string) DatabaseSetting {
-	return DatabaseSetting{state: databasePath, path: path}
-}
+// --- Test runner options ---
 
-// DatabaseDisabled returns a [DatabaseSetting] that disables example-database
-// persistence. No failing examples are saved or replayed.
-//
-// In CI environments, the database is disabled by default; this setting is
-// useful when you want to disable it explicitly outside of CI.
-func DatabaseDisabled() DatabaseSetting {
-	return DatabaseSetting{state: databaseDisabled}
-}
+// settingApplier mutates a libhegel settings object. Options that map to an
+// engine setting append one of these; [runOptions.buildSettings] runs them in
+// order, so a later applier overrides an earlier one (this is how user options
+// override the CI defaults seeded by [run]).
+type settingApplier func(*libhegel.Context, *libhegel.Settings) error
 
 // runOptions holds options for property tests.
+//
+// Settings-backed options are recorded as appliers rather than inert fields, so
+// "not set" is simply "no applier" — the engine default applies and there is no
+// set/unset bookkeeping. Only options the runner itself reads (beyond
+// configuring libhegel) keep dedicated fields.
 type runOptions struct {
-	testCases           int
-	suppressHealthCheck []HealthCheck
-	database            DatabaseSetting
-	derandomize         bool
-	seed                *int64
-	singleTestCase      bool
-	// databaseKey identifies the test for example-database lookups. Set by
-	// [Test] from t.Name(); nil for [Run]/[MustRun].
-	databaseKey string
+	settingsAppliers []settingApplier
+	// singleTestCase is read by the runner and replay logic, not just passed to
+	// libhegel as a mode.
+	singleTestCase bool
 	// output receives note/draw-report output during single-test-case mode
 	// and during the final replay of interesting cases. nil means no output.
 	output io.Writer
+}
+
+// addSetting appends a libhegel settings mutation applied at build time.
+func (o *runOptions) addSetting(apply settingApplier) {
+	o.settingsAppliers = append(o.settingsAppliers, apply)
 }
 
 // Option is a functional option for Test and Run.
@@ -320,45 +353,129 @@ type Option func(*runOptions)
 
 // WithTestCases sets the number of test cases to run.
 func WithTestCases(n int) Option {
-	return func(o *runOptions) { o.testCases = n }
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.TestCases(ctx, uint64(n))
+		})
+	}
 }
 
-// SuppressHealthCheck suppresses the given health checks so they do not cause test failure.
+// SuppressHealthCheck suppresses the given health checks so they do not cause
+// test failure.
+//
+// Each call sets the complete suppression mask; calls do not accumulate, so
+// when SuppressHealthCheck is passed more than once the last call wins. Pass
+// every check to suppress in a single call.
 func SuppressHealthCheck(checks ...HealthCheck) Option {
-	return func(o *runOptions) { o.suppressHealthCheck = append(o.suppressHealthCheck, checks...) }
+	var mask HealthCheck
+	for _, hc := range checks {
+		mask |= hc
+	}
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.SuppressHealthCheck(ctx, mask)
+		})
+	}
 }
 
-// WithDatabase configures example-database persistence for this test.
-// Construct the setting with [Database] (a path) or [DatabaseDisabled].
+// WithDatabase configures example-database persistence for this test. A
+// non-empty path persists failing examples to that directory; an empty path
+// disables persistence entirely, so no failing examples are saved or replayed.
 //
 // The default (when WithDatabase is not specified) is to use libhegel's default
 // database location, except in CI environments where the database is
 // automatically disabled.
-func WithDatabase(db DatabaseSetting) Option {
-	return func(o *runOptions) { o.database = db }
+func WithDatabase(path string) Option {
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.Database(ctx, path)
+		})
+	}
 }
 
 // WithDerandomize sets whether to use a fixed seed for reproducible runs.
 func WithDerandomize(derandomize bool) Option {
-	return func(o *runOptions) { o.derandomize = derandomize }
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.Derandomize(ctx, derandomize)
+		})
+	}
 }
 
 // WithSeed sets a fixed random seed for the test, making it deterministic.
 func WithSeed(seed int64) Option {
-	return func(o *runOptions) { o.seed = &seed }
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.Seed(ctx, uint64(seed), true)
+		})
+	}
+}
+
+// WithBackend selects the engine's randomness backend. See [Backend]. The
+// default is [BackendAuto].
+func WithBackend(b Backend) Option {
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.Backend(ctx, b)
+		})
+	}
+}
+
+// WithVerbosity sets how much the engine logs during a run. See [Verbosity].
+// The default is [VerbosityNormal].
+func WithVerbosity(v Verbosity) Option {
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.Verbosity(ctx, v)
+		})
+	}
+}
+
+// WithReportMultipleFailures sets whether the engine reports every distinct
+// counterexample it finds rather than stopping at the first.
+func WithReportMultipleFailures(report bool) Option {
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.ReportMultipleFailures(ctx, report)
+		})
+	}
+}
+
+// WithPhases restricts the run to the given test phases. See [Phase] and
+// [AllPhases]. When WithPhases is not specified the engine runs all phases.
+func WithPhases(phases ...Phase) Option {
+	var mask Phase
+	for _, p := range phases {
+		mask |= p
+	}
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.Phases(ctx, mask)
+		})
+	}
 }
 
 // WithSingleTestCase runs exactly one test case with no shrinking, replay, or
 // example database. Use it for long-running workloads or tests whose body is
 // not safely re-runnable on the same inputs.
 func WithSingleTestCase() Option {
-	return func(o *runOptions) { o.singleTestCase = true }
+	return func(o *runOptions) {
+		o.singleTestCase = true
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.Mode(ctx, libhegel.MODE_SINGLE_TEST_CASE)
+		})
+	}
 }
 
 // withDatabaseKey sets the example-database key. Unexported: only [Test]
-// supplies a key, deriving it from t.Name().
+// supplies a key, deriving it from t.Name(). The key is applied unconditionally;
+// libhegel ignores it when the database is disabled.
 func withDatabaseKey(key string) Option {
-	return func(o *runOptions) { o.databaseKey = key }
+	return func(o *runOptions) {
+		o.addSetting(func(ctx *libhegel.Context, s *libhegel.Settings) error {
+			return s.DatabaseKey(ctx, key)
+		})
+	}
 }
 
 // withOutput sets the writer that receives note and draw-report output
@@ -367,43 +484,6 @@ func withDatabaseKey(key string) Option {
 // [Workload] to its stdout. Tests use it to inspect output.
 func withOutput(w io.Writer) Option {
 	return func(o *runOptions) { o.output = w }
-}
-
-// ciEnvVar describes a single CI-detection env var. If matchAny is true, the
-// var counts as a CI signal whenever it is present in the environment.
-type ciEnvVar struct {
-	name     string
-	expected string
-	matchAny bool
-}
-
-var ciEnvVars = []ciEnvVar{
-	{name: "CI", matchAny: true},
-	{name: "__TOX_ENVIRONMENT_VARIABLE_ORIGINAL_CI", matchAny: true},
-	{name: "TF_BUILD", expected: "true"},
-	{name: "bamboo.buildKey", matchAny: true},
-	{name: "BUILDKITE", expected: "true"},
-	{name: "CIRCLECI", expected: "true"},
-	{name: "CIRRUS_CI", expected: "true"},
-	{name: "CODEBUILD_BUILD_ID", matchAny: true},
-	{name: "GITHUB_ACTIONS", expected: "true"},
-	{name: "GITLAB_CI", matchAny: true},
-	{name: "HEROKU_TEST_RUN_ID", matchAny: true},
-	{name: "TEAMCITY_VERSION", matchAny: true},
-}
-
-// isCI reports whether any well-known CI environment variable is set.
-func isCI() bool {
-	for _, v := range ciEnvVars {
-		val, ok := os.LookupEnv(v.name)
-		if !ok {
-			continue
-		}
-		if v.matchAny || val == v.expected {
-			return true
-		}
-	}
-	return false
 }
 
 // Run runs a property test and returns any error.
@@ -441,13 +521,7 @@ func Test(t *testing.T, fn func(*T), opts ...Option) {
 // entry points leave it nil. Note/draw-report output is routed via
 // [withOutput]; absent that option no output is produced.
 func run(fn testBody, opts ...Option) error {
-	inCI := isCI()
-	o := runOptions{
-		derandomize: inCI,
-	}
-	if inCI {
-		o.database = DatabaseSetting{state: databaseDisabled}
-	}
+	var o runOptions
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -457,7 +531,7 @@ func run(fn testBody, opts ...Option) error {
 }
 
 func runWithContext(ctx *libhegel.Context, fn testBody, opts runOptions) error {
-	s, err := buildSettings(ctx, opts)
+	s, err := opts.buildSettings(ctx)
 	if err != nil {
 		return err
 	}
@@ -512,47 +586,19 @@ func runWithContext(ctx *libhegel.Context, fn testBody, opts runOptions) error {
 	}
 }
 
-func buildSettings(ctx *libhegel.Context, opts runOptions) (*libhegel.Settings, error) {
+// buildSettings constructs the libhegel settings for this run by applying every
+// recorded setting in order; later appliers override earlier ones.
+//
+// Each applier is a fallible libhegel call; a non-nil error means the option
+// was rejected and must be surfaced rather than silently dropped. Errors are
+// collected (nil entries dropped by errors.Join) so a bad option is reported
+// instead of being lost.
+func (o runOptions) buildSettings(ctx *libhegel.Context) (*libhegel.Settings, error) {
 	s := ctx.SettingsNew()
 
-	// Each setter is a fallible libhegel call; a non-nil error means the option
-	// was rejected and must be surfaced rather than silently dropped. Collect
-	// every applicable setter's error (nil entries are dropped by errors.Join)
-	// so a bad option is reported instead of being lost.
 	var errs []error
-	if opts.testCases > 0 {
-		errs = append(errs, s.TestCases(ctx, uint64(opts.testCases)))
-	}
-	errs = append(errs, s.Derandomize(ctx, opts.derandomize))
-	if opts.seed != nil {
-		errs = append(errs, s.Seed(ctx, uint64(*opts.seed), true))
-	}
-	if opts.singleTestCase {
-		errs = append(errs, s.Mode(ctx, libhegel.MODE_SINGLE_TEST_CASE))
-	}
-
-	switch opts.database.state {
-	case databaseUnset:
-		// Don't call: libhegel uses its default.
-	case databaseDisabled:
-		// Empty string disables the database.
-		errs = append(errs, s.Database(ctx, ""))
-	case databasePath:
-		errs = append(errs, s.Database(ctx, opts.database.path))
-	default: // coverage-ignore (databaseState enum is closed)
-		return nil, fmt.Errorf("unknown database state %d", opts.database.state)
-	}
-
-	if opts.database.state != databaseDisabled && opts.databaseKey != "" {
-		errs = append(errs, s.DatabaseKey(ctx, opts.databaseKey))
-	}
-
-	if len(opts.suppressHealthCheck) > 0 {
-		var mask HealthCheck
-		for _, hc := range opts.suppressHealthCheck {
-			mask |= hc
-		}
-		errs = append(errs, s.SuppressHealthCheck(ctx, mask))
+	for _, apply := range o.settingsAppliers {
+		errs = append(errs, apply(ctx, s))
 	}
 
 	if err := errors.Join(errs...); err != nil {

--- a/runner_test.go
+++ b/runner_test.go
@@ -75,7 +75,7 @@ func TestConcurrentRunHegelTest(t *testing.T) {
 				if v < 0 || v > 1000 {
 					panic("out of range")
 				}
-			}, WithTestCases(50), WithDatabase(DatabaseDisabled()))
+			}, WithTestCases(50), WithDatabase(""))
 			if err != nil {
 				failures.Add(1)
 			}
@@ -117,7 +117,7 @@ func TestMustRunPanicsOnUserPanic(t *testing.T) {
 	}()
 	MustRun(func(tc TestCase) {
 		panic("nope")
-	}, WithTestCases(2), WithDatabase(DatabaseDisabled()))
+	}, WithTestCases(2), WithDatabase(""))
 }
 
 // TestMustRunPanicsOnReturnedError covers MustRun's panic(err) branch: failing
@@ -132,7 +132,7 @@ func TestMustRunPanicsOnReturnedError(t *testing.T) {
 	}()
 	MustRun(func(tc TestCase) {
 		tc.Fail()
-	}, WithTestCases(2), WithDatabase(DatabaseDisabled()))
+	}, WithTestCases(2), WithDatabase(""))
 }
 
 func TestMustRunSuccess(t *testing.T) {
@@ -166,7 +166,7 @@ func TestStateFailedPath(t *testing.T) {
 	t.Parallel()
 	err := Run(func(tc TestCase) {
 		tc.Errorf("forced failure")
-	}, WithTestCases(5), WithDatabase(DatabaseDisabled()))
+	}, WithTestCases(5), WithDatabase(""))
 	if err == nil {
 		t.Fatal("expected failure when Errorf is called")
 	}
@@ -176,58 +176,9 @@ func TestFatalSentinelPath(t *testing.T) {
 	t.Parallel()
 	err := Run(func(tc TestCase) {
 		tc.FailNow()
-	}, WithTestCases(5), WithDatabase(DatabaseDisabled()))
+	}, WithTestCases(5), WithDatabase(""))
 	if err == nil {
 		t.Fatal("expected failure when FailNow is called")
-	}
-}
-
-// --- isCI: expected-value and match-any branches ---
-
-func TestIsCIMatchExpectedValue(t *testing.T) {
-	clearCIEnv(t)
-	// GITHUB_ACTIONS is a non-matchAny var: only "true" counts.
-	t.Setenv("GITHUB_ACTIONS", "true")
-	if !isCI() {
-		t.Error("expected isCI() true when GITHUB_ACTIONS=true")
-	}
-}
-
-func TestIsCIExpectedValueMismatch(t *testing.T) {
-	clearCIEnv(t)
-	// Present but not the expected value: must not count as CI.
-	t.Setenv("GITHUB_ACTIONS", "false")
-	if isCI() {
-		t.Error("expected isCI() false when GITHUB_ACTIONS=false")
-	}
-}
-
-func TestIsCIMatchAny(t *testing.T) {
-	clearCIEnv(t)
-	// CI is a matchAny var: any value (even empty) counts.
-	t.Setenv("CI", "")
-	if !isCI() {
-		t.Error("expected isCI() true when matchAny var CI is set")
-	}
-}
-
-func TestIsCINoneSet(t *testing.T) {
-	clearCIEnv(t)
-	if isCI() {
-		t.Error("expected isCI() false when no CI var is set")
-	}
-}
-
-// TestRunUnderCIDisablesDatabase covers run()'s CI branch (derandomize on,
-// database disabled by default) by forcing a CI env var, independent of
-// whether the test process itself runs on a CI runner.
-func TestRunUnderCIDisablesDatabase(t *testing.T) {
-	clearCIEnv(t)
-	t.Setenv("CI", "true")
-	if err := Run(func(tc TestCase) {
-		_ = Draw[bool](tc, Booleans())
-	}, WithTestCases(3)); err != nil {
-		t.Errorf("Run under CI: %v", err)
 	}
 }
 
@@ -276,12 +227,39 @@ func TestAllHealthChecks(t *testing.T) {
 	}
 }
 
-func TestSuppressHealthCheckOption(t *testing.T) {
+func TestAllPhases(t *testing.T) {
 	t.Parallel()
-	o := runOptions{}
-	SuppressHealthCheck(FilterTooMuch, TooSlow)(&o)
-	if len(o.suppressHealthCheck) != 2 {
-		t.Errorf("expected 2 suppressed checks, got %d", len(o.suppressHealthCheck))
+	all := AllPhases()
+	if len(all) != 5 {
+		t.Errorf("AllPhases: expected 5, got %d", len(all))
+	}
+}
+
+// TestSettingsOptionsRecordApplier checks that each settings-backed option
+// records exactly one applier. The value each applier sets is exercised
+// end-to-end by TestBuildSettingsExercisesAllSetters (against a stub) and the
+// per-option integration tests (against the real engine).
+func TestSettingsOptionsRecordApplier(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		opt  Option
+	}{
+		{"WithTestCases", WithTestCases(42)},
+		{"WithSeed", WithSeed(12345)},
+		{"WithDerandomize", WithDerandomize(true)},
+		{"WithDatabase", WithDatabase("/tmp/foo")},
+		{"WithBackend", WithBackend(BackendURandom)},
+		{"WithVerbosity", WithVerbosity(VerbosityVerbose)},
+		{"WithReportMultipleFailures", WithReportMultipleFailures(true)},
+		{"WithPhases", WithPhases(PhaseGenerate, PhaseShrink)},
+		{"SuppressHealthCheck", SuppressHealthCheck(FilterTooMuch, TooSlow)},
+	}
+	for _, tc := range cases {
+		o := applyOpts([]Option{tc.opt})
+		if len(o.settingsAppliers) != 1 {
+			t.Errorf("%s: recorded %d appliers, want 1", tc.name, len(o.settingsAppliers))
+		}
 	}
 }
 
@@ -291,7 +269,7 @@ func TestSuppressHealthCheckIntegration(t *testing.T) {
 		tc.Assume(false) // always reject
 	}, WithTestCases(20),
 		SuppressHealthCheck(FilterTooMuch),
-		WithDatabase(DatabaseDisabled()))
+		WithDatabase(""))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -299,47 +277,11 @@ func TestSuppressHealthCheckIntegration(t *testing.T) {
 
 // --- Options ---
 
-func TestWithTestCasesOption(t *testing.T) {
-	t.Parallel()
-	o := runOptions{}
-	WithTestCases(42)(&o)
-	if o.testCases != 42 {
-		t.Errorf("WithTestCases: expected 42, got %d", o.testCases)
-	}
-}
-
-func TestWithSeedOption(t *testing.T) {
-	t.Parallel()
-	o := runOptions{}
-	WithSeed(12345)(&o)
-	if o.seed == nil || *o.seed != 12345 {
-		t.Errorf("WithSeed: expected 12345, got %v", o.seed)
-	}
-}
-
-func TestDatabaseDisabledSetting(t *testing.T) {
-	t.Parallel()
-	o := runOptions{}
-	WithDatabase(DatabaseDisabled())(&o)
-	if o.database.state != databaseDisabled {
-		t.Errorf("WithDatabase(DatabaseDisabled): expected databaseDisabled, got %v", o.database.state)
-	}
-}
-
-func TestDatabasePathSetting(t *testing.T) {
-	t.Parallel()
-	o := runOptions{}
-	WithDatabase(Database("/tmp/foo"))(&o)
-	if o.database.state != databasePath || o.database.path != "/tmp/foo" {
-		t.Errorf("WithDatabase(Database): expected databasePath /tmp/foo, got %v %q", o.database.state, o.database.path)
-	}
-}
-
 func TestWithDerandomizeIntegration(t *testing.T) {
 	t.Parallel()
 	err := Run(func(tc TestCase) {
 		_ = Draw[int](tc, Integers[int](0, 100))
-	}, WithTestCases(5), WithDerandomize(true), WithDatabase(DatabaseDisabled()))
+	}, WithTestCases(5), WithDerandomize(true), WithDatabase(""))
 	if err != nil {
 		t.Errorf("derandomize integration: %v", err)
 	}
@@ -349,24 +291,56 @@ func TestWithSeedIntegration(t *testing.T) {
 	t.Parallel()
 	err := Run(func(tc TestCase) {
 		_ = Draw[int](tc, Integers[int](0, 100))
-	}, WithTestCases(5), WithSeed(42), WithDatabase(DatabaseDisabled()))
+	}, WithTestCases(5), WithSeed(42), WithDatabase(""))
 	if err != nil {
 		t.Errorf("seed integration: %v", err)
 	}
 }
 
-func TestRunHegelDisablesDatabaseInCI(t *testing.T) {
+func TestWithBackendIntegration(t *testing.T) {
 	t.Parallel()
-	// Apply opts directly without running so we can inspect.
-	if !isCI() {
-		t.Skip("only meaningful when CI env vars are set")
+	for _, b := range []Backend{BackendAuto, BackendDefault} {
+		err := Run(func(tc TestCase) {
+			_ = Draw[int](tc, Integers[int](0, 100))
+		}, WithTestCases(5), WithBackend(b), WithDatabase(""))
+		if err != nil {
+			t.Errorf("backend %v integration: %v", b, err)
+		}
 	}
-	o := runOptions{testCases: 100, derandomize: isCI()}
-	if isCI() {
-		o.database = DatabaseSetting{state: databaseDisabled}
+}
+
+func TestWithVerbosityIntegration(t *testing.T) {
+	t.Parallel()
+	err := Run(func(tc TestCase) {
+		_ = Draw[int](tc, Integers[int](0, 100))
+	}, WithTestCases(5), WithVerbosity(VerbosityQuiet), WithDatabase(""))
+	if err != nil {
+		t.Errorf("verbosity integration: %v", err)
 	}
-	if o.database.state != databaseDisabled {
-		t.Errorf("expected DB disabled in CI, got %v", o.database.state)
+}
+
+func TestWithPhasesIntegration(t *testing.T) {
+	t.Parallel()
+	// Restrict to generation only; a passing property still completes.
+	err := Run(func(tc TestCase) {
+		_ = Draw[int](tc, Integers[int](0, 100))
+	}, WithTestCases(5), WithPhases(PhaseGenerate), WithDatabase(""))
+	if err != nil {
+		t.Errorf("phases integration: %v", err)
+	}
+}
+
+// TestWithReportMultipleFailuresIntegration checks the option is accepted by
+// the engine on a passing property. (The distinct-failure count it controls is
+// keyed off per-call-site origins, which collapse to one in these white-box
+// tests, so the count itself isn't observable here.)
+func TestWithReportMultipleFailuresIntegration(t *testing.T) {
+	t.Parallel()
+	err := Run(func(tc TestCase) {
+		_ = Draw[int](tc, Integers[int](0, 100))
+	}, WithTestCases(5), WithReportMultipleFailures(true), WithDatabase(""))
+	if err != nil {
+		t.Errorf("report-multiple-failures integration: %v", err)
 	}
 }
 
@@ -405,7 +379,7 @@ func TestRunWithHandleRunStartError(t *testing.T) {
 		libhegel.E_BACKEND, // run_start fails
 		"run_start boom",
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil || !strings.Contains(err.Error(), "run_start boom") {
 		t.Fatalf("expected run_start error, got %v", err)
 	}
@@ -420,7 +394,7 @@ func TestRunWithHandleNextTestCaseError(t *testing.T) {
 		libhegel.E_BACKEND, // next_test_case fails...
 		"next boom",        // ...with an error message
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil || !strings.Contains(err.Error(), "next boom") {
 		t.Fatalf("expected next_test_case error, got %v", err)
 	}
@@ -435,7 +409,7 @@ func TestRunWithHandleRunResultError(t *testing.T) {
 		uintptr(0),                        // next_test_case NULL => run finished
 		libhegel.E_BACKEND, "result boom", // run_result fails
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil || !strings.Contains(err.Error(), "result boom") {
 		t.Fatalf("expected run_result error, got %v", err)
 	}
@@ -456,7 +430,7 @@ func TestRunWithHandleCollectFailures(t *testing.T) {
 		uintptr(1),                 // test_case_from_blob handle (replay)
 		"prop_test.go:7",           // failure origin
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil {
 		t.Fatal("expected failure error")
 	}
@@ -481,7 +455,7 @@ func TestRunWithContextSingleModeFailure(t *testing.T) {
 		uintptr(1),  // run_result
 		libhegel.RUN_STATUS_FAILED,
 	)
-	err := runWithContext(lib, func(tc TestCase) { tc.(*testCase).Fail() }, runOptions{singleTestCase: true})
+	err := runWithContext(lib, func(tc TestCase) { tc.(*testCase).Fail() }, applyOpts([]Option{WithDerandomize(false), WithSingleTestCase()}))
 	if !errors.Is(err, errPropTestFailed) {
 		t.Fatalf("expected single-mode prop-test failure, got %v", err)
 	}
@@ -505,7 +479,7 @@ func TestRunWithContextReplayBlobError(t *testing.T) {
 		libhegel.E_BACKEND, // test_case_from_blob fails...
 		"replay boom",      // ...with this diagnostic
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil || !strings.Contains(err.Error(), "replay boom") {
 		t.Fatalf("expected replay error, got %v", err)
 	}
@@ -523,7 +497,7 @@ func TestRunWithHandleFailureError(t *testing.T) {
 		uint64(1),                          // one failure
 		libhegel.E_BACKEND, "failure boom", // failure fetch fails
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil || !strings.Contains(err.Error(), "failure boom") {
 		t.Fatalf("expected failure-fetch error, got %v", err)
 	}
@@ -540,7 +514,7 @@ func TestRunWithHandleRunError(t *testing.T) {
 		libhegel.RUN_STATUS_ERROR, // run errored (e.g. failed health check)
 		"FailedHealthCheck: FilterTooMuch — …", // run-level error message
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil {
 		t.Fatal("expected run-error error")
 	}
@@ -550,8 +524,9 @@ func TestRunWithHandleRunError(t *testing.T) {
 }
 
 // TestBuildSettingsExercisesAllSetters drives a clean (no-test-case) run with
-// rich options so buildSettings invokes every conditionally-applied settings
-// setter: Mode, TestCases, Seed, Database, DatabaseKey and SuppressHealthCheck.
+// every settings-backed option so buildSettings invokes each setter applier:
+// TestCases, Derandomize, Seed, Database, DatabaseKey, SuppressHealthCheck,
+// Backend, Verbosity, ReportMultipleFailures, Phases and Mode.
 func TestBuildSettingsExercisesAllSetters(t *testing.T) {
 	t.Parallel()
 	lib := libhegel.Stub(
@@ -559,24 +534,34 @@ func TestBuildSettingsExercisesAllSetters(t *testing.T) {
 		libhegel.OK,                // test_cases
 		libhegel.OK,                // derandomize
 		libhegel.OK,                // seed
-		libhegel.OK,                // mode (single-test-case)
 		libhegel.OK,                // database
 		libhegel.OK,                // database_key
 		libhegel.OK,                // suppress_health_check
+		libhegel.OK,                // backend
+		libhegel.OK,                // verbosity
+		libhegel.OK,                // report_multiple_failures
+		libhegel.OK,                // phases
+		libhegel.OK,                // mode (single-test-case)
 		uintptr(1),                 // run_start
 		uintptr(0),                 // next_test_case NULL => run finished
 		uintptr(1),                 // run_result
 		libhegel.RUN_STATUS_PASSED, // passed
 	)
-	seed := int64(7)
-	opts := runOptions{
-		testCases:           5,
-		seed:                &seed,
-		singleTestCase:      true,
-		database:            Database("/tmp/does-not-matter.db"),
-		databaseKey:         "TestBuildSettingsExercisesAllSetters",
-		suppressHealthCheck: []HealthCheck{FilterTooMuch},
-	}
+	// Apply every settings-backed option, in the same order the stub expects
+	// each setter to fire.
+	opts := applyOpts([]Option{
+		WithTestCases(5),
+		WithDerandomize(false),
+		WithSeed(7),
+		WithDatabase("/tmp/does-not-matter.db"),
+		withDatabaseKey("TestBuildSettingsExercisesAllSetters"),
+		SuppressHealthCheck(FilterTooMuch),
+		WithBackend(BackendURandom),
+		WithVerbosity(VerbosityVerbose),
+		WithReportMultipleFailures(true),
+		WithPhases(PhaseGenerate, PhaseShrink),
+		WithSingleTestCase(),
+	})
 	if err := runWithContext(lib, func(TestCase) {}, opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -584,8 +569,8 @@ func TestBuildSettingsExercisesAllSetters(t *testing.T) {
 
 // TestBuildSettingsSetterError covers the setter-error branch in buildSettings:
 // a rejected settings option surfaces as an error from runWithContext rather
-// than being silently dropped. Derandomize is always applied, so a bare
-// runOptions{} reaches a setter before run_start.
+// than being silently dropped. A single derandomize applier reaches a setter
+// before run_start.
 func TestBuildSettingsSetterError(t *testing.T) {
 	t.Parallel()
 	lib := libhegel.Stub(
@@ -593,7 +578,7 @@ func TestBuildSettingsSetterError(t *testing.T) {
 		libhegel.E_BACKEND, // derandomize fails
 		"setter boom",      // diagnostic read by invoke
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil || !strings.Contains(err.Error(), "setter boom") {
 		t.Fatalf("expected settings-setter error, got %v", err)
 	}
@@ -612,7 +597,7 @@ func TestRunWithHandleMarkCompleteError(t *testing.T) {
 		libhegel.E_BACKEND, // mark_complete fails
 		"mark boom",        // diagnostic read by invoke
 	)
-	err := runWithContext(lib, func(TestCase) {}, runOptions{})
+	err := runWithContext(lib, func(TestCase) {}, applyOpts([]Option{WithDerandomize(false)}))
 	if err == nil || !strings.Contains(err.Error(), "mark boom") {
 		t.Fatalf("expected mark_complete error, got %v", err)
 	}
@@ -635,7 +620,7 @@ func TestRunWithHandleTargetPanic(t *testing.T) {
 	defer expectErrorPanic(t, libhegel.E_BACKEND)
 	runWithContext(lib, func(tc TestCase) {
 		tc.Target(1.0, "x")
-	}, runOptions{singleTestCase: true})
+	}, applyOpts([]Option{WithDerandomize(false), WithSingleTestCase()}))
 }
 
 // stubOpCase drives a single test case whose body calls fn against the
@@ -655,7 +640,7 @@ func stubOpCase(t *testing.T, op any, fn func(*testCase)) {
 		uintptr(1),
 		libhegel.RUN_STATUS_PASSED,
 	)
-	if err := runWithContext(lib, func(tc TestCase) { fn(tc.(*testCase)) }, runOptions{}); err != nil {
+	if err := runWithContext(lib, func(tc TestCase) { fn(tc.(*testCase)) }, applyOpts([]Option{WithDerandomize(false)})); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -706,7 +691,7 @@ func TestRunWithHandleUnrecognizedShortCircuit(t *testing.T) {
 	defer expectErrorPanic(t, sentinel)
 	runWithContext(lib, func(tc TestCase) {
 		tc.abort(sentinel)
-	}, runOptions{singleTestCase: true})
+	}, applyOpts([]Option{WithDerandomize(false), WithSingleTestCase()}))
 }
 
 // TestAbortDoesNotDowngradeInteresting covers the guard in abort that refuses
@@ -809,7 +794,7 @@ func TestDrawMapKeyError(t *testing.T) {
 		Draw[map[int]int](tc, Maps[int, int](
 			errGen[int]{err: libhegel.E_ASSUME}, errGen[int]{},
 		).MinSize(1))
-	}, WithTestCases(5), WithDatabase(DatabaseDisabled()), SuppressHealthCheck(FilterTooMuch))
+	}, WithTestCases(5), WithDatabase(""), SuppressHealthCheck(FilterTooMuch))
 	if err != nil {
 		t.Fatalf("expected all-invalid pass, got %v", err)
 	}
@@ -826,7 +811,7 @@ func TestDrawMapValueError(t *testing.T) {
 		Draw[map[int]int](tc, Maps[int, int](
 			Integers[int](0, 5), errGen[int]{err: libhegel.E_ASSUME},
 		).MinSize(1))
-	}, WithTestCases(5), WithDatabase(DatabaseDisabled()), SuppressHealthCheck(FilterTooMuch))
+	}, WithTestCases(5), WithDatabase(""), SuppressHealthCheck(FilterTooMuch))
 	if err != nil {
 		t.Fatalf("expected all-invalid pass, got %v", err)
 	}
@@ -837,7 +822,7 @@ func TestDrawMapBasic(t *testing.T) {
 	t.Parallel()
 	err := run(func(tc TestCase) {
 		_ = Draw[map[int]int](tc, Maps[int, int](Integers[int](0, 5), Integers[int](0, 5)))
-	}, WithTestCases(5), WithDatabase(DatabaseDisabled()))
+	}, WithTestCases(5), WithDatabase(""))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/single_test_case_test.go
+++ b/single_test_case_test.go
@@ -73,7 +73,7 @@ func TestSingleTestCasePermissiveOptions(t *testing.T) {
 		WithSingleTestCase(),
 		WithTestCases(50),
 		WithDerandomize(true),
-		WithDatabase(DatabaseDisabled()),
+		WithDatabase(""),
 		SuppressHealthCheck(FilterTooMuch),
 	)
 	if err != nil {

--- a/workload.go
+++ b/workload.go
@@ -150,8 +150,8 @@ func (f *singleTestCaseFlag) Option() Option {
 	return WithSingleTestCase()
 }
 
-// databaseFlag wires --database to [WithDatabase]. A non-empty value selects
-// [Database]; an empty value (--database=) selects [DatabaseDisabled].
+// databaseFlag wires --database to [WithDatabase]. A non-empty value sets the
+// database directory; an empty value (--database=) disables persistence.
 type databaseFlag struct {
 	path string
 }
@@ -167,10 +167,7 @@ func (f *databaseFlag) Set(s string) error {
 
 // Option returns the option corresponding to this flag.
 func (f *databaseFlag) Option() Option {
-	if f.path == "" {
-		return WithDatabase(DatabaseDisabled())
-	}
-	return WithDatabase(Database(f.path))
+	return WithDatabase(f.path)
 }
 
 // suppressHealthCheckFlag wires --suppress-health-check to

--- a/workload_test.go
+++ b/workload_test.go
@@ -49,9 +49,11 @@ func TestTestCasesFlagSetOption(t *testing.T) {
 	if f.String() != "7" {
 		t.Errorf("String=%q want %q", f.String(), "7")
 	}
-	o := applyOpts([]Option{f.Option()})
-	if o.testCases != 7 {
-		t.Errorf("testCases=%d want 7", o.testCases)
+	if f.n != 7 {
+		t.Errorf("n=%d want 7", f.n)
+	}
+	if o := applyOpts([]Option{f.Option()}); len(o.settingsAppliers) != 1 {
+		t.Errorf("Option recorded %d appliers, want 1", len(o.settingsAppliers))
 	}
 }
 
@@ -75,9 +77,11 @@ func TestDerandomizeFlagSetOption(t *testing.T) {
 	if f.String() != "true" {
 		t.Errorf("String=%q want %q", f.String(), "true")
 	}
-	o := applyOpts([]Option{f.Option()})
-	if !o.derandomize {
+	if !f.derandomize {
 		t.Error("expected derandomize=true")
+	}
+	if o := applyOpts([]Option{f.Option()}); len(o.settingsAppliers) != 1 {
+		t.Errorf("Option recorded %d appliers, want 1", len(o.settingsAppliers))
 	}
 }
 
@@ -98,10 +102,11 @@ func TestDatabaseFlagPath(t *testing.T) {
 	if f.String() != "/tmp/db" {
 		t.Errorf("String=%q want %q", f.String(), "/tmp/db")
 	}
-	o := applyOpts([]Option{f.Option()})
-	want := Database("/tmp/db")
-	if o.database != want {
-		t.Errorf("database=%+v want %+v", o.database, want)
+	if f.path != "/tmp/db" {
+		t.Errorf("path=%q want /tmp/db", f.path)
+	}
+	if o := applyOpts([]Option{f.Option()}); len(o.settingsAppliers) != 1 {
+		t.Errorf("Option recorded %d appliers, want 1", len(o.settingsAppliers))
 	}
 }
 
@@ -111,9 +116,11 @@ func TestDatabaseFlagDisabledViaEmpty(t *testing.T) {
 	if err := f.Set(""); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
-	o := applyOpts([]Option{f.Option()})
-	if o.database != DatabaseDisabled() {
-		t.Errorf("database=%+v want DatabaseDisabled()", o.database)
+	if f.path != "" {
+		t.Errorf("path=%q want empty", f.path)
+	}
+	if o := applyOpts([]Option{f.Option()}); len(o.settingsAppliers) != 1 {
+		t.Errorf("Option recorded %d appliers, want 1", len(o.settingsAppliers))
 	}
 }
 
@@ -129,10 +136,12 @@ func TestSuppressHealthCheckFlagRepeated(t *testing.T) {
 	if f.String() != "filter_too_much,too_slow" {
 		t.Errorf("String=%q", f.String())
 	}
-	o := applyOpts([]Option{f.Option()})
 	want := []HealthCheck{FilterTooMuch, TooSlow}
-	if !reflect.DeepEqual(o.suppressHealthCheck, want) {
-		t.Errorf("suppressHealthCheck=%v want %v", o.suppressHealthCheck, want)
+	if !reflect.DeepEqual(f.checks, want) {
+		t.Errorf("checks=%v want %v", f.checks, want)
+	}
+	if o := applyOpts([]Option{f.Option()}); len(o.settingsAppliers) != 1 {
+		t.Errorf("Option recorded %d appliers, want 1", len(o.settingsAppliers))
 	}
 }
 
@@ -222,6 +231,12 @@ func TestWorkloadBadHealthCheckReturnsError(t *testing.T) {
 }
 
 // --- Layering: Workload default < opts < CLI ---
+//
+// Each layer appends its own settings applier in order, so all layers are
+// preserved and the last one applied (CLI > opts > default) wins when
+// buildSettings replays them against libhegel (the engine setter is
+// last-call-wins). These tests assert that every layer contributes an applier,
+// in order; TestWorkloadParsesFlags exercises the composed result end-to-end.
 
 func TestWorkloadLayeringCLIOverrides(t *testing.T) {
 	t.Parallel()
@@ -234,8 +249,8 @@ func TestWorkloadLayeringCLIOverrides(t *testing.T) {
 	all = append(all, userOpts...)
 	all = append(all, tcFlag.Option())
 	o := applyOpts(all)
-	if o.testCases != 7 {
-		t.Errorf("CLI should win: testCases=%d want 7", o.testCases)
+	if len(o.settingsAppliers) != 3 {
+		t.Errorf("CLI layering: %d appliers, want 3 (default, opts, CLI)", len(o.settingsAppliers))
 	}
 }
 
@@ -244,8 +259,8 @@ func TestWorkloadLayeringOptsOverridesDefault(t *testing.T) {
 	userOpts := []Option{WithTestCases(13)}
 	all := append([]Option{WithTestCases(math.MaxInt)}, userOpts...)
 	o := applyOpts(all)
-	if o.testCases != 13 {
-		t.Errorf("opts should beat default: testCases=%d want 13", o.testCases)
+	if len(o.settingsAppliers) != 2 {
+		t.Errorf("opts layering: %d appliers, want 2 (default, opts)", len(o.settingsAppliers))
 	}
 }
 
@@ -253,8 +268,8 @@ func TestWorkloadLayeringDefaultAlone(t *testing.T) {
 	t.Parallel()
 	all := []Option{WithTestCases(math.MaxInt)}
 	o := applyOpts(all)
-	if o.testCases != math.MaxInt {
-		t.Errorf("default: testCases=%d want MaxInt", o.testCases)
+	if len(o.settingsAppliers) != 1 {
+		t.Errorf("default layering: %d appliers, want 1", len(o.settingsAppliers))
 	}
 }
 


### PR DESCRIPTION
Add WithBackend, WithVerbosity, WithReportMultipleFailures, and WithPhases options (plus the Backend/Verbosity/Phase types and AllPhases), surfacing libhegel settings that previously had no public API.

Rework settings options to record the libhegel mutation they perform rather than translating inert runOptions fields at build time, so an option that is not passed simply leaves the engine default in place — no set/unset bookkeeping. buildSettings is now a method on runOptions that replays the recorded appliers in order (later wins). SuppressHealthCheck is now last-wins across repeated calls.

Drop hegel-go's own CI detection: hegel_settings_new already detects CI environments and applies the derandomize/disabled-database defaults, so the duplicate isCI() logic is removed. Behavior is unchanged.