### PR TITLE
Fix use-after-free bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## Unreleased
-
-Fixed a rare crash: a wrapper's GC cleanup could free its native libhegel
-handle while a call on that same handle was still executing, because the
-raw handle is invisible to the collector and the wrapper's last use can
-precede the call's return (observed once as a SIGSEGV inside
-`hegel_mark_complete`). Every native call now pins its handle's wrapper
-with `runtime.KeepAlive`, and a test enforces the rule for all future
-bindings.
-
 ## 0.6.15 - 2026-07-08
 
 This patch bumps our pinned libhegel ([hegel-rust](hegeldev/hegel-rust)) from [0.27.0](https://github.com/hegeldev/hegel-rust/releases/tag/v0.27.0) to [0.28.0](https://github.com/hegeldev/hegel-rust/releases/tag/v0.28.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+Fixed a rare crash: a wrapper's GC cleanup could free its native libhegel
+handle while a call on that same handle was still executing, because the
+raw handle is invisible to the collector and the wrapper's last use can
+precede the call's return (observed once as a SIGSEGV inside
+`hegel_mark_complete`). Every native call now pins its handle's wrapper
+with `runtime.KeepAlive`, and a test enforces the rule for all future
+bindings.
+
 ## 0.6.15 - 2026-07-08
 
 This patch bumps our pinned libhegel ([hegel-rust](hegeldev/hegel-rust)) from [0.27.0](https://github.com/hegeldev/hegel-rust/releases/tag/v0.27.0) to [0.28.0](https://github.com/hegeldev/hegel-rust/releases/tag/v0.28.0).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch fixes a rare crash. A wrapper's GC cleanup could free its
+native libhegel handle while a call on that same handle was still
+executing, because the raw handle is invisible to the collector and the
+wrapper's last use can precede the call's return (observed once as a
+segfault inside `hegel_mark_complete`). Every native call now pins its
+handle's wrapper with `runtime.KeepAlive`, and a test enforces the rule
+for all future bindings.

--- a/internal/libhegel/keepalive_test.go
+++ b/internal/libhegel/keepalive_test.go
@@ -1,0 +1,80 @@
+package libhegel
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestNativeCallsKeepHandleOwnersAlive enforces the binding's lifetime rule:
+// every function that reads a wrapper's raw handle must also pass the wrapper
+// to runtime.KeepAlive, so the wrapper stays reachable for the duration of
+// the native call that uses the handle.
+//
+// The raw handle is a plain uintptr — the collector cannot see it — and each
+// wrapper's GC cleanup frees the native handle. Per runtime.AddCleanup, "a
+// function argument or receiver may become unreachable at the last point
+// where the object is used", which for a wrapper method is before the native
+// call returns: the closure has already loaded x.syms and x.raw. Without the
+// KeepAlive, a collection during the call can free the handle out from under
+// the still-executing native code (observed in practice as a one-off SIGSEGV
+// inside hegel_mark_complete: the *TestCase wrapper's last use was the
+// MarkComplete call itself, and the cleanup's hegel_test_case_free ran while
+// the native call held references into the freed handle).
+func TestNativeCallsKeepHandleOwnersAlive(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "libhegel.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse libhegel.go: %v", err)
+	}
+
+	// Constructors that only touch raw before registering the cleanup: no
+	// cleanup exists yet, so nothing can free the handle mid-call.
+	exempt := map[string]bool{
+		"allocate":   true,
+		"NewContext": true,
+	}
+
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || exempt[fd.Name.Name] {
+			continue
+		}
+		rawOwners := map[string]bool{}
+		kept := map[string]bool{}
+		ast.Inspect(fd, func(n ast.Node) bool {
+			switch e := n.(type) {
+			case *ast.SelectorExpr:
+				if e.Sel.Name == "raw" {
+					if id, ok := e.X.(*ast.Ident); ok {
+						rawOwners[id.Name] = true
+					}
+				}
+			case *ast.CallExpr:
+				sel, ok := e.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "runtime" || sel.Sel.Name != "KeepAlive" {
+					return true
+				}
+				if len(e.Args) == 1 {
+					if id, ok := e.Args[0].(*ast.Ident); ok {
+						kept[id.Name] = true
+					}
+				}
+			}
+			return true
+		})
+		for owner := range rawOwners {
+			if !kept[owner] {
+				pos := fset.Position(fd.Pos())
+				t.Errorf("%s (%s): %s.raw is passed to a native call without runtime.KeepAlive(%s)",
+					fd.Name.Name, pos, owner, owner)
+			}
+		}
+	}
+}

--- a/internal/libhegel/libhegel.go
+++ b/internal/libhegel/libhegel.go
@@ -430,16 +430,21 @@ func (c *Context) invoke(op string, fn func(ctx ctxT) Error) error {
 
 	e := fn(ptr)
 	if e == OK {
+		runtime.KeepAlive(c)
 		return nil
 	}
 
+	var err error
 	if c != nil {
 		if msg := c.syms.ContextLastError(c.raw); msg != "" {
-			return fmt.Errorf("%s: %w: %s", op, e, msg)
+			err = fmt.Errorf("%s: %w: %s", op, e, msg)
 		}
 	}
-
-	return fmt.Errorf("%s: %w", op, e)
+	if err == nil {
+		err = fmt.Errorf("%s: %w", op, e)
+	}
+	runtime.KeepAlive(c)
+	return err
 }
 
 // globalSymbols loads the libhegel shared library once and returns the shared,
@@ -594,68 +599,90 @@ func (c *Context) SettingsNew() *Settings {
 
 func (s *Settings) Mode(ctx *Context, m Mode) error {
 	return ctx.invoke("hegel_settings_set_mode", func(ctx ctxT) Error {
-		return s.syms.SettingsSetMode(ctx, s.raw, m)
+		e := s.syms.SettingsSetMode(ctx, s.raw, m)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 // Backend selects the engine's randomness backend. See [Backend].
 func (s *Settings) Backend(ctx *Context, b Backend) error {
 	return ctx.invoke("hegel_settings_set_backend", func(ctx ctxT) Error {
-		return s.syms.SettingsSetBackend(ctx, s.raw, b)
+		e := s.syms.SettingsSetBackend(ctx, s.raw, b)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) TestCases(ctx *Context, n uint64) error {
 	return ctx.invoke("hegel_settings_set_test_cases", func(ctx ctxT) Error {
-		return s.syms.SettingsSetTestCases(ctx, s.raw, n)
+		e := s.syms.SettingsSetTestCases(ctx, s.raw, n)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) Verbosity(ctx *Context, v Verbosity) error {
 	return ctx.invoke("hegel_settings_set_verbosity", func(ctx ctxT) Error {
-		return s.syms.SettingsSetVerbosity(ctx, s.raw, v)
+		e := s.syms.SettingsSetVerbosity(ctx, s.raw, v)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) Seed(ctx *Context, seed uint64, hasSeed bool) error {
 	return ctx.invoke("hegel_settings_set_seed", func(ctx ctxT) Error {
-		return s.syms.SettingsSetSeed(ctx, s.raw, seed, hasSeed)
+		e := s.syms.SettingsSetSeed(ctx, s.raw, seed, hasSeed)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) Derandomize(ctx *Context, on bool) error {
 	return ctx.invoke("hegel_settings_set_derandomize", func(ctx ctxT) Error {
-		return s.syms.SettingsSetDerandomize(ctx, s.raw, on)
+		e := s.syms.SettingsSetDerandomize(ctx, s.raw, on)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) ReportMultipleFailures(ctx *Context, yes bool) error {
 	return ctx.invoke("hegel_settings_set_report_multiple_failures", func(ctx ctxT) Error {
-		return s.syms.SettingsSetReportMultipleFailures(ctx, s.raw, yes)
+		e := s.syms.SettingsSetReportMultipleFailures(ctx, s.raw, yes)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) Database(ctx *Context, path string) error {
 	return ctx.invoke("hegel_settings_set_database", func(ctx ctxT) Error {
-		return s.syms.SettingsSetDatabase(ctx, s.raw, path)
+		e := s.syms.SettingsSetDatabase(ctx, s.raw, path)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) DatabaseKey(ctx *Context, key string) error {
 	return ctx.invoke("hegel_settings_set_database_key", func(ctx ctxT) Error {
-		return s.syms.SettingsSetDatabaseKey(ctx, s.raw, key)
+		e := s.syms.SettingsSetDatabaseKey(ctx, s.raw, key)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) Phases(ctx *Context, p Phase) error {
 	return ctx.invoke("hegel_settings_set_phases", func(ctx ctxT) Error {
-		return s.syms.SettingsSetPhases(ctx, s.raw, p)
+		e := s.syms.SettingsSetPhases(ctx, s.raw, p)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
 func (s *Settings) SuppressHealthCheck(ctx *Context, checks HealthCheck) error {
 	return ctx.invoke("hegel_settings_set_suppress_health_check", func(ctx ctxT) Error {
-		return s.syms.SettingsSetSuppressHealthCheck(ctx, s.raw, checks)
+		e := s.syms.SettingsSetSuppressHealthCheck(ctx, s.raw, checks)
+		runtime.KeepAlive(s)
+		return e
 	})
 }
 
@@ -765,7 +792,9 @@ func (tc *TestCase) Clone(ctx *Context) (*TestCase, error) {
 // not shrunk).
 func (tc *TestCase) GenerateBoolean(ctx *Context, p float64, forced, hasForced bool) (bool, error) {
 	err := ctx.invoke("hegel_generate_boolean", func(ctx ctxT) Error {
-		return tc.syms.GenerateBoolean(ctx, tc.raw, p, forced, hasForced, &tc.outBool)
+		e := tc.syms.GenerateBoolean(ctx, tc.raw, p, forced, hasForced, &tc.outBool)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outBool, err
 }
@@ -774,7 +803,9 @@ func (tc *TestCase) GenerateBoolean(ctx *Context, p float64, forced, hasForced b
 // fit in int64; for wider bounds use [TestCase.GenerateIntegerBig].
 func (tc *TestCase) GenerateInteger(ctx *Context, minValue, maxValue int64) (int64, error) {
 	err := ctx.invoke("hegel_generate_integer", func(ctx ctxT) Error {
-		return tc.syms.GenerateInteger(ctx, tc.raw, minValue, maxValue, &tc.outInt)
+		e := tc.syms.GenerateInteger(ctx, tc.raw, minValue, maxValue, &tc.outInt)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outInt, err
 }
@@ -853,10 +884,12 @@ func (b BigInt) Uint64() uint64 {
 // buffers. Returns the drawn value's minimal little-endian bytes.
 func (tc *TestCase) GenerateIntegerBig(ctx *Context, minValue, maxValue BigInt) (BigInt, error) {
 	err := ctx.invoke("hegel_generate_integer_big", func(ctx ctxT) Error {
-		return tc.syms.GenerateIntegerBig(ctx, tc.raw,
+		e := tc.syms.GenerateIntegerBig(ctx, tc.raw,
 			slicePtr(minValue), uint64(len(minValue)),
 			slicePtr(maxValue), uint64(len(maxValue)),
 			&tc.outFixed[0], uint64(len(tc.outFixed)), &tc.outLen)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	if err != nil {
 		return nil, err
@@ -868,7 +901,9 @@ func (tc *TestCase) GenerateIntegerBig(ctx *Context, minValue, maxValue BigInt) 
 // maxValue]. See hegel_generate_float for the meaning of each flag.
 func (tc *TestCase) GenerateFloat(ctx *Context, width uint32, minValue, maxValue float64, allowNaN, allowInfinity, excludeMin, excludeMax bool, smallestNonzero float64) (float64, error) {
 	err := ctx.invoke("hegel_generate_float", func(ctx ctxT) Error {
-		return tc.syms.GenerateFloat(ctx, tc.raw, width, minValue, maxValue, allowNaN, allowInfinity, excludeMin, excludeMax, smallestNonzero, &tc.outFloat)
+		e := tc.syms.GenerateFloat(ctx, tc.raw, width, minValue, maxValue, allowNaN, allowInfinity, excludeMin, excludeMax, smallestNonzero, &tc.outFloat)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outFloat, err
 }
@@ -876,7 +911,9 @@ func (tc *TestCase) GenerateFloat(ctx *Context, width uint32, minValue, maxValue
 // GenerateBytes draws a byte string with length in [minSize, maxSize].
 func (tc *TestCase) GenerateBytes(ctx *Context, minSize, maxSize uint64) ([]byte, error) {
 	err := ctx.invoke("hegel_generate_bytes", func(ctx ctxT) Error {
-		return tc.syms.GenerateBytes(ctx, tc.raw, minSize, maxSize, &tc.outBytesRes)
+		e := tc.syms.GenerateBytes(ctx, tc.raw, minSize, maxSize, &tc.outBytesRes)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	if err != nil {
 		return nil, err
@@ -891,6 +928,7 @@ func (tc *TestCase) GenerateBytes(ctx *Context, minSize, maxSize uint64) ([]byte
 func (tc *TestCase) GenerateString(ctx *Context, gen *StringGenerator) (string, error) {
 	err := ctx.invoke("hegel_generate_string", func(ctx ctxT) Error {
 		e := tc.syms.GenerateString(ctx, tc.raw, gen.raw, &tc.outStringRes)
+		runtime.KeepAlive(tc)
 		runtime.KeepAlive(gen)
 		return e
 	})
@@ -906,7 +944,9 @@ func (tc *TestCase) GenerateString(ctx *Context, gen *StringGenerator) (string, 
 // GenerateDate draws a Gregorian calendar date in [minValue, maxValue].
 func (tc *TestCase) GenerateDate(ctx *Context, minValue, maxValue Date) (Date, error) {
 	err := ctx.invoke("hegel_generate_date", func(ctx ctxT) Error {
-		return tc.syms.GenerateDate(ctx, tc.raw, minValue, maxValue, &tc.outDate)
+		e := tc.syms.GenerateDate(ctx, tc.raw, minValue, maxValue, &tc.outDate)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outDate, err
 }
@@ -914,7 +954,9 @@ func (tc *TestCase) GenerateDate(ctx *Context, minValue, maxValue Date) (Date, e
 // GenerateTime draws a time of day in [minValue, maxValue].
 func (tc *TestCase) GenerateTime(ctx *Context, minValue, maxValue Time) (Time, error) {
 	err := ctx.invoke("hegel_generate_time", func(ctx ctxT) Error {
-		return tc.syms.GenerateTime(ctx, tc.raw, minValue, maxValue, &tc.outTime)
+		e := tc.syms.GenerateTime(ctx, tc.raw, minValue, maxValue, &tc.outTime)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outTime, err
 }
@@ -922,7 +964,9 @@ func (tc *TestCase) GenerateTime(ctx *Context, minValue, maxValue Time) (Time, e
 // GenerateDatetime draws a naive datetime in [minValue, maxValue].
 func (tc *TestCase) GenerateDatetime(ctx *Context, minValue, maxValue Datetime) (Datetime, error) {
 	err := ctx.invoke("hegel_generate_datetime", func(ctx ctxT) Error {
-		return tc.syms.GenerateDatetime(ctx, tc.raw, minValue, maxValue, &tc.outDatetime)
+		e := tc.syms.GenerateDatetime(ctx, tc.raw, minValue, maxValue, &tc.outDatetime)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outDatetime, err
 }
@@ -931,7 +975,9 @@ func (tc *TestCase) GenerateDatetime(ctx *Context, minValue, maxValue Datetime) 
 // RFC 4122 version nibble is forced to version.
 func (tc *TestCase) GenerateUUID(ctx *Context, version uint8, hasVersion bool) ([16]byte, error) {
 	err := ctx.invoke("hegel_generate_uuid", func(ctx ctxT) Error {
-		return tc.syms.GenerateUUID(ctx, tc.raw, version, hasVersion, &tc.outFixed[0])
+		e := tc.syms.GenerateUUID(ctx, tc.raw, version, hasVersion, &tc.outFixed[0])
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outFixed, err
 }
@@ -939,7 +985,9 @@ func (tc *TestCase) GenerateUUID(ctx *Context, version uint8, hasVersion bool) (
 // GenerateIPv4 draws an IPv4 address as 4 network-order bytes.
 func (tc *TestCase) GenerateIPv4(ctx *Context) ([4]byte, error) {
 	err := ctx.invoke("hegel_generate_ipv4", func(ctx ctxT) Error {
-		return tc.syms.GenerateIPv4(ctx, tc.raw, &tc.outFixed[0])
+		e := tc.syms.GenerateIPv4(ctx, tc.raw, &tc.outFixed[0])
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return [4]byte(tc.outFixed[:4]), err
 }
@@ -947,47 +995,61 @@ func (tc *TestCase) GenerateIPv4(ctx *Context) ([4]byte, error) {
 // GenerateIPv6 draws an IPv6 address as 16 network-order bytes.
 func (tc *TestCase) GenerateIPv6(ctx *Context) ([16]byte, error) {
 	err := ctx.invoke("hegel_generate_ipv6", func(ctx ctxT) Error {
-		return tc.syms.GenerateIPv6(ctx, tc.raw, &tc.outFixed[0])
+		e := tc.syms.GenerateIPv6(ctx, tc.raw, &tc.outFixed[0])
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outFixed, err
 }
 
 func (tc *TestCase) StartSpan(ctx *Context, label Label) error {
 	return ctx.invoke("hegel_start_span", func(ctx ctxT) Error {
-		return tc.syms.StartSpan(ctx, tc.raw, label)
+		e := tc.syms.StartSpan(ctx, tc.raw, label)
+		runtime.KeepAlive(tc)
+		return e
 	})
 }
 
 func (tc *TestCase) StopSpan(ctx *Context, discard bool) error {
 	return ctx.invoke("hegel_stop_span", func(ctx ctxT) Error {
-		return tc.syms.StopSpan(ctx, tc.raw, discard)
+		e := tc.syms.StopSpan(ctx, tc.raw, discard)
+		runtime.KeepAlive(tc)
+		return e
 	})
 }
 
 func (tc *TestCase) NewCollection(ctx *Context, min, max uint64) (Collection, error) {
 	err := ctx.invoke("hegel_new_collection", func(ctx ctxT) Error {
-		return tc.syms.NewCollection(ctx, tc.raw, min, max, &tc.outColl)
+		e := tc.syms.NewCollection(ctx, tc.raw, min, max, &tc.outColl)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outColl, err
 }
 
 func (tc *TestCase) CollectionMore(ctx *Context, coll Collection) (bool, error) {
 	err := ctx.invoke("hegel_collection_more", func(ctx ctxT) Error {
-		return tc.syms.CollectionMore(ctx, tc.raw, coll, &tc.outBool)
+		e := tc.syms.CollectionMore(ctx, tc.raw, coll, &tc.outBool)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outBool, err
 }
 
 func (tc *TestCase) CollectionReject(ctx *Context, coll Collection, why string) error {
 	return ctx.invoke("hegel_collection_reject", func(ctx ctxT) Error {
-		return tc.syms.CollectionReject(ctx, tc.raw, coll, why)
+		e := tc.syms.CollectionReject(ctx, tc.raw, coll, why)
+		runtime.KeepAlive(tc)
+		return e
 	})
 }
 
 // NewPool creates an engine-managed variable pool for stateful testing.
 func (tc *TestCase) NewPool(ctx *Context) (int64, error) {
 	err := ctx.invoke("hegel_new_pool", func(ctx ctxT) Error {
-		return tc.syms.NewPool(ctx, tc.raw, &tc.outInt)
+		e := tc.syms.NewPool(ctx, tc.raw, &tc.outInt)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outInt, err
 }
@@ -995,7 +1057,9 @@ func (tc *TestCase) NewPool(ctx *Context) (int64, error) {
 // PoolAdd registers a new variable in the pool, returning the engine-assigned id.
 func (tc *TestCase) PoolAdd(ctx *Context, pool int64) (int64, error) {
 	err := ctx.invoke("hegel_pool_add", func(ctx ctxT) Error {
-		return tc.syms.PoolAdd(ctx, tc.raw, pool, &tc.outInt)
+		e := tc.syms.PoolAdd(ctx, tc.raw, pool, &tc.outInt)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outInt, err
 }
@@ -1005,7 +1069,9 @@ func (tc *TestCase) PoolAdd(ctx *Context, pool int64) (int64, error) {
 // drawn variable is removed from the pool.
 func (tc *TestCase) PoolGenerate(ctx *Context, pool int64, consume bool) (int64, error) {
 	err := ctx.invoke("hegel_pool_generate", func(ctx ctxT) Error {
-		return tc.syms.PoolGenerate(ctx, tc.raw, pool, consume, &tc.outInt)
+		e := tc.syms.PoolGenerate(ctx, tc.raw, pool, consume, &tc.outInt)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outInt, err
 }
@@ -1023,12 +1089,14 @@ func (tc *TestCase) NewStateMachine(ctx *Context, ruleNames, invariantNames []st
 		return 0, fmt.Errorf("hegel_new_state_machine: invariant names: %w", err)
 	}
 	err = ctx.invoke("hegel_new_state_machine", func(ctx ctxT) Error {
-		return tc.syms.NewStateMachine(
+		e := tc.syms.NewStateMachine(
 			ctx, tc.raw,
 			slicePtr(rules), uint64(len(ruleNames)),
 			slicePtr(invariants), uint64(len(invariantNames)),
 			&tc.outSM,
 		)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outSM, err
 }
@@ -1037,20 +1105,26 @@ func (tc *TestCase) NewStateMachine(ctx *Context, ruleNames, invariantNames []st
 // [0, num_rules), letting the engine choose and shrink the rule sequence.
 func (tc *TestCase) StateMachineNextRule(ctx *Context, machine StateMachine) (int64, error) {
 	err := ctx.invoke("hegel_state_machine_next_rule", func(ctx ctxT) Error {
-		return tc.syms.StateMachineNextRule(ctx, tc.raw, machine, &tc.outInt)
+		e := tc.syms.StateMachineNextRule(ctx, tc.raw, machine, &tc.outInt)
+		runtime.KeepAlive(tc)
+		return e
 	})
 	return tc.outInt, err
 }
 
 func (tc *TestCase) Target(ctx *Context, value float64, label string) error {
 	return ctx.invoke("hegel_target", func(ctx ctxT) Error {
-		return tc.syms.Target(ctx, tc.raw, value, label)
+		e := tc.syms.Target(ctx, tc.raw, value, label)
+		runtime.KeepAlive(tc)
+		return e
 	})
 }
 
 func (tc *TestCase) MarkComplete(ctx *Context, status Status, origin string) error {
 	return ctx.invoke("hegel_mark_complete", func(ctx ctxT) Error {
-		return tc.syms.MarkComplete(ctx, tc.raw, status, origin)
+		e := tc.syms.MarkComplete(ctx, tc.raw, status, origin)
+		runtime.KeepAlive(tc)
+		return e
 	})
 }
 
@@ -1075,7 +1149,9 @@ func (r *Result) Status(ctx *Context) RunStatus {
 	// handle, which we never produce) is never mistaken for a pass.
 	r.outStatus = RUN_STATUS_ERROR
 	_ = ctx.invoke("hegel_run_result_status", func(ctx ctxT) Error {
-		return r.syms.ResultStatus(ctx, r.raw, &r.outStatus)
+		e := r.syms.ResultStatus(ctx, r.raw, &r.outStatus)
+		runtime.KeepAlive(r)
+		return e
 	})
 	return r.outStatus
 }
@@ -1084,14 +1160,18 @@ func (r *Result) Status(ctx *Context) RunStatus {
 // [RUN_STATUS_ERROR], or the empty string otherwise.
 func (r *Result) ErrorMessage(ctx *Context) string {
 	_ = ctx.invoke("hegel_run_result_error", func(ctx ctxT) Error {
-		return r.syms.ResultError(ctx, r.raw, &r.outBytes)
+		e := r.syms.ResultError(ctx, r.raw, &r.outBytes)
+		runtime.KeepAlive(r)
+		return e
 	})
 	return goString(r.outBytes)
 }
 
 func (r *Result) FailureCount(ctx *Context) uint64 {
 	_ = ctx.invoke("hegel_run_result_failure_count", func(ctx ctxT) Error {
-		return r.syms.ResultFailureCount(ctx, r.raw, &r.outCount)
+		e := r.syms.ResultFailureCount(ctx, r.raw, &r.outCount)
+		runtime.KeepAlive(r)
+		return e
 	})
 	return r.outCount
 }
@@ -1121,7 +1201,9 @@ type Failure struct {
 // shrinker used to group probes for this bug.
 func (f *Failure) Origin(ctx *Context) string {
 	_ = ctx.invoke("hegel_failure_origin", func(ctx ctxT) Error {
-		return f.syms.FailureOrigin(ctx, f.raw, &f.outBytes)
+		e := f.syms.FailureOrigin(ctx, f.raw, &f.outBytes)
+		runtime.KeepAlive(f)
+		return e
 	})
 	return goString(f.outBytes)
 }
@@ -1131,7 +1213,9 @@ func (f *Failure) Origin(ctx *Context) string {
 // string if the engine produced no blob for this failure.
 func (f *Failure) ReproductionBlob(ctx *Context) string {
 	_ = ctx.invoke("hegel_failure_reproduction_blob", func(ctx ctxT) Error {
-		return f.syms.FailureReproductionBlob(ctx, f.raw, &f.outBytes)
+		e := f.syms.FailureReproductionBlob(ctx, f.raw, &f.outBytes)
+		runtime.KeepAlive(f)
+		return e
 	})
 	return goString(f.outBytes)
 }


### PR DESCRIPTION
<details>
<summary>Details (AI-generated)</summary>

Each handle wrapper in `internal/libhegel` registers a GC cleanup (`runtime.AddCleanup`) that frees its native handle. The raw handle is a plain `uintptr` the collector cannot see, and a wrapper's last use can precede a native call's return — the closure has already loaded `x.syms` and `x.raw` before the call blocks. When the call is also the wrapper's last use (notably `tc.MarkComplete` at the end of each `runWithContext` iteration), a collection during the call can run `hegel_test_case_free` — natively `drop(Box::from_raw(tc))` — while `hegel_mark_complete` still holds references into the freed handle. Observed in practice as a one-off SIGSEGV inside `hegel_mark_complete` during a full `-race`+coverage suite run: the stub tests force two garbage collections after every stubbed call, so the full parallel suite runs under exactly the GC pressure that fires this race, while isolated reruns never could.

The fix pins every handle's wrapper with `runtime.KeepAlive` after each native call (draw calls were previously safe only by accident: their `&tc.out*` out-parameters pin the wrapper through the reflect layer; calls passing only values, like `MarkComplete`, `Target`, and `Note`, had no such pin). A new AST-based test, `TestNativeCallsKeepHandleOwnersAlive`, enforces the rule structurally — any function reading an `x.raw` handle must also call `runtime.KeepAlive(x)` — so future bindings cannot reintroduce the race; it failed with 41 violations before the fix.

Verified with the full `-race` + coverage suite; only the pre-existing local-only coverage gap (the auto-download branch of `load()`, covered on CI) remains.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)