### PR TITLE
libhegel: take io.Writer for engine output instead of a callback

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Wire up libhegels new output mechanism to TestCase. This will provide
+better output from libhegel on failure.

--- a/internal/libhegel/callback.go
+++ b/internal/libhegel/callback.go
@@ -1,0 +1,46 @@
+package libhegel
+
+import (
+	"io"
+	"runtime"
+	"runtime/cgo"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+func newOutputFn(w io.Writer) (outputCallbackT, cgo.Handle) {
+	if w != nil {
+		return outputCallbackPtr, cgo.NewHandle(w)
+	}
+	return 0, 0
+}
+
+func freeOutputFn[T ~uintptr](ptr *pointer[T], h cgo.Handle) {
+	if h == 0 {
+		return
+	}
+
+	if ptr == nil {
+		// The C call failed, so there is no object whose GC will run the
+		// cleanup: delete the handle now. Falling through to AddCleanup with a
+		// nil ptr would panic.
+		h.Delete()
+		return
+	}
+
+	runtime.AddCleanup(ptr, cgo.Handle.Delete, h)
+}
+
+var outputCallbackPtr = outputCallbackT(purego.NewCallback(outputCallback))
+
+// The return value is unused: hegel_output_callback_t is void-returning, so
+// the engine ignores it. It exists only because purego.NewCallback maps to
+// syscall.NewCallback on Windows, which requires exactly one uintptr result.
+func outputCallback(userData uintptr, line *byte, length uint) uintptr {
+	w := cgo.Handle(userData).Value().(io.Writer)
+	// unsafe.String aliases the C buffer; io.WriteString copies the bytes into
+	// the writer before this returns, so no separate copy is needed.
+	_, _ = io.WriteString(w, unsafe.String(line, int(length)))
+	return 0
+}

--- a/internal/libhegel/callback_test.go
+++ b/internal/libhegel/callback_test.go
@@ -1,0 +1,64 @@
+package libhegel
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOutputCallbackReceivesEngineOutput drives a verbose run with a non-nil
+// [OutputFn] and asserts the engine forwards its log lines through the callback.
+// This is the only mode in which libhegel invokes the callback (single-test-case
+// and replay modes emit nothing), so it covers both outputCallback and
+// freeOutputFn's AddCleanup arm end-to-end.
+func TestOutputCallbackReceivesEngineOutput(t *testing.T) {
+	ctx := NewContext()
+	s := ctx.SettingsNew()
+	s.TestCases(ctx, 3)
+	s.Database(ctx, "")
+	s.Verbosity(ctx, VERBOSITY_VERBOSE)
+
+	var sb strings.Builder
+	run, err := s.RunStart(ctx, &sb)
+	if err != nil {
+		t.Fatalf("RunStart: %v", err)
+	}
+	for {
+		tc, err := run.NextTestCase(ctx)
+		if err != nil {
+			t.Fatalf("NextTestCase: %v", err)
+		}
+		if tc == nil {
+			break
+		}
+		if _, err := tc.GenerateInteger(ctx, 0, 100); err != nil {
+			t.Fatalf("GenerateInteger: %v", err)
+		}
+		if err := tc.MarkComplete(ctx, STATUS_VALID, ""); err != nil {
+			t.Fatalf("MarkComplete: %v", err)
+		}
+	}
+	if _, err := run.RunResult(ctx); err != nil {
+		t.Fatalf("RunResult: %v", err)
+	}
+
+	if !strings.Contains(sb.String(), "phase") {
+		t.Errorf("expected verbose phase output via callback, got %q", sb.String())
+	}
+}
+
+// TestFreeOutputFnFailedCall covers freeOutputFn's ptr==nil arm: when a non-nil
+// output writer is supplied but the underlying C call fails (nil result
+// pointer), the handle must be deleted immediately and the call must return the
+// error without panicking on runtime.AddCleanup(nil, ...).
+func TestFreeOutputFnFailedCall(t *testing.T) {
+	lib := Stub(t, uintptr(0), E_INTERNAL, "boom") // run_start: placeholder handle, error, diagnostic
+	s := &Settings{syms: lib.syms, raw: 1}
+
+	run, err := s.RunStart(lib, &strings.Builder{})
+	if err == nil || run != nil {
+		t.Fatalf("expected error and nil run, got run=%v err=%v", run, err)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected diagnostic in error, got %q", err)
+	}
+}

--- a/internal/libhegel/libhegel.go
+++ b/internal/libhegel/libhegel.go
@@ -26,6 +26,7 @@ package libhegel
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"slices"
@@ -701,14 +702,16 @@ func (s *Settings) SuppressHealthCheck(ctx *Context, checks HealthCheck) error {
 }
 
 // RunStart starts a run against these settings. callback and userData set the
-// engine-output destination (see [outputCallbackT]); pass 0 for both to leave
+// engine-output destination (see [outputCallbackT]); pass a nil writer to leave
 // output on stderr, which every hegel-package caller currently does.
-func (s *Settings) RunStart(ctx *Context, callback outputCallbackT, userData uintptr) (*Run, error) {
+func (s *Settings) RunStart(ctx *Context, out io.Writer) (*Run, error) {
+	callback, handle := newOutputFn(out)
 	ptr, err := allocate(ctx, "hegel_run_start", func(ctx ctxT, raw *runT) Error {
-		e := s.syms.RunStart(ctx, s.raw, callback, userData, raw)
+		e := s.syms.RunStart(ctx, s.raw, callback, uintptr(handle), raw)
 		runtime.KeepAlive(s)
 		return e
 	}, s.syms.RunFree)
+	freeOutputFn(ptr, handle)
 	return (*Run)(ptr), err
 }
 
@@ -717,14 +720,16 @@ func (s *Settings) RunStart(ctx *Context, callback outputCallbackT, userData uin
 // test cases from [Run.NextTestCase], the returned handle is owned by the
 // caller and is freed automatically via the GC. A rejected blob surfaces as a
 // nil test case and a non-nil error. callback and userData set the
-// engine-output destination for the replay (see [outputCallbackT]); pass 0 for
-// both to leave output on stderr, which every hegel-package caller currently does.
-func (s *Settings) TestCaseFromBlob(ctx *Context, blob string, callback outputCallbackT, userData uintptr) (tc *TestCase, err error) {
+// engine-output destination for the replay (see [outputCallbackT]); pass a nil
+// writer to leave output on stderr, which every hegel-package caller currently does.
+func (s *Settings) TestCaseFromBlob(ctx *Context, blob string, out io.Writer) (tc *TestCase, err error) {
+	callback, handle := newOutputFn(out)
 	ptr, err := allocate(ctx, "hegel_test_case_from_blob", func(ctx ctxT, raw *testCaseT) Error {
-		e := s.syms.TestCaseFromBlob(ctx, s.raw, blob, callback, userData, raw)
+		e := s.syms.TestCaseFromBlob(ctx, s.raw, blob, callback, uintptr(handle), raw)
 		runtime.KeepAlive(s)
 		return e
 	}, s.syms.TestCaseFree)
+	freeOutputFn(ptr, handle)
 	if ptr == nil {
 		return nil, err
 	}

--- a/internal/libhegel/libhegel_smoke_test.go
+++ b/internal/libhegel/libhegel_smoke_test.go
@@ -19,7 +19,7 @@ func TestLibhegelEndToEnd(t *testing.T) {
 	// Disable the database so the test is hermetic.
 	settings.Database(ctx, "")
 
-	run, err := settings.RunStart(ctx, 0, 0)
+	run, err := settings.RunStart(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/libhegel/stub_test.go
+++ b/internal/libhegel/stub_test.go
@@ -258,7 +258,7 @@ func TestStubBlobAndFailureAccessors(t *testing.T) {
 	)
 
 	s := &Settings{syms: lib.syms, raw: 1}
-	tc, err := s.TestCaseFromBlob(lib, "YmxvYg==", 0, 0)
+	tc, err := s.TestCaseFromBlob(lib, "YmxvYg==", nil)
 	if err != nil || tc == nil {
 		t.Fatalf("TestCaseFromBlob: tc=%v err=%v", tc, err)
 	}
@@ -314,7 +314,7 @@ func TestStubCloneError(t *testing.T) {
 func TestStubBlobError(t *testing.T) {
 	lib := Stub(t, uintptr(0), E_INVALID_ARG, "bad blob") // handle, result, diagnostic
 	s := &Settings{syms: lib.syms, raw: 1}
-	tc, err := s.TestCaseFromBlob(lib, "not-base64", 0, 0)
+	tc, err := s.TestCaseFromBlob(lib, "not-base64", nil)
 	if err == nil || tc != nil {
 		t.Fatalf("expected error, got tc=%v err=%v", tc, err)
 	}

--- a/runner.go
+++ b/runner.go
@@ -528,17 +528,18 @@ func runWithContext(ctx *libhegel.Context, fn testBody, opts runOptions) error {
 		return err
 	}
 
-	run, err := s.RunStart(ctx, 0, 0)
-	if err != nil {
-		return err
-	}
-
 	var output io.Writer
 	var skipUserPanic bool
 	if opts.singleTestCase {
 		output = opts.output
 		skipUserPanic = true
 	}
+
+	run, err := s.RunStart(ctx, output)
+	if err != nil {
+		return err
+	}
+
 	for {
 		tc, err := run.NextTestCase(ctx)
 		if err != nil {
@@ -645,7 +646,7 @@ func replayFailures(ctx *libhegel.Context, s *libhegel.Settings, result *libhege
 		if err != nil {
 			return err
 		}
-		tc, err := s.TestCaseFromBlob(ctx, fail.ReproductionBlob(ctx), 0, 0)
+		tc, err := s.TestCaseFromBlob(ctx, fail.ReproductionBlob(ctx), opts.output)
 		if err != nil {
 			return err
 		}

--- a/runner_test.go
+++ b/runner_test.go
@@ -392,7 +392,7 @@ func newStubTestCase(t testing.TB, opReturns ...any) *testCase {
 	}, opReturns...)
 	lib := libhegel.Stub(t, returns...)
 	s := lib.SettingsNew()
-	run, _ := s.RunStart(lib, 0, 0)
+	run, _ := s.RunStart(lib, nil)
 	tc, _ := run.NextTestCase(lib)
 	return &testCase{ctx: lib, tc: tc}
 }
@@ -404,7 +404,7 @@ func newRealTestCase(t testing.TB) *testCase {
 	t.Helper()
 	ctx := libhegel.NewContext()
 	s := ctx.SettingsNew()
-	run, err := s.RunStart(ctx, 0, 0)
+	run, err := s.RunStart(ctx, nil)
 	if err != nil {
 		t.Fatalf("RunStart: %v", err)
 	}


### PR DESCRIPTION
RunStart and TestCaseFromBlob now accept an io.Writer for the engine's output; the writer-to-C callback adaptation moves into the libhegel package. Plumb through the io.Writer from testCase.