### PR TITLE
Fall back to tmp dir on cache failure

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -74,8 +74,10 @@ The library is resolved in this order; first hit wins:
    fails to open)
 2. the `go:embed`'d vendored binary for the host platform (see below),
    materialized to `~/.cache/hegel-go/libhegel/<version>/` and dlopen'd from
-   there. Skipped when `$HEGEL_LIBHEGEL_PATH` is set or on a platform with no
-   vendored artifact.
+   there. The cache is best-effort: if it cannot be read or written (e.g. a
+   sandbox that denies access to the user cache dir), the binary is extracted
+   to a fresh directory under the system temp dir instead. Skipped when
+   `$HEGEL_LIBHEGEL_PATH` is set or on a platform with no vendored artifact.
 
 The library does **not** hunt for a sibling `hegel-rust` checkout; local
 development against a fresh build goes through `HEGEL_LIBHEGEL_PATH` (see below).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hegel is a property-based testing library for Go. Hegel is based on [Hypothesis]
 
 To install: `go get hegel.dev/go/hegel@latest`.
 
-Hegel for Go drives [libhegel](https://github.com/hegeldev/hegel-rust) — the native Rust engine. At runtime hegel-go loads `libhegel.so` (Linux), `libhegel.dylib` (macOS), or `libhegel.dll` (Windows) from `$HEGEL_LIBHEGEL_PATH` if set; otherwise it falls back to a pre-compiled `libhegel` vendored inside the module: it is stored via git-lfs, `go:embed`'d into your binary at build time, and materialized under `~/.cache/hegel-go/libhegel/<version>/` to be loaded. The vendored build matches the pinned hegel-rust release, so nothing is downloaded at runtime.
+Hegel for Go drives [libhegel](https://github.com/hegeldev/hegel-rust) — the native Rust engine. At runtime hegel-go loads `libhegel.so` (Linux), `libhegel.dylib` (macOS), or `libhegel.dll` (Windows) shipped with hegel-go. You can override this behavior with `$HEGEL_LIBHEGEL_PATH`.
 
 Supported platforms (those with a published libhegel artifact): Linux amd64/arm64, macOS arm64 (Apple Silicon), and Windows amd64/arm64.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch makes the libhegel cache best-effort. Previously, hegel-go failed to load if it could not write the embedded libhegel to the per-user cache directory (`~/.cache/hegel-go` on Linux, `~/Library/Caches/hegel-go` on macOS), so sandboxed environments that deny writes outside the workspace — such as Codex's macOS sandbox — could not run hegel tests at all ([#115](https://github.com/hegeldev/hegel-go/issues/115)).
-
-The cache is now purely a performance optimization: when it cannot be read or written, the library is extracted to a fresh directory under the system temp dir instead, and loading fails only when that also fails.
+Fix error when cache directory for libhegel could not be written to, for example inside of a sandbox.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch makes the libhegel cache best-effort. Previously, hegel-go failed to load if it could not write the embedded libhegel to the per-user cache directory (`~/.cache/hegel-go` on Linux, `~/Library/Caches/hegel-go` on macOS), so sandboxed environments that deny writes outside the workspace — such as Codex's macOS sandbox — could not run hegel tests at all ([#115](https://github.com/hegeldev/hegel-go/issues/115)).
+
+The cache is now purely a performance optimization: when it cannot be read or written, the library is extracted to a fresh directory under the system temp dir instead, and loading fails only when that also fails.

--- a/internal/libhegel/embed.go
+++ b/internal/libhegel/embed.go
@@ -9,21 +9,32 @@ import (
 
 var chmodCacheDir = os.Chmod
 var lockCacheDir = lockLibraryCache
+var mkdirTemp = os.MkdirTemp
 
-// writeDynamicLibrary writes lib to the per-version cache directory atomically
-// (temp file + rename), marked executable, and returns the destination path.
-// An existing destination of the expected size is authoritative: because this
-// function installs it by atomic rename, its presence short-circuits the write.
-// On Windows, an inter-process lock serializes the cache check and rename so the
-// rename never has to replace a DLL another process has already loaded.
-// An empty lib (unsupported platform) is reported as an error before touching
-// the disk.
-func writeDynamicLibrary(lib []byte) (path string, err error) {
+// writeDynamicLibrary materializes lib on disk and returns the path to dlopen.
+//
+// The per-version user cache is preferred. When it cannot be used, the bytes are
+// extracted to a fresh directory under the system temp dir instead.
+func writeDynamicLibrary(lib []byte) (string, error) {
 	if len(lib) == 0 {
 		return "", fmt.Errorf("no vendored libhegel for %s/%s; build libhegel yourself and set %s to its path",
 			runtime.GOOS, runtime.GOARCH, LibraryPathEnv)
 	}
 
+	path, cacheErr := cachedLibrary(lib)
+	if cacheErr == nil {
+		return path, nil
+	}
+	path, tmpErr := tempLibrary(lib)
+	if tmpErr != nil {
+		return "", fmt.Errorf("%w (cache also unusable: %v)", tmpErr, cacheErr)
+	}
+	return path, nil
+}
+
+// cachedLibrary returns the per-version cached copy of lib, writing it on
+// first use.
+func cachedLibrary(lib []byte) (path string, err error) {
 	dir, err := libhegelCacheDir(hegelVersion)
 	if err != nil {
 		return "", err
@@ -53,8 +64,24 @@ func writeDynamicLibrary(lib []byte) (path string, err error) {
 		return dest, nil
 	}
 
+	return installLibrary(dir, lib)
+}
+
+// tempLibrary extracts lib to a fresh private directory under the system temp
+// dir.
+func tempLibrary(lib []byte) (string, error) {
+	dir, err := mkdirTemp("", "hegel-go-libhegel-")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	return installLibrary(dir, lib)
+}
+
+// installLibrary writes lib into dir atomically (temp file + rename to dest),
+// marked executable, and returns dest.
+func installLibrary(dir string, lib []byte) (string, error) {
 	tmp, err := os.CreateTemp(dir, ".libhegel-*.partial")
-	if err != nil { // coverage-ignore (rare under user cache dir)
+	if err != nil { // coverage-ignore (rare under a directory we just created)
 		return "", err
 	}
 	tmpName := tmp.Name()
@@ -71,8 +98,7 @@ func writeDynamicLibrary(lib []byte) (path string, err error) {
 	if err := os.Chmod(tmpName, 0o755); err != nil { // coverage-ignore
 		return "", err
 	}
-	// On Windows the publication lock guarantees dest does not exist, avoiding
-	// the unsupported operation of replacing a DLL mapped by another process.
+	dest := filepath.Join(dir, libhegelAssetName())
 	if err := os.Rename(tmpName, dest); err != nil { // coverage-ignore
 		return "", err
 	}

--- a/internal/libhegel/embed_test.go
+++ b/internal/libhegel/embed_test.go
@@ -21,6 +21,15 @@ func testHomeOverride(t *testing.T) string {
 	return dir
 }
 
+// stubVar replaces the package-level stub *p with v for the duration of the
+// test, restoring the original on cleanup.
+func stubVar[T any](t *testing.T, p *T, v T) {
+	t.Helper()
+	orig := *p
+	*p = v
+	t.Cleanup(func() { *p = orig })
+}
+
 // TestEmbeddedLibPresent asserts that a vendored libhegel binary is embedded
 // for the platform the test suite runs on. CI runs this on linux/amd64,
 // darwin/arm64, and windows/amd64 — the published, vendored assets.
@@ -117,56 +126,82 @@ func TestMaterializeEmbeddedRepairsCacheDirMode(t *testing.T) {
 	}
 }
 
-// TestMaterializeEmbeddedCacheDirChmodError covers failure to repair the
-// permissions of an existing cache directory.
-func TestMaterializeEmbeddedCacheDirChmodError(t *testing.T) {
+// TestMaterializeEmbeddedFallsBackToTemp verifies an unusable cache degrades
+// to a fresh extraction under the system temp dir rather than an error: with
+// no cached library, the library must still materialize.
+func TestMaterializeEmbeddedFallsBackToTemp(t *testing.T) {
 	testHomeOverride(t)
-	want := errors.New("chmod failed")
-	original := chmodCacheDir
-	chmodCacheDir = func(string, os.FileMode) error { return want }
-	t.Cleanup(func() { chmodCacheDir = original })
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp) // unix temp root
+	t.Setenv("TMP", tmp)    // windows temp root
+	stubVar(t, &chmodCacheDir, func(string, os.FileMode) error { return errors.New("chmod denied") })
 
-	_, err := writeDynamicLibrary([]byte("libhegel"))
-	if !errors.Is(err, want) {
-		t.Fatalf("writeDynamicLibrary: got %v, want chmod error", err)
+	payload := []byte("fallback payload")
+	path, err := writeDynamicLibrary(payload)
+	if err != nil {
+		t.Fatalf("writeDynamicLibrary: %v", err)
 	}
-	if !strings.Contains(err.Error(), "secure cache dir") {
-		t.Errorf("expected cache security context; got %q", err)
+	got, err := os.ReadFile(path)
+	if err != nil { // coverage-ignore
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("body mismatch: got %q", got)
+	}
+	if filepath.Base(path) != libhegelAssetName() {
+		t.Errorf("expected file named %q, got %q", libhegelAssetName(), filepath.Base(path))
 	}
 }
 
-// TestMaterializeEmbeddedCacheLockError covers failure to acquire the
-// cross-process publication lock.
-func TestMaterializeEmbeddedCacheLockError(t *testing.T) {
+// TestMaterializeEmbeddedTempFallbackError covers the terminal case: both the
+// cache and the temp-dir fallback are unusable. The error must surface both
+// causes.
+func TestMaterializeEmbeddedTempFallbackError(t *testing.T) {
 	testHomeOverride(t)
-	want := errors.New("lock failed")
-	original := lockCacheDir
-	lockCacheDir = func(string) (func() error, error) { return nil, want }
-	t.Cleanup(func() { lockCacheDir = original })
+	stubVar(t, &chmodCacheDir, func(string, os.FileMode) error { return errors.New("chmod denied") })
+	want := errors.New("temp dir denied")
+	stubVar(t, &mkdirTemp, func(string, string) (string, error) { return "", want })
 
 	_, err := writeDynamicLibrary([]byte("libhegel"))
 	if !errors.Is(err, want) {
-		t.Fatalf("writeDynamicLibrary: got %v, want lock error", err)
+		t.Fatalf("writeDynamicLibrary: got %v, want temp dir error", err)
+	}
+	if !strings.Contains(err.Error(), "cache also unusable") {
+		t.Errorf("expected the cache failure to be surfaced too; got %q", err)
+	}
+	if !strings.Contains(err.Error(), "secure cache dir") {
+		t.Errorf("expected the cache failure detail; got %q", err)
+	}
+}
+
+// TestCachedLibraryLockError covers failure to acquire the cross-process
+// publication lock.
+func TestCachedLibraryLockError(t *testing.T) {
+	testHomeOverride(t)
+	want := errors.New("lock failed")
+	stubVar(t, &lockCacheDir, func(string) (func() error, error) { return nil, want })
+
+	_, err := cachedLibrary([]byte("libhegel"))
+	if !errors.Is(err, want) {
+		t.Fatalf("cachedLibrary: got %v, want lock error", err)
 	}
 	if !strings.Contains(err.Error(), "lock cache dir") {
 		t.Errorf("expected cache lock context; got %q", err)
 	}
 }
 
-// TestMaterializeEmbeddedCacheUnlockError covers failure to release the
-// cross-process publication lock after a successful write.
-func TestMaterializeEmbeddedCacheUnlockError(t *testing.T) {
+// TestCachedLibraryUnlockError covers failure to release the cross-process
+// publication lock after a successful write.
+func TestCachedLibraryUnlockError(t *testing.T) {
 	testHomeOverride(t)
 	want := errors.New("unlock failed")
-	original := lockCacheDir
-	lockCacheDir = func(string) (func() error, error) {
+	stubVar(t, &lockCacheDir, func(string) (func() error, error) {
 		return func() error { return want }, nil
-	}
-	t.Cleanup(func() { lockCacheDir = original })
+	})
 
-	_, err := writeDynamicLibrary([]byte("libhegel"))
+	_, err := cachedLibrary([]byte("libhegel"))
 	if !errors.Is(err, want) {
-		t.Fatalf("writeDynamicLibrary: got %v, want unlock error", err)
+		t.Fatalf("cachedLibrary: got %v, want unlock error", err)
 	}
 	if !strings.Contains(err.Error(), "unlock cache dir") {
 		t.Errorf("expected cache unlock context; got %q", err)
@@ -187,9 +222,10 @@ func TestMaterializeEmbeddedEmpty(t *testing.T) {
 	}
 }
 
-// TestMaterializeEmbeddedUserCacheDirError verifies that failure to resolve a
-// per-user cache is returned rather than falling back to a shared temp dir.
-func TestMaterializeEmbeddedUserCacheDirError(t *testing.T) {
+// TestCachedLibraryUserCacheDirError verifies that failure to resolve a
+// per-user cache is reported to the caller (which then falls back to the
+// system temp dir).
+func TestCachedLibraryUserCacheDirError(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin": // coverage-ignore (unreachable on the linux CI runner)
 		t.Setenv("HOME", "")
@@ -199,7 +235,7 @@ func TestMaterializeEmbeddedUserCacheDirError(t *testing.T) {
 		t.Setenv("XDG_CACHE_HOME", "relative")
 	}
 
-	_, err := writeDynamicLibrary([]byte("libhegel"))
+	_, err := cachedLibrary([]byte("libhegel"))
 	if err == nil {
 		t.Fatal("expected user cache directory resolution to fail")
 	}

--- a/internal/libhegel/libhegel.go
+++ b/internal/libhegel/libhegel.go
@@ -13,9 +13,12 @@
 //  2. the libhegel binary go:embed'd from internal/libhegel/libs (vendored via
 //     git-lfs), materialized to
 //     ~/.cache/hegel-go/libhegel/<version>/libhegel-<goos>-<goarch>.<ext> and
-//     dlopen'd from there. Skipped when HEGEL_LIBHEGEL_PATH is set (an explicit
-//     override means the user wants that exact file) or on platforms with no
-//     vendored artifact.
+//     dlopen'd from there. The cache is purely a performance optimization:
+//     when it cannot be read or written (e.g. a sandbox that denies access to
+//     the user cache dir), the binary is extracted to a fresh directory under
+//     the system temp dir instead. Skipped when HEGEL_LIBHEGEL_PATH is set (an
+//     explicit override means the user wants that exact file) or on platforms
+//     with no vendored artifact.
 //
 // The library does not search for a sibling hegel-rust checkout; local
 // development against a fresh build goes through HEGEL_LIBHEGEL_PATH.

--- a/internal/libhegel/libhegel_test.go
+++ b/internal/libhegel/libhegel_test.go
@@ -1,8 +1,8 @@
 package libhegel
 
 import (
+	"errors"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -59,20 +59,13 @@ func TestLoadLibMissing(t *testing.T) {
 }
 
 // TestLoadEmbeddedWriteFails covers the fallback path in load: with no path
-// override, writing the embedded library out to the cache must fail when the
-// cache root cannot be created. We point the cache dir at a path beneath a
-// regular file so MkdirAll fails with ENOTDIR.
+// override, writing the embedded library out must fail when both the cache
+// and the temp-dir fallback are unusable.
 func TestLoadEmbeddedWriteFails(t *testing.T) {
 	t.Setenv(LibraryPathEnv, "")
-
-	dir := t.TempDir()
-	notADir := filepath.Join(dir, "file")
-	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil { // coverage-ignore
-		t.Fatalf("write file: %v", err)
-	}
-	t.Setenv("XDG_CACHE_HOME", notADir)
-	t.Setenv("HOME", notADir) // macOS fallback when XDG_CACHE_HOME is unset
-	t.Setenv("LocalAppData", notADir)
+	testHomeOverride(t)
+	stubVar(t, &chmodCacheDir, func(string, os.FileMode) error { return errors.New("chmod denied") })
+	stubVar(t, &mkdirTemp, func(string, string) (string, error) { return "", errors.New("temp dir denied") })
 
 	_, err := load()
 	if err == nil {


### PR DESCRIPTION
Closes https://github.com/hegeldev/hegel-go/issues/115. When a cache write fails, we now fall back to extracting to a tmp dir instead of failing. This is palatable now that a cache miss is milliseconds of file copy instead of the previous overhead of a network call/download.

<details><summary>Claude-written description</summary>

Fixes #115.

hegel-go previously refused to load if it could not write the embedded libhegel to the per-user cache directory. Sandboxes that deny writes outside the workspace (e.g. Codex's macOS seatbelt policy) hit this even when nothing needed writing: the loader unconditionally `chmod`ed the cache dir before checking whether the dylib was already materialized, producing the `secure cache dir ... operation not permitted` error from the issue.

The cache is now purely a performance optimization. `writeDynamicLibrary` tries the per-version user cache first (unchanged semantics: 0700 dir, Windows publication lock, size-checked reuse, atomic temp-file-plus-rename install); on any cache failure it silently extracts to a fresh directory under the system temp dir instead — which sandboxes allow — and leaves reclaiming it to the OS's temp cleaning. Loading fails only when both paths fail, with an error reporting both causes.

Verified against a Codex-like seatbelt profile (`sandbox-exec` denying writes to the user cache dir): fresh-cache sandboxed, warm-cache sandboxed, and unsandboxed runs all pass; previously the first two failed with mkdir/chmod EPERM.

The temp-fallback design follows the precedent of other embed-and-dlopen ecosystems (JVM native loaders, .NET single-file): extraction is a few milliseconds for the 2.2 MB dylib, so per-process extraction in the rare fallback case costs effectively nothing.

</details>
