### PR TITLE
claude: update release-type guidance to zerover semantics

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -7,31 +7,41 @@ description: "Changelog style guide for writing RELEASE.md files. Use when creat
 
 This guide describes the style for writing `RELEASE.md` files for hegel-go. The style is modeled on the [Hypothesis changelog](https://hypothesis.readthedocs.io/en/latest/changes.html).
 
+## Choosing `RELEASE_TYPE`
+
+hegel-go is currently zerover (`0.x.y`), so the usual semver mapping does **not** apply. While we are pre-1.0:
+
+- `patch` — bug fixes, internal changes, and new features / non-breaking API additions. The default choice.
+- `minor` — breaking changes only. Any change that requires users to update their code (renamed/removed APIs, changed signatures, behavior changes that could break downstream tests) is a minor bump.
+- `major` — not used while we are zerover. Reserved for the eventual 1.0 and beyond.
+
+If you find yourself reaching for `minor` because the change feels "big," check whether it actually breaks any caller. A large new feature that adds API surface without removing or changing existing behavior is still a `patch`.
+
 ## Opening sentence pattern
 
 Every entry should open with a sentence that signals the scope and nature of the change:
 
-- **Small fixes/improvements (patch):** Start with `"This patch ..."`
-- **Larger changes (minor):** Start with `"This release ..."`
+- **Patch (fixes, improvements, new features):** Start with `"This patch ..."`
+- **Minor (breaking changes):** Start with `"This release ..."` and explain migration
 - **Tiny internal-only changes:** A bare sentence is fine — `"Internal refactoring."` or `"Clean up some internal code."`
 
 The opening verb should tell the reader what *kind* of change this is:
 
-| Change type | Opening pattern |
-|---|---|
-| Bug fix | `"This patch fixes ..."` or `"Fix ..."` |
-| New feature | `"This release adds ..."` |
-| Improvement | `"This patch improves ..."` or `"This release makes ... more ..."` |
-| Deprecation | `"This release deprecates ..."` |
-| Breaking change | `"This release changes ..."` (then explain migration) |
-| Performance | `"This patch improves the performance of ..."` or `"Optimize ..."` |
-| Internal-only | `"Internal refactoring."` / `"Refactor some internals."` / `"Clean up some internal code."` |
+| Change type | RELEASE_TYPE | Opening pattern |
+|---|---|---|
+| Bug fix | patch | `"This patch fixes ..."` or `"Fix ..."` |
+| New feature | patch | `"This patch adds ..."` |
+| Improvement | patch | `"This patch improves ..."` or `"This patch makes ... more ..."` |
+| Performance | patch | `"This patch improves the performance of ..."` or `"Optimize ..."` |
+| Deprecation | minor | `"This release deprecates ..."` |
+| Breaking change | minor | `"This release changes ..."` (then explain migration) |
+| Internal-only | patch | `"Internal refactoring."` / `"Refactor some internals."` / `"Clean up some internal code."` |
 
 ## Describe the user impact, not the implementation
 
 Bad: `"Refactored the socket handling code to use a shared connection pool."`
 
-Good: `"This release changes the way the client manages the server to run a single persistent process for the whole test run. This should improve the performance of running many hegel tests."`
+Good: `"This patch changes the way the client manages the server to run a single persistent process for the whole test run. This should improve the performance of running many hegel tests."`
 
 For **bug fixes**, describe the bug (what went wrong from the user's perspective), not just "fixed a bug":
 
@@ -95,18 +105,18 @@ RELEASE_TYPE: patch
 Internal refactoring of the protocol handling code.
 ```
 
-**Good minor (new feature):**
+**Good patch (new feature):**
 ```
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This release adds support for `HealthCheck`. A health check is a proactive error raised by Hegel when we detect your test is likely to have degraded testing power or performance. For example, `FilterTooMuch` is raised when too many test cases are filtered out by the rejection sampling of `.Filter()` or `Assume()`.
+This patch adds support for `HealthCheck`. A health check is a proactive error raised by Hegel when we detect your test is likely to have degraded testing power or performance. For example, `FilterTooMuch` is raised when too many test cases are filtered out by the rejection sampling of `.Filter()` or `Assume()`.
 
 Health checks can be suppressed with the new `SuppressHealthCheck` setting.
 ```
 
-**Good major (breaking change):**
+**Good minor (breaking change):**
 ```
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 This release changes the signature of `RunHegelTest` to accept a `*testing.T` instead of a `testing.TB`:
 

--- a/RELEASE-sample.md
+++ b/RELEASE-sample.md
@@ -6,7 +6,7 @@ This patch adds support for setting `seed` to the protocol.
 
 Every pull request which modifies the source code must include a `RELEASE.md` file. This `RELEASE-sample.md` file is an example of that file.
 
-In the example above, "patch" on the first line should be replaced by "minor" if changes are visible in the public API, or "major" if there are breaking changes.  Note that only maintainers should ever make a major release.
+While we are on a `0.x` major version the semver levels are shifted: **breaking changes are "minor"** and **everything else (bug fixes, internal changes, and new non-breaking features / API additions) is "patch"**. So in the example above, "patch" on the first line should be replaced by "minor" only for a breaking change. "major" is reserved for the eventual 1.0 and beyond, and only maintainers should ever make a major release.
 
 The remaining lines are the actual changelog text for this release, which should:
 


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Syncs the zerover (`0.x.y`) release-type guidance into this repo's changelog docs, part of a cross-repo sweep across all seven Hegel libraries. The stale classic-semver wording ("minor if visible in the public API, major if breaking") recently caused a breaking change to be mislabeled `RELEASE_TYPE: major`.

- `RELEASE-sample.md`: replaced the old semver paragraph with the canonical zerover paragraph (breaking changes are `minor`, everything else is `patch`, `major` is reserved for 1.0+).
- `.claude/skills/changelog/SKILL.md`:
  - Added a "Choosing `RELEASE_TYPE`" section with the canonical zerover mapping.
  - Fixed the "Opening sentence pattern" bullets and table — new features are now `patch` ("This patch adds ..."), breaking changes are `minor`; the table gains a RELEASE_TYPE column.
  - Fixed the two miscategorized examples at the bottom (new feature: minor → patch; breaking change: major → minor).
  - Also changed the "Describe the user impact" good example's opener from "This release changes ..." to "This patch changes ..." — self-review flagged that it modeled the "This release" opener for a non-breaking change, contradicting the new mapping.

Self-review finding left unaddressed for the human reviewer: the table maps **Deprecation → minor**, which is in tension with the new "minor — breaking changes only" rule (a deprecation doesn't require callers to change code). The Deprecation=minor row is part of the canonical cross-repo table, so it's kept as specified; if it should be `patch` instead, that's a decision to make once across all seven parallel PRs.

Docs-only change; no RELEASE.md needed since no source files are modified.

</details>
