### PR TITLE
Fix flaky TestRunStatefulAssumeRejectionRetries

### DIFF
--- a/stateful_test.go
+++ b/stateful_test.go
@@ -178,11 +178,19 @@ func TestRunStatefulRuleAssumeFalse(t *testing.T) {
 func TestRunStatefulAssumeRejectionRetries(t *testing.T) {
 	t.Parallel()
 	totalGateRuns := 0
+	// A single test case only increments gateCount when swarm testing leaves
+	// both rules enabled (probability 1/3: the engine draws a per-case
+	// disabling probability p uniform on [0,1) and E[(1-p)^2] = 1/3) AND the
+	// engine draws a step budget of at least two (RuleGated can only succeed
+	// after a successful RuleOpen step). Measured over 3000 test cases, a
+	// case has gateCount == 0 with probability q = 0.648, so with 10 test
+	// cases this test failed at q^10 ~ 1.3% per run. 100 test cases push the
+	// false-failure probability down to q^100 ~ 2e-19.
 	err := Run(func(tc TestCase) {
 		m := &gatedMachine{}
 		RunStateful(tc, m)
 		totalGateRuns += m.gateCount
-	}, WithTestCases(10))
+	}, WithTestCases(100))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
<details><summary>Implementation details (AI-generated)</summary>

`TestRunStatefulAssumeRejectionRetries` was ~1% flaky on unmodified main (measured 5/500 and independently 8/500 failing runs, all with `RuleGated never succeeded; assume retry appears broken`).

**Root cause** — the test's statistical bound, not the library. The test ran 10 stateful test cases of a two-rule machine (`RuleOpen`, `RuleGated`, where `RuleGated` Assume-rejects until `RuleOpen` has run) and required `gateCount > 0` at least once across the run. Per test case that event requires two independent engine draws to cooperate:

1. **Swarm testing**: the engine draws a per-case rule-disabling probability `p` uniform on [0, 1) (`FeatureFlags` in libhegel's `state_machine.rs`, `draw_integer(0, 254)/255`), then disables each rule with probability `p`, forcing at least one rule enabled. With two rules both survive only with probability `E[(1-p)^2] = 1/3`; in the other ~2/3 of cases one of the two rules is disabled and `gateCount` cannot advance at all.
2. **Step count**: even with both rules enabled, `RuleGated` can only succeed after a successful `RuleOpen` step, so the skewed step-count draw (`min(draw, 50)`, heavily favoring small values) must be >= 2.

Measured over 3000 test cases on unmodified main: P(gateCount == 0 per case) = **q = 0.648**. With 10 cases the test failed at `q^10 ~ 1.3%` per run — matching all observed flake rates. The failure also reproduces deterministically: `WithSeed(63)` (and seeds 195, 293, 308, 387 within the first 400) makes the old 10-case test fail 100% of the time, which was used as the TDD red step.

**Fix**: raise the run to `WithTestCases(100)`, dropping the false-failure probability to `q^100 ~ 2e-19`, with a comment in the test documenting the math. The assume-retry behavior itself is correct, and swarm's per-case rule disabling is by design (it guarantees at least one enabled rule, and hegel-rust's own swarm statistics test uses 100 test cases for the same reason), so no library change is warranted.

**Verification**: 1200 consecutive runs of the fixed test all pass (~16 failures expected at that N before the fix); `just check vendored` (gofmt, go vet, staticcheck, docs check, `go test -race`, 100% file-coverage gate) is green. Test-only change, so no RELEASE.md is required per `release.py`'s `is_source_file` rules (confirmed with `release.py check main`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
