### PR TITLE
Use per-version bump branches so releases can't clobber PR work

### DIFF
--- a/.github/scripts/bump_hegel_rust.py
+++ b/.github/scripts/bump_hegel_rust.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 RUST_REPO = "hegeldev/hegel-rust"
-BRANCH = "ci/bump-hegel-rust"
+# One branch per pinned version. A fixed, reused branch meant every release
+# force-recreated it from main, clobbering any manual or agent work pushed to
+# the open PR; a per-version branch keeps re-runs of the *same* version
+# idempotent (the force-push below) while never touching another version's
+# work. The workflow closes superseded bot-only bump PRs after pushing.
+BRANCH_PREFIX = "ci/bump-hegel-rust-"
 VERSION_FILE = ROOT / "internal" / "libhegel" / "version.go"
 LIBS_DIR = ROOT / "internal" / "libhegel" / "libs"
 RELEASE_MD = ROOT / "RELEASE.md"
@@ -66,9 +71,10 @@ def bump(requested: str) -> None:
     git("config", "user.name", "hegel-release[bot]")
     git("config", "user.email", f"{app_id}+hegel-release[bot]@users.noreply.github.com")
 
-    # A fixed branch we reuse across releases. Commit locally only; the workflow
-    # pushes it after folding in the FFI alignment.
-    git("checkout", "-B", BRANCH)
+    # The per-version branch for this release. Commit locally only; the
+    # workflow pushes it after folding in the FFI alignment.
+    branch = BRANCH_PREFIX + new
+    git("checkout", "-B", branch)
     git("add", str(VERSION_FILE), str(LIBS_DIR), str(RELEASE_MD))
     git(
         "commit",
@@ -80,7 +86,7 @@ def bump(requested: str) -> None:
 
     set_output("bumped", "true")
     set_output("version", new)
-    set_output("branch", BRANCH)
+    set_output("branch", branch)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/bump-hegel-rust.yml
+++ b/.github/workflows/bump-hegel-rust.yml
@@ -95,7 +95,10 @@ jobs:
           git add -A
           git commit --amend --no-edit
 
-      # The single push: force-push the reused branch and open/update the PR.
+      # The single push: force-push the per-version branch and open/update the
+      # PR. The branch name embeds the pinned version, so the force-push only
+      # ever overwrites a re-run of this same version — never another
+      # version's (or a human's) work.
       - name: Push and open/update the PR
         if: steps.bump.outputs.bumped == 'true'
         env:
@@ -124,3 +127,41 @@ jobs:
           else
             gh pr create --title "$title" --body "$body"
           fi
+
+      # Older bump PRs are now superseded by this one. Close the ones that
+      # carry only bot commits; a PR someone (or an alignment agent) pushed
+      # work to is left open with a note instead — closing must never bury
+      # manual work. Runs after the new PR exists, and best-effort: a hiccup
+      # here must not fail the bump itself.
+      - name: Supersede older bump PRs
+        if: steps.bump.outputs.bumped == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+        run: |
+          set -euo pipefail
+          new_pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+
+          gh pr list --state open --json number,headRefName \
+            --jq '.[] | [.number, .headRefName] | @tsv' |
+          while IFS=$'\t' read -r pr head; do
+            [ "$head" = "$BRANCH" ] && continue
+            # Match the legacy fixed branch name and the per-version branches.
+            case "$head" in
+              ci/bump-hegel-rust | ci/bump-hegel-rust-*) ;;
+              *) continue ;;
+            esac
+            # Authors other than the bot on the PR's commits? (GraphQL reports
+            # the bot's login without the [bot] suffix; check both spellings.)
+            others=$(gh pr view "$pr" --json commits \
+              --jq '[.commits[].authors[] | (.login // .name // empty)] | unique
+                    | map(select(. != "" and . != "hegel-release" and . != "hegel-release[bot]"))
+                    | join(", ")')
+            if [ -z "$others" ]; then
+              gh pr close "$pr" --comment "Superseded by #${new_pr}, which pins libhegel ${VERSION}."
+            else
+              gh pr comment "$pr" --body "Superseded by #${new_pr}, which pins libhegel ${VERSION}. Leaving this PR open because it carries commits by: ${others}."
+            fi
+          done

--- a/.github/workflows/bump-hegel-rust.yml
+++ b/.github/workflows/bump-hegel-rust.yml
@@ -155,9 +155,13 @@ jobs:
             esac
             # Authors other than the bot on the PR's commits? (GraphQL reports
             # the bot's login without the [bot] suffix; check both spellings.)
+            # Bot commits can carry an empty-string login (and jq's // treats
+            # "" as truthy), so fall through to the name explicitly; an author
+            # with neither login nor name is treated as human — never close a
+            # PR on an unknown author.
             others=$(gh pr view "$pr" --json commits \
-              --jq '[.commits[].authors[] | (.login // .name // empty)] | unique
-                    | map(select(. != "" and . != "hegel-release" and . != "hegel-release[bot]"))
+              --jq '[.commits[].authors[] | (if (.login // "") != "" then .login elif (.name // "") != "" then .name else "unknown author" end)] | unique
+                    | map(select(. != "hegel-release" and . != "hegel-release[bot]"))
                     | join(", ")')
             if [ -z "$others" ]; then
               gh pr close "$pr" --comment "Superseded by #${new_pr}, which pins libhegel ${VERSION}."


### PR DESCRIPTION
<details>
<summary>🤖 AI-generated description (written by Claude Code; wrapped per convention so the provenance is explicit)</summary>

The bump automation reused a single fixed branch, `ci/bump-hegel-rust`, and force-recreated it from main on every libhegel release. Any work pushed to the open bump PR in the meantime was silently erased by the next release's force-push — this bit hegel-typescript today, where a hand-built FFI port on its bump PR was wiped out by the next release. hegel-go's bump automation has the identical structure, so it has the identical hazard.

This ports hegel-typescript's fix (hegeldev/hegel-typescript#63):

- **Per-version branches.** `.github/scripts/bump_hegel_rust.py` now creates `ci/bump-hegel-rust-<version>` instead of the fixed branch. The force-push stays: it is now idempotent per re-run of the *same* version and can never touch another version's (or a human's) branch.
- **Supersede older bump PRs.** After pushing and opening/updating the PR, a new best-effort (`continue-on-error`) step lists open PRs on the legacy fixed branch or any `ci/bump-hegel-rust-*` branch. PRs whose commits are authored solely by `hegel-release` are closed with a "Superseded by #N" comment; a PR carrying anyone else's commits gets the same comment but stays open, naming the authors — closing must never bury manual work.

Verified: workflow YAML parses, every embedded `run:` block passes `bash -n`, the bump script passes `py_compile`, `zizmor 1.23.1` (as run in CI) reports no findings, and the author-detection jq was dry-tested read-only against real hegel-go PRs (#125 bot-only → close path; #120/#110 by lmb → leave-open path, naming `lmb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>

